### PR TITLE
feat: Add OzoneTool client for comprehensive tools.ozone.* API support

### DIFF
--- a/packages/bluesky/CHANGELOG.md
+++ b/packages/bluesky/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Release Note
 
+## v1.0.11
+
+- feat: Added OzoneTool client for comprehensive `tools.ozone.*` API support
+  - New `OzoneTool` class provides access to all Ozone moderation and administrative services
+  - Includes Communication, Hosting, Moderation, Server, Team, and additional Ozone services
+  - Available via separate `package:bluesky/ozone.dart` import for modular usage
+  - Requires session-based authentication for secure administrative operations
+  - Complete API coverage for moderation events, team management, server configuration, and more
+
 ## v1.0.10
 
 - **BREAKING CHANGE**: Enhanced lexicon known values naming with proper camelCase convention

--- a/packages/bluesky/README.md
+++ b/packages/bluesky/README.md
@@ -37,6 +37,7 @@ Use this package when building applications specifically for Bluesky Social. For
 - **Real-time Notifications** - Push notifications and notification management  
 - **Chat & Messaging** - Direct messages and conversation management  
 - **Content Moderation** - Advanced moderation tools and content filtering  
+- **Ozone Moderation Tools** - Complete `tools.ozone.*` API for administrative operations  
 - **Media Support** - Image, video, and blob upload with processing  
 - **Built-in AT Protocol** - Includes all `atproto` package functionality  
 - **Advanced Authentication** - Session management and OAuth DPoP support  
@@ -62,6 +63,12 @@ flutter pub add bluesky
 
 ```dart
 import 'package:bluesky/bluesky.dart';
+```
+
+**For Ozone moderation tools:**
+
+```dart
+import 'package:bluesky/ozone.dart';
 ```
 
 ### 1.2.3. Implementation
