### PR TITLE
chore: Add changelog entries for PR #2105 and #2107

### DIFF
--- a/packages/atproto/CHANGELOG.md
+++ b/packages/atproto/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Note
 
+## v1.0.8
+
+- chore: Sync Lexicon Data. ([#2105](https://github.com/myConsciousness/atproto.dart/pull/2105), [#2107](https://github.com/myConsciousness/atproto.dart/pull/2107))
+
 ## v1.0.7
 
 - fix: Drop `universal_io` for WASM compatibility.

--- a/packages/bluesky/CHANGELOG.md
+++ b/packages/bluesky/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Note
 
+## v1.0.9
+
+- chore: Sync Lexicon Data. ([#2105](https://github.com/myConsciousness/atproto.dart/pull/2105), [#2107](https://github.com/myConsciousness/atproto.dart/pull/2107))
+
 ## v1.0.8
 
 - chore: Sync Lexicon Data. ([#2100](https://github.com/myConsciousness/atproto.dart/pull/2100))


### PR DESCRIPTION
## Summary

Added changelog entries for lexicon synchronization updates in both atproto and bluesky packages.

## Changes

### packages/atproto/CHANGELOG.md
- Added v1.0.8 entry documenting lexicon data sync from PRs #2105 and #2107

### packages/bluesky/CHANGELOG.md
- Added v1.0.9 entry documenting lexicon data sync from PRs #2105 and #2107

## Diff Summary

**atproto package:**

**bluesky package:**

Both entries follow the established changelog format and properly reference the PRs that contained the lexicon synchronization updates.