### PR TITLE
feat: bump versions to v1.2.0 with new services and features

### DIFF
--- a/packages/atproto/CHANGELOG.md
+++ b/packages/atproto/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Release Note
 
+## v1.2.0
+
+- feat: Added Admin and Lexicon services to ATProto
+  - Added AdminService for `com.atproto.admin.*` endpoints
+  - Added LexiconService for `com.atproto.lexicon.*` endpoints
+  - Enhanced AT Protocol service coverage with comprehensive admin and lexicon functionality
+
 ## v1.1.1
 
 - **MIGRATION**: Updated to use the consolidated `at_primitives` package for all AT Protocol primitive types.

--- a/packages/atproto/pubspec.yaml
+++ b/packages/atproto/pubspec.yaml
@@ -1,6 +1,6 @@
 name: atproto
 description: The most famous and powerful Dart/Flutter library for AT Protocol.
-version: 1.1.1
+version: 1.2.0
 homepage: https://atprotodart.com
 documentation: https://atprotodart.com/docs/packages/atproto
 repository: https://github.com/myConsciousness/atproto.dart/tree/main/packages/atproto

--- a/packages/bluesky/CHANGELOG.md
+++ b/packages/bluesky/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Release Note
 
+## v1.2.0
+
+- feat: Merged #2137 - Added comprehensive Ozone moderation and administration services
+  - Added CommunicationService for `tools.ozone.communication.*` endpoints
+  - Added HostingService for `tools.ozone.hosting.*` endpoints  
+  - Added ModerationService for `tools.ozone.moderation.*` endpoints
+  - Added SafelinkService for `tools.ozone.safelink.*` endpoints
+  - Added ServerService for `tools.ozone.server.*` endpoints
+  - Added SetService for `tools.ozone.set.*` endpoints
+  - Added SettingService for `tools.ozone.setting.*` endpoints
+  - Added SignatureService for `tools.ozone.signature.*` endpoints
+  - Added TeamService for `tools.ozone.team.*` endpoints
+  - Added VerificationService for `tools.ozone.verification.*` endpoints
+  - Enhanced moderation and administrative capabilities for Bluesky applications
+- feat: Enhanced actor profile support
+  - Added `pronouns` field to `app.bsky.actor.defs#profileViewDetailed` and `app.bsky.actor.profile` record
+  - Added `website` field to `app.bsky.actor.defs#profileViewDetailed` and `app.bsky.actor.profile` record
+  - Improved user profile customization capabilities with pronouns and website information
+
 ## v1.1.1
 
 - **MIGRATION**: Updated to use the consolidated `at_primitives` package for all AT Protocol primitive types.

--- a/packages/bluesky/pubspec.yaml
+++ b/packages/bluesky/pubspec.yaml
@@ -1,6 +1,6 @@
 name: bluesky
 description: The most famous and powerful Dart/Flutter library for Bluesky Social.
-version: 1.1.1
+version: 1.2.0
 homepage: https://atprotodart.com
 documentation: https://atprotodart.com/docs/packages/bluesky
 repository: https://github.com/myConsciousness/atproto.dart/tree/main/packages/bluesky
@@ -18,7 +18,7 @@ topics:
 
 dependencies:
   atproto_core: ^1.0.7
-  atproto: ^1.1.1
+  atproto: ^1.2.0
   freezed_annotation: ^3.1.0
   json_annotation: ^4.9.0
   characters: ^1.4.1


### PR DESCRIPTION
- atproto v1.2.0: Added Admin and Lexicon services
- bluesky v1.2.0: Added Ozone services and enhanced actor profiles with pronouns/website fields