@@ -208,6 +215,37 @@ Future<void> main(List<String> args) async {
 }
 ```
 
+#### Ozone Moderation Tools
+
+```dart
+import 'package:bluesky/atproto.dart';
+import 'package:bluesky/ozone.dart';
+
+Future<void> main(List<String> args) async {
+  // Create a session with your Bluesky credentials
+  final session = await createSession(
+    service: 'bsky.social',
+    identifier: 'your.handle.bsky.social',
+    password: 'your-app-password',
+  );
+
+  // Initialize Ozone client for moderation tools
+  final ozone = OzoneTool.fromSession(session.data);
+
+  // Query moderation events
+  final events = await ozone.moderation.queryEvents(limit: 50);
+
+  // Get moderation subjects
+  final subjects = await ozone.moderation.getSubjects();
+
+  // Access team management
+  final teamMembers = await ozone.team.listMembers();
+
+  // Server configuration
+  final serverConfig = await ozone.server.getConfig();
+}
+```
+
 ## 1.3. Supported Endpoints 👀
 
 The `bluesky` package provides comprehensive coverage of both AT Protocol and Bluesky-specific services:
@@ -247,6 +285,34 @@ The `bluesky` package provides comprehensive coverage of both AT Protocol and Bl
 - **Message Management** - Send, receive, and manage messages
 - **Conversation Operations** - Create, list, and manage conversations
 - **Chat Moderation** - Report and moderate chat content
+
+### Ozone Moderation Services (`tools.ozone.*`)
+
+#### Communication Service (`tools.ozone.communication.*`)
+- **Communication Management** - Handle moderation communications and templates
+
+#### Hosting Service (`tools.ozone.hosting.*`)
+- **Hosting Operations** - Manage hosting configurations and settings
+
+#### Moderation Service (`tools.ozone.moderation.*`)
+- **Event Management** - Query and manage moderation events
+- **Subject Operations** - Handle moderation subjects and actions
+- **Reporter Statistics** - Access reporting metrics and analytics
+
+#### Server Service (`tools.ozone.server.*`)
+- **Server Configuration** - Manage server settings and configurations
+- **Administrative Tools** - Server administration and monitoring
+
+#### Team Service (`tools.ozone.team.*`)
+- **Team Management** - Manage moderation team members and roles
+- **Permission Control** - Handle team permissions and access levels
+
+#### Additional Ozone Services
+- **Safelink Service** - URL safety and link verification
+- **Set Service** - Manage moderation rule sets and configurations
+- **Setting Service** - Administrative settings and preferences
+- **Signature Service** - Digital signatures and verification
+- **Verification Service** - Identity and content verification
 
 ### AT Protocol Services (Inherited from `atproto`)
 

--- a/packages/bluesky/lib/ozone.dart
+++ b/packages/bluesky/lib/ozone.dart
@@ -1,0 +1,5 @@
+// Copyright (c) 2023-2025, Shinya Kato.
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+export 'package:bluesky/src/ozone_tool.dart';

--- a/packages/bluesky/lib/src/ozone_tool.dart
+++ b/packages/bluesky/lib/src/ozone_tool.dart
@@ -1,0 +1,180 @@
+// Copyright (c) 2023-2025, Shinya Kato.
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// Package imports:
+import 'package:atproto/atproto.dart' as atp;
+import 'package:atproto_core/atproto_core.dart' as core;
+
+// Project imports:
+import 'services/codegen/tools/ozone/communication_service.dart';
+import 'services/codegen/tools/ozone/hosting_service.dart';
+import 'services/codegen/tools/ozone/moderation_service.dart';
+import 'services/codegen/tools/ozone/safelink_service.dart';
+import 'services/codegen/tools/ozone/server_service.dart';
+import 'services/codegen/tools/ozone/set_service.dart';
+import 'services/codegen/tools/ozone/setting_service.dart';
+import 'services/codegen/tools/ozone/signature_service.dart';
+import 'services/codegen/tools/ozone/team_service.dart';
+import 'services/codegen/tools/ozone/verification_service.dart';
+
+/// Provides `tools.ozone.*` services.
+sealed class OzoneTool {
+  /// Returns the new instance of [OzoneTool].
+  factory OzoneTool.fromSession(
+    final core.Session session, {
+    final Map<String, String>? headers,
+    final core.Protocol? protocol,
+    final String? service,
+    final String? relayService,
+    final Duration? timeout,
+    final core.RetryConfig? retryConfig,
+    final core.GetClient? getClient,
+    final core.PostClient? postClient,
+  }) => _OzoneTool(
+    core.ServiceContext(
+      headers: headers,
+      protocol: protocol,
+      service: service,
+      relayService: relayService,
+      session: session,
+      timeout: timeout,
+      retryConfig: retryConfig,
+      getClient: getClient,
+      postClient: postClient,
+    ),
+    atp.ATProto.fromSession(
+      session,
+      headers: headers,
+      protocol: protocol,
+      service: service,
+      relayService: relayService,
+      timeout: timeout,
+      retryConfig: retryConfig,
+      getClient: getClient,
+      postClient: postClient,
+    ),
+  );
+
+  /// Returns the global headers without auth header.
+  Map<String, String> get headers;
+
+  /// Returns the current session.
+  ///
+  /// Set only if an instance of this object was created in
+  /// [OzoneTool.fromSession], otherwise null.
+  core.Session? get session;
+
+  /// Returns the current service.
+  /// Defaults to `bsky.social`.
+  String get service;
+
+  /// Returns the current replay service.
+  /// Defaults to `bsky.network`.
+  String get relayService;
+
+  /// Returns atproto features.
+  atp.ATProto get atproto;
+
+  /// Returns the communication service.
+  /// This service represents `tools.ozone.communication.*`.
+  CommunicationService get communication;
+
+  /// Returns the hosting service.
+  /// This service represents `tools.ozone.hosting.*`.
+  HostingService get hosting;
+
+  /// Returns the moderation service.
+  /// This service represents `tools.ozone.moderation.*`.
+  ModerationService get moderation;
+
+  /// Returns the safelink service.
+  /// This service represents `tools.ozone.safelink.*`.
+  SafelinkService get safelink;
+
+  /// Returns the server service.
+  /// This service represents `tools.ozone.server.*`.
+  ServerService get server;
+
+  /// Returns the set service.
+  /// This service represents `tools.ozone.set.*`.
+  SetService get set;
+
+  /// Returns the setting service.
+  /// This service represents `tools.ozone.setting.*`.
+  SettingService get setting;
+
+  /// Returns the signature service.
+  /// This service represents `tools.ozone.signature.*`.
+  SignatureService get signature;
+
+  /// Returns the team service.
+  /// This service represents `tools.ozone.team.*`.
+  TeamService get team;
+
+  /// Returns the verification service.
+  /// This service represents `tools.ozone.verification.*`.
+  VerificationService get verification;
+}
+
+final class _OzoneTool implements OzoneTool {
+  _OzoneTool(final core.ServiceContext ctx, this.atproto)
+    : communication = CommunicationService(ctx),
+      hosting = HostingService(ctx),
+      moderation = ModerationService(ctx),
+      safelink = SafelinkService(ctx),
+      server = ServerService(ctx),
+      set = SetService(ctx),
+      setting = SettingService(ctx),
+      signature = SignatureService(ctx),
+      team = TeamService(ctx),
+      verification = VerificationService(ctx),
+      _ctx = ctx;
+
+  final core.ServiceContext _ctx;
+
+  @override
+  Map<String, String> get headers => _ctx.headers;
+
+  @override
+  core.Session? get session => _ctx.session;
+
+  @override
+  String get service => _ctx.service;
+
+  @override
+  String get relayService => _ctx.relayService;
+
+  @override
+  final atp.ATProto atproto;
+
+  @override
+  final CommunicationService communication;
+
+  @override
+  final HostingService hosting;
+
+  @override
+  final ModerationService moderation;
+
+  @override
+  final SafelinkService safelink;
+
+  @override
+  final ServerService server;
+
+  @override
+  final SetService set;
+
+  @override
+  final SettingService setting;
+
+  @override
+  final SignatureService signature;
+
+  @override
+  final TeamService team;
+
+  @override
+  final VerificationService verification;
+}

--- a/packages/bluesky/pubspec.yaml
+++ b/packages/bluesky/pubspec.yaml
@@ -1,6 +1,6 @@
 name: bluesky
 description: The most famous and powerful Dart/Flutter library for Bluesky Social.
-version: 1.0.10
+version: 1.0.11
 homepage: https://atprotodart.com
 documentation: https://atprotodart.com/docs/packages/bluesky
 repository: https://github.com/myConsciousness/atproto.dart/tree/main/packages/bluesky


### PR DESCRIPTION
## Summary
This PR adds a new `OzoneTool` client to the bluesky package, providing comprehensive access to all `tools.ozone.*` moderation and administrative services.

## Changes Made
- ✅ **New OzoneTool class** - Complete client for Ozone moderation tools
- ✅ **Modular import** - Available via separate `package:bluesky/ozone.dart` import
- ✅ **Comprehensive service coverage** - All 10 Ozone services included:
  - Communication, Hosting, Moderation, Server, Team
  - Safelink, Set, Setting, Signature, Verification
- ✅ **Session-based authentication** - Secure authentication for administrative operations
- ✅ **Documentation updates** - README with usage examples and API reference
- ✅ **Version bump** - Updated to v1.0.11 with changelog entry

## Usage Example
```dart
import 'package:bluesky/ozone.dart';

final session = await createSession(/* credentials */);
final ozone = OzoneTool.fromSession(session.data);

// Query moderation events
final events = await ozone.moderation.queryEvents(limit: 50);

// Manage team members  
final teamMembers = await ozone.team.listMembers();

// Server configuration
final serverConfig = await ozone.server.getConfig();
```

## Design Decisions
- **Session-only authentication** - No OAuth/anonymous access for security
- **Separate import path** - Keeps ozone functionality modular
- **Follows existing patterns** - Same structure as Bluesky client
- **Complete AT Protocol integration** - Includes atproto services

## Files Changed
- `packages/bluesky/lib/src/ozone_tool.dart` - Main OzoneTool implementation
- `packages/bluesky/lib/ozone.dart` - Export file
- `packages/bluesky/README.md` - Documentation and examples
- `packages/bluesky/pubspec.yaml` - Version bump to 1.0.11
- `packages/bluesky/CHANGELOG.md` - Release notes

## Testing
- ✅ All existing services properly imported and exposed
- ✅ Follows same patterns as existing Bluesky client
- ✅ Session-based authentication working correctly