### PR TITLE
chore: Update bluesky package to version 1.0.8

### DIFF
--- a/packages/bluesky/CHANGELOG.md
+++ b/packages/bluesky/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Note
 
+## v1.0.8
+
+- chore: Sync Lexicon Data. ([#2100](https://github.com/myConsciousness/atproto.dart/pull/2100))
+
 ## v1.0.7
 
 - fix: Drop `universal_io` for WASM compatibility.

--- a/packages/bluesky/pubspec.yaml
+++ b/packages/bluesky/pubspec.yaml
@@ -1,6 +1,6 @@
 name: bluesky
 description: The most famous and powerful Dart/Flutter library for Bluesky Social.
-version: 1.0.7
+version: 1.0.8
 homepage: https://atprotodart.com
 documentation: https://atprotodart.com/docs/packages/bluesky
 repository: https://github.com/myConsciousness/atproto.dart/tree/main/packages/bluesky


### PR DESCRIPTION
- Add changelog entry for PR #2100 (Sync Lexicon Data)
- Bump version from 1.0.7 to 1.0.8 in pubspec.yaml