### PR TITLE
fix(did_plc): reduce pubspec topics to 5 items maximum

### DIFF
--- a/packages/did_plc/pubspec.yaml
+++ b/packages/did_plc/pubspec.yaml
@@ -16,8 +16,6 @@ topics:
   - identity
   - decentralized
   - atproto
-  - bluesky
-  - resolver
 
 dependencies:
   http: ^1.2.0


### PR DESCRIPTION
- Remove 'bluesky' and 'resolver' topics to comply with pub.dev limit
- Keep most important topics: did, plc, identity, decentralized, atproto
- Maintain optimal discoverability while meeting platform requirements