### PR TITLE
docs: Update bluesky.md to remove deprecated subscribeRepoUpdates()

### DIFF
--- a/website/docs/packages/bluesky.md
+++ b/website/docs/packages/bluesky.md
@@ -538,7 +538,7 @@ Future<void> main() async {
   // Authentication is not required.
   final bluesky = Bluesky.anonymous();
 
-  final subscription = await bluesky.sync.subscribeRepoUpdates();
+  final subscription = await bluesky.sync.subscribeRepos();
 
   // Use `RepoCommitAdaptor`.
   final repoCommitAdaptor = RepoCommitAdaptor(


### PR DESCRIPTION
Update second firehose example to use subscribeRepos() over subscribeRepoUpdates()

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [ ] I have updated/added tests for new/updated/fixed functionality.
- [ ] I have updated/added dartdoc comments with `///`.

## Breaking Change

<!-- Does your PR require users to manually update their apps to accommodate your change?

If the PR is a breaking change this should be indicated with suffix "!"  (for example, `feat!:`, `fix!:`). See [Conventional Commit] for details.
-->

- [ ] Yes, this is a breaking change.
- [x] No, this is _not_ a breaking change.

## Related Issues

<!-- Provide a list of issues related to this PR from the [issue database].
Indicate which of these issues are resolved or fixed by this PR, i.e. Fixes #xxxx* !-->

<!-- Links -->

[contributor guide]: https://github.com/myConsciousness/atproto.dart/blob/main/CONTRIBUTING.md
[conventional commit]: https://conventionalcommits.org
