### PR TITLE
feat: implement sealed union classes for exhaustiveness checking

### DIFF
--- a/packages/atproto/CHANGELOG.md
+++ b/packages/atproto/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Release Note
 
+## v1.2.1
+
+- **IMPROVEMENT**: Enhanced union type classes with sealed class implementation
+  - Union type classes are now generated as `sealed` classes instead of `abstract` classes
+  - Enabled Dart's exhaustiveness checking for switch statements on union types
+  - Improved compile-time safety by ensuring all union cases are handled
+  - Prevents runtime errors from unhandled union variants through static analysis
+
 ## v1.2.0
 
 - feat: Added Admin and Lexicon services to ATProto

--- a/packages/atproto/lib/src/services/codegen/com/atproto/admin/getSubjectStatus/union_main_subject.dart
+++ b/packages/atproto/lib/src/services/codegen/com/atproto/admin/getSubjectStatus/union_main_subject.dart
@@ -23,7 +23,7 @@ part 'union_main_subject.freezed.dart';
 // **************************************************************************
 
 @freezed
-abstract class UAdminGetSubjectStatusSubject
+sealed class UAdminGetSubjectStatusSubject
     with _$UAdminGetSubjectStatusSubject {
   const UAdminGetSubjectStatusSubject._();
 

--- a/packages/atproto/lib/src/services/codegen/com/atproto/admin/getSubjectStatus/union_main_subject.freezed.dart
+++ b/packages/atproto/lib/src/services/codegen/com/atproto/admin/getSubjectStatus/union_main_subject.freezed.dart
@@ -87,10 +87,7 @@ case UAdminGetSubjectStatusSubjectRepoRef():
 return repoRef(_that);case UAdminGetSubjectStatusSubjectRepoStrongRef():
 return repoStrongRef(_that);case UAdminGetSubjectStatusSubjectRepoBlobRef():
 return repoBlobRef(_that);case UAdminGetSubjectStatusSubjectUnknown():
-return unknown(_that);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that);}
 }
 /// A variant of `map` that fallback to returning `null`.
 ///
@@ -158,10 +155,7 @@ case UAdminGetSubjectStatusSubjectRepoRef():
 return repoRef(_that.data);case UAdminGetSubjectStatusSubjectRepoStrongRef():
 return repoStrongRef(_that.data);case UAdminGetSubjectStatusSubjectRepoBlobRef():
 return repoBlobRef(_that.data);case UAdminGetSubjectStatusSubjectUnknown():
-return unknown(_that.data);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that.data);}
 }
 /// A variant of `when` that fallback to returning `null`
 ///

--- a/packages/atproto/lib/src/services/codegen/com/atproto/admin/updateSubjectStatus/union_main_subject.dart
+++ b/packages/atproto/lib/src/services/codegen/com/atproto/admin/updateSubjectStatus/union_main_subject.dart
@@ -23,7 +23,7 @@ part 'union_main_subject.freezed.dart';
 // **************************************************************************
 
 @freezed
-abstract class UAdminUpdateSubjectStatusSubject
+sealed class UAdminUpdateSubjectStatusSubject
     with _$UAdminUpdateSubjectStatusSubject {
   const UAdminUpdateSubjectStatusSubject._();
 

--- a/packages/atproto/lib/src/services/codegen/com/atproto/admin/updateSubjectStatus/union_main_subject.freezed.dart
+++ b/packages/atproto/lib/src/services/codegen/com/atproto/admin/updateSubjectStatus/union_main_subject.freezed.dart
@@ -87,10 +87,7 @@ case UAdminUpdateSubjectStatusSubjectRepoRef():
 return repoRef(_that);case UAdminUpdateSubjectStatusSubjectRepoStrongRef():
 return repoStrongRef(_that);case UAdminUpdateSubjectStatusSubjectRepoBlobRef():
 return repoBlobRef(_that);case UAdminUpdateSubjectStatusSubjectUnknown():
-return unknown(_that);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that);}
 }
 /// A variant of `map` that fallback to returning `null`.
 ///
@@ -158,10 +155,7 @@ case UAdminUpdateSubjectStatusSubjectRepoRef():
 return repoRef(_that.data);case UAdminUpdateSubjectStatusSubjectRepoStrongRef():
 return repoStrongRef(_that.data);case UAdminUpdateSubjectStatusSubjectRepoBlobRef():
 return repoBlobRef(_that.data);case UAdminUpdateSubjectStatusSubjectUnknown():
-return unknown(_that.data);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that.data);}
 }
 /// A variant of `when` that fallback to returning `null`
 ///

--- a/packages/atproto/lib/src/services/codegen/com/atproto/label/subscribeLabels/union_main_message.dart
+++ b/packages/atproto/lib/src/services/codegen/com/atproto/label/subscribeLabels/union_main_message.dart
@@ -22,8 +22,7 @@ part 'union_main_message.freezed.dart';
 // **************************************************************************
 
 @freezed
-abstract class ULabelSubscribeLabelsMessage
-    with _$ULabelSubscribeLabelsMessage {
+sealed class ULabelSubscribeLabelsMessage with _$ULabelSubscribeLabelsMessage {
   const ULabelSubscribeLabelsMessage._();
 
   const factory ULabelSubscribeLabelsMessage.labels({required Labels data}) =

--- a/packages/atproto/lib/src/services/codegen/com/atproto/label/subscribeLabels/union_main_message.freezed.dart
+++ b/packages/atproto/lib/src/services/codegen/com/atproto/label/subscribeLabels/union_main_message.freezed.dart
@@ -85,10 +85,7 @@ switch (_that) {
 case ULabelSubscribeLabelsMessageLabels():
 return labels(_that);case ULabelSubscribeLabelsMessageInfo():
 return info(_that);case ULabelSubscribeLabelsMessageUnknown():
-return unknown(_that);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that);}
 }
 /// A variant of `map` that fallback to returning `null`.
 ///
@@ -153,10 +150,7 @@ switch (_that) {
 case ULabelSubscribeLabelsMessageLabels():
 return labels(_that.data);case ULabelSubscribeLabelsMessageInfo():
 return info(_that.data);case ULabelSubscribeLabelsMessageUnknown():
-return unknown(_that.data);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that.data);}
 }
 /// A variant of `when` that fallback to returning `null`
 ///

--- a/packages/atproto/lib/src/services/codegen/com/atproto/moderation/createReport/union_main_subject.dart
+++ b/packages/atproto/lib/src/services/codegen/com/atproto/moderation/createReport/union_main_subject.dart
@@ -22,7 +22,7 @@ part 'union_main_subject.freezed.dart';
 // **************************************************************************
 
 @freezed
-abstract class UModerationCreateReportSubject
+sealed class UModerationCreateReportSubject
     with _$UModerationCreateReportSubject {
   const UModerationCreateReportSubject._();
 

--- a/packages/atproto/lib/src/services/codegen/com/atproto/moderation/createReport/union_main_subject.freezed.dart
+++ b/packages/atproto/lib/src/services/codegen/com/atproto/moderation/createReport/union_main_subject.freezed.dart
@@ -85,10 +85,7 @@ switch (_that) {
 case UModerationCreateReportSubjectRepoRef():
 return repoRef(_that);case UModerationCreateReportSubjectRepoStrongRef():
 return repoStrongRef(_that);case UModerationCreateReportSubjectUnknown():
-return unknown(_that);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that);}
 }
 /// A variant of `map` that fallback to returning `null`.
 ///
@@ -153,10 +150,7 @@ switch (_that) {
 case UModerationCreateReportSubjectRepoRef():
 return repoRef(_that.data);case UModerationCreateReportSubjectRepoStrongRef():
 return repoStrongRef(_that.data);case UModerationCreateReportSubjectUnknown():
-return unknown(_that.data);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that.data);}
 }
 /// A variant of `when` that fallback to returning `null`
 ///

--- a/packages/atproto/lib/src/services/codegen/com/atproto/repo/applyWrites/union_main_results.dart
+++ b/packages/atproto/lib/src/services/codegen/com/atproto/repo/applyWrites/union_main_results.dart
@@ -23,7 +23,7 @@ part 'union_main_results.freezed.dart';
 // **************************************************************************
 
 @freezed
-abstract class URepoApplyWritesResults with _$URepoApplyWritesResults {
+sealed class URepoApplyWritesResults with _$URepoApplyWritesResults {
   const URepoApplyWritesResults._();
 
   const factory URepoApplyWritesResults.createResult({

--- a/packages/atproto/lib/src/services/codegen/com/atproto/repo/applyWrites/union_main_results.freezed.dart
+++ b/packages/atproto/lib/src/services/codegen/com/atproto/repo/applyWrites/union_main_results.freezed.dart
@@ -87,10 +87,7 @@ case URepoApplyWritesResultsCreateResult():
 return createResult(_that);case URepoApplyWritesResultsUpdateResult():
 return updateResult(_that);case URepoApplyWritesResultsDeleteResult():
 return deleteResult(_that);case URepoApplyWritesResultsUnknown():
-return unknown(_that);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that);}
 }
 /// A variant of `map` that fallback to returning `null`.
 ///
@@ -158,10 +155,7 @@ case URepoApplyWritesResultsCreateResult():
 return createResult(_that.data);case URepoApplyWritesResultsUpdateResult():
 return updateResult(_that.data);case URepoApplyWritesResultsDeleteResult():
 return deleteResult(_that.data);case URepoApplyWritesResultsUnknown():
-return unknown(_that.data);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that.data);}
 }
 /// A variant of `when` that fallback to returning `null`
 ///

--- a/packages/atproto/lib/src/services/codegen/com/atproto/repo/applyWrites/union_main_writes.dart
+++ b/packages/atproto/lib/src/services/codegen/com/atproto/repo/applyWrites/union_main_writes.dart
@@ -23,7 +23,7 @@ part 'union_main_writes.freezed.dart';
 // **************************************************************************
 
 @freezed
-abstract class URepoApplyWritesWrites with _$URepoApplyWritesWrites {
+sealed class URepoApplyWritesWrites with _$URepoApplyWritesWrites {
   const URepoApplyWritesWrites._();
 
   const factory URepoApplyWritesWrites.create({required Create data}) =

--- a/packages/atproto/lib/src/services/codegen/com/atproto/repo/applyWrites/union_main_writes.freezed.dart
+++ b/packages/atproto/lib/src/services/codegen/com/atproto/repo/applyWrites/union_main_writes.freezed.dart
@@ -87,10 +87,7 @@ case URepoApplyWritesWritesCreate():
 return create(_that);case URepoApplyWritesWritesUpdate():
 return update(_that);case URepoApplyWritesWritesDelete():
 return delete(_that);case URepoApplyWritesWritesUnknown():
-return unknown(_that);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that);}
 }
 /// A variant of `map` that fallback to returning `null`.
 ///
@@ -158,10 +155,7 @@ case URepoApplyWritesWritesCreate():
 return create(_that.data);case URepoApplyWritesWritesUpdate():
 return update(_that.data);case URepoApplyWritesWritesDelete():
 return delete(_that.data);case URepoApplyWritesWritesUnknown():
-return unknown(_that.data);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that.data);}
 }
 /// A variant of `when` that fallback to returning `null`
 ///

--- a/packages/atproto/lib/src/services/codegen/com/atproto/sync/subscribeRepos/union_main_message.dart
+++ b/packages/atproto/lib/src/services/codegen/com/atproto/sync/subscribeRepos/union_main_message.dart
@@ -25,7 +25,7 @@ part 'union_main_message.freezed.dart';
 // **************************************************************************
 
 @freezed
-abstract class USyncSubscribeReposMessage with _$USyncSubscribeReposMessage {
+sealed class USyncSubscribeReposMessage with _$USyncSubscribeReposMessage {
   const USyncSubscribeReposMessage._();
 
   const factory USyncSubscribeReposMessage.commit({required Commit data}) =

--- a/packages/atproto/lib/src/services/codegen/com/atproto/sync/subscribeRepos/union_main_message.freezed.dart
+++ b/packages/atproto/lib/src/services/codegen/com/atproto/sync/subscribeRepos/union_main_message.freezed.dart
@@ -91,10 +91,7 @@ return sync(_that);case USyncSubscribeReposMessageIdentity():
 return identity(_that);case USyncSubscribeReposMessageAccount():
 return account(_that);case USyncSubscribeReposMessageInfo():
 return info(_that);case USyncSubscribeReposMessageUnknown():
-return unknown(_that);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that);}
 }
 /// A variant of `map` that fallback to returning `null`.
 ///
@@ -168,10 +165,7 @@ return sync(_that.data);case USyncSubscribeReposMessageIdentity():
 return identity(_that.data);case USyncSubscribeReposMessageAccount():
 return account(_that.data);case USyncSubscribeReposMessageInfo():
 return info(_that.data);case USyncSubscribeReposMessageUnknown():
-return unknown(_that.data);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that.data);}
 }
 /// A variant of `when` that fallback to returning `null`
 ///

--- a/packages/atproto/lib/src/services/codegen/com/atproto/temp/checkHandleAvailability/union_main_result.dart
+++ b/packages/atproto/lib/src/services/codegen/com/atproto/temp/checkHandleAvailability/union_main_result.dart
@@ -22,7 +22,7 @@ part 'union_main_result.freezed.dart';
 // **************************************************************************
 
 @freezed
-abstract class UTempCheckHandleAvailabilityResult
+sealed class UTempCheckHandleAvailabilityResult
     with _$UTempCheckHandleAvailabilityResult {
   const UTempCheckHandleAvailabilityResult._();
 

--- a/packages/atproto/lib/src/services/codegen/com/atproto/temp/checkHandleAvailability/union_main_result.freezed.dart
+++ b/packages/atproto/lib/src/services/codegen/com/atproto/temp/checkHandleAvailability/union_main_result.freezed.dart
@@ -85,10 +85,7 @@ switch (_that) {
 case UTempCheckHandleAvailabilityResultResultAvailable():
 return resultAvailable(_that);case UTempCheckHandleAvailabilityResultResultUnavailable():
 return resultUnavailable(_that);case UTempCheckHandleAvailabilityResultUnknown():
-return unknown(_that);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that);}
 }
 /// A variant of `map` that fallback to returning `null`.
 ///
@@ -153,10 +150,7 @@ switch (_that) {
 case UTempCheckHandleAvailabilityResultResultAvailable():
 return resultAvailable(_that.data);case UTempCheckHandleAvailabilityResultResultUnavailable():
 return resultUnavailable(_that.data);case UTempCheckHandleAvailabilityResultUnknown():
-return unknown(_that.data);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that.data);}
 }
 /// A variant of `when` that fallback to returning `null`
 ///

--- a/packages/atproto/pubspec.yaml
+++ b/packages/atproto/pubspec.yaml
@@ -1,6 +1,6 @@
 name: atproto
 description: The most famous and powerful Dart/Flutter library for AT Protocol.
-version: 1.2.0
+version: 1.2.1
 homepage: https://atprotodart.com
 documentation: https://atprotodart.com/docs/packages/atproto
 repository: https://github.com/myConsciousness/atproto.dart/tree/main/packages/atproto

--- a/packages/bluesky/CHANGELOG.md
+++ b/packages/bluesky/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Release Note
 
+## v1.2.3
+
+- **IMPROVEMENT**: Enhanced union type classes with sealed class implementation
+  - Union type classes are now generated as `sealed` classes instead of `abstract` classes
+  - Enabled Dart's exhaustiveness checking for switch statements on union types
+  - Improved compile-time safety by ensuring all union cases are handled
+  - Prevents runtime errors from unhandled union variants through static analysis
+
 ## v1.2.2
 
 - feat: Merged #2150 - Added pronouns field support to actor profiles

--- a/packages/bluesky/lib/src/services/codegen/app/bsky/actor/defs/union_post_interaction_settings_pref_postgate_embedding_rules.dart
+++ b/packages/bluesky/lib/src/services/codegen/app/bsky/actor/defs/union_post_interaction_settings_pref_postgate_embedding_rules.dart
@@ -21,7 +21,7 @@ part 'union_post_interaction_settings_pref_postgate_embedding_rules.freezed.dart
 // **************************************************************************
 
 @freezed
-abstract class UPostInteractionSettingsPrefPostgateEmbeddingRules
+sealed class UPostInteractionSettingsPrefPostgateEmbeddingRules
     with _$UPostInteractionSettingsPrefPostgateEmbeddingRules {
   const UPostInteractionSettingsPrefPostgateEmbeddingRules._();
 

--- a/packages/bluesky/lib/src/services/codegen/app/bsky/actor/defs/union_post_interaction_settings_pref_postgate_embedding_rules.freezed.dart
+++ b/packages/bluesky/lib/src/services/codegen/app/bsky/actor/defs/union_post_interaction_settings_pref_postgate_embedding_rules.freezed.dart
@@ -83,10 +83,7 @@ final _that = this;
 switch (_that) {
 case UPostInteractionSettingsPrefPostgateEmbeddingRulesDisableRule():
 return disableRule(_that);case UPostInteractionSettingsPrefPostgateEmbeddingRulesUnknown():
-return unknown(_that);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that);}
 }
 /// A variant of `map` that fallback to returning `null`.
 ///
@@ -148,10 +145,7 @@ return unknown(_that.data);case _:
 switch (_that) {
 case UPostInteractionSettingsPrefPostgateEmbeddingRulesDisableRule():
 return disableRule(_that.data);case UPostInteractionSettingsPrefPostgateEmbeddingRulesUnknown():
-return unknown(_that.data);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that.data);}
 }
 /// A variant of `when` that fallback to returning `null`
 ///

--- a/packages/bluesky/lib/src/services/codegen/app/bsky/actor/defs/union_post_interaction_settings_pref_threadgate_allow_rules.dart
+++ b/packages/bluesky/lib/src/services/codegen/app/bsky/actor/defs/union_post_interaction_settings_pref_threadgate_allow_rules.dart
@@ -24,7 +24,7 @@ part 'union_post_interaction_settings_pref_threadgate_allow_rules.freezed.dart';
 // **************************************************************************
 
 @freezed
-abstract class UPostInteractionSettingsPrefThreadgateAllowRules
+sealed class UPostInteractionSettingsPrefThreadgateAllowRules
     with _$UPostInteractionSettingsPrefThreadgateAllowRules {
   const UPostInteractionSettingsPrefThreadgateAllowRules._();
 

--- a/packages/bluesky/lib/src/services/codegen/app/bsky/actor/defs/union_post_interaction_settings_pref_threadgate_allow_rules.freezed.dart
+++ b/packages/bluesky/lib/src/services/codegen/app/bsky/actor/defs/union_post_interaction_settings_pref_threadgate_allow_rules.freezed.dart
@@ -89,10 +89,7 @@ return mentionRule(_that);case UPostInteractionSettingsPrefThreadgateAllowRulesF
 return followerRule(_that);case UPostInteractionSettingsPrefThreadgateAllowRulesFollowingRule():
 return followingRule(_that);case UPostInteractionSettingsPrefThreadgateAllowRulesListRule():
 return listRule(_that);case UPostInteractionSettingsPrefThreadgateAllowRulesUnknown():
-return unknown(_that);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that);}
 }
 /// A variant of `map` that fallback to returning `null`.
 ///
@@ -163,10 +160,7 @@ return mentionRule(_that.data);case UPostInteractionSettingsPrefThreadgateAllowR
 return followerRule(_that.data);case UPostInteractionSettingsPrefThreadgateAllowRulesFollowingRule():
 return followingRule(_that.data);case UPostInteractionSettingsPrefThreadgateAllowRulesListRule():
 return listRule(_that.data);case UPostInteractionSettingsPrefThreadgateAllowRulesUnknown():
-return unknown(_that.data);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that.data);}
 }
 /// A variant of `when` that fallback to returning `null`
 ///

--- a/packages/bluesky/lib/src/services/codegen/app/bsky/actor/defs/union_preferences.dart
+++ b/packages/bluesky/lib/src/services/codegen/app/bsky/actor/defs/union_preferences.dart
@@ -34,7 +34,7 @@ part 'union_preferences.freezed.dart';
 // **************************************************************************
 
 @freezed
-abstract class UPreferences with _$UPreferences {
+sealed class UPreferences with _$UPreferences {
   const UPreferences._();
 
   const factory UPreferences.adultContentPref({

--- a/packages/bluesky/lib/src/services/codegen/app/bsky/actor/defs/union_preferences.freezed.dart
+++ b/packages/bluesky/lib/src/services/codegen/app/bsky/actor/defs/union_preferences.freezed.dart
@@ -109,10 +109,7 @@ return bskyAppStatePref(_that);case UPreferencesLabelersPref():
 return labelersPref(_that);case UPreferencesPostInteractionSettingsPref():
 return postInteractionSettingsPref(_that);case UPreferencesVerificationPrefs():
 return verificationPrefs(_that);case UPreferencesUnknown():
-return unknown(_that);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that);}
 }
 /// A variant of `map` that fallback to returning `null`.
 ///
@@ -213,10 +210,7 @@ return bskyAppStatePref(_that.data);case UPreferencesLabelersPref():
 return labelersPref(_that.data);case UPreferencesPostInteractionSettingsPref():
 return postInteractionSettingsPref(_that.data);case UPreferencesVerificationPrefs():
 return verificationPrefs(_that.data);case UPreferencesUnknown():
-return unknown(_that.data);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that.data);}
 }
 /// A variant of `when` that fallback to returning `null`
 ///

--- a/packages/bluesky/lib/src/services/codegen/app/bsky/actor/defs/union_status_view_embed.dart
+++ b/packages/bluesky/lib/src/services/codegen/app/bsky/actor/defs/union_status_view_embed.dart
@@ -21,7 +21,7 @@ part 'union_status_view_embed.freezed.dart';
 // **************************************************************************
 
 @freezed
-abstract class UStatusViewEmbed with _$UStatusViewEmbed {
+sealed class UStatusViewEmbed with _$UStatusViewEmbed {
   const UStatusViewEmbed._();
 
   const factory UStatusViewEmbed.embedExternalView({

--- a/packages/bluesky/lib/src/services/codegen/app/bsky/actor/defs/union_status_view_embed.freezed.dart
+++ b/packages/bluesky/lib/src/services/codegen/app/bsky/actor/defs/union_status_view_embed.freezed.dart
@@ -83,10 +83,7 @@ final _that = this;
 switch (_that) {
 case UStatusViewEmbedEmbedExternalView():
 return embedExternalView(_that);case UStatusViewEmbedUnknown():
-return unknown(_that);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that);}
 }
 /// A variant of `map` that fallback to returning `null`.
 ///
@@ -148,10 +145,7 @@ return unknown(_that.data);case _:
 switch (_that) {
 case UStatusViewEmbedEmbedExternalView():
 return embedExternalView(_that.data);case UStatusViewEmbedUnknown():
-return unknown(_that.data);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that.data);}
 }
 /// A variant of `when` that fallback to returning `null`
 ///

--- a/packages/bluesky/lib/src/services/codegen/app/bsky/actor/profile/union_main_labels.dart
+++ b/packages/bluesky/lib/src/services/codegen/app/bsky/actor/profile/union_main_labels.dart
@@ -19,7 +19,7 @@ part 'union_main_labels.freezed.dart';
 // **************************************************************************
 
 @freezed
-abstract class UActorProfileLabels with _$UActorProfileLabels {
+sealed class UActorProfileLabels with _$UActorProfileLabels {
   const UActorProfileLabels._();
 
   const factory UActorProfileLabels.selfLabels({required SelfLabels data}) =

--- a/packages/bluesky/lib/src/services/codegen/app/bsky/actor/profile/union_main_labels.freezed.dart
+++ b/packages/bluesky/lib/src/services/codegen/app/bsky/actor/profile/union_main_labels.freezed.dart
@@ -83,10 +83,7 @@ final _that = this;
 switch (_that) {
 case UActorProfileLabelsSelfLabels():
 return selfLabels(_that);case UActorProfileLabelsUnknown():
-return unknown(_that);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that);}
 }
 /// A variant of `map` that fallback to returning `null`.
 ///
@@ -148,10 +145,7 @@ return unknown(_that.data);case _:
 switch (_that) {
 case UActorProfileLabelsSelfLabels():
 return selfLabels(_that.data);case UActorProfileLabelsUnknown():
-return unknown(_that.data);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that.data);}
 }
 /// A variant of `when` that fallback to returning `null`
 ///

--- a/packages/bluesky/lib/src/services/codegen/app/bsky/actor/status/union_main_embed.dart
+++ b/packages/bluesky/lib/src/services/codegen/app/bsky/actor/status/union_main_embed.dart
@@ -21,7 +21,7 @@ part 'union_main_embed.freezed.dart';
 // **************************************************************************
 
 @freezed
-abstract class UActorStatusEmbed with _$UActorStatusEmbed {
+sealed class UActorStatusEmbed with _$UActorStatusEmbed {
   const UActorStatusEmbed._();
 
   const factory UActorStatusEmbed.embedExternal({required EmbedExternal data}) =

--- a/packages/bluesky/lib/src/services/codegen/app/bsky/actor/status/union_main_embed.freezed.dart
+++ b/packages/bluesky/lib/src/services/codegen/app/bsky/actor/status/union_main_embed.freezed.dart
@@ -83,10 +83,7 @@ final _that = this;
 switch (_that) {
 case UActorStatusEmbedEmbedExternal():
 return embedExternal(_that);case UActorStatusEmbedUnknown():
-return unknown(_that);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that);}
 }
 /// A variant of `map` that fallback to returning `null`.
 ///
@@ -148,10 +145,7 @@ return unknown(_that.data);case _:
 switch (_that) {
 case UActorStatusEmbedEmbedExternal():
 return embedExternal(_that.data);case UActorStatusEmbedUnknown():
-return unknown(_that.data);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that.data);}
 }
 /// A variant of `when` that fallback to returning `null`
 ///

--- a/packages/bluesky/lib/src/services/codegen/app/bsky/bookmark/defs/union_bookmark_view_item.dart
+++ b/packages/bluesky/lib/src/services/codegen/app/bsky/bookmark/defs/union_bookmark_view_item.dart
@@ -23,7 +23,7 @@ part 'union_bookmark_view_item.freezed.dart';
 // **************************************************************************
 
 @freezed
-abstract class UBookmarkViewItem with _$UBookmarkViewItem {
+sealed class UBookmarkViewItem with _$UBookmarkViewItem {
   const UBookmarkViewItem._();
 
   const factory UBookmarkViewItem.blockedPost({required BlockedPost data}) =

--- a/packages/bluesky/lib/src/services/codegen/app/bsky/bookmark/defs/union_bookmark_view_item.freezed.dart
+++ b/packages/bluesky/lib/src/services/codegen/app/bsky/bookmark/defs/union_bookmark_view_item.freezed.dart
@@ -87,10 +87,7 @@ case UBookmarkViewItemBlockedPost():
 return blockedPost(_that);case UBookmarkViewItemNotFoundPost():
 return notFoundPost(_that);case UBookmarkViewItemPostView():
 return postView(_that);case UBookmarkViewItemUnknown():
-return unknown(_that);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that);}
 }
 /// A variant of `map` that fallback to returning `null`.
 ///
@@ -158,10 +155,7 @@ case UBookmarkViewItemBlockedPost():
 return blockedPost(_that.data);case UBookmarkViewItemNotFoundPost():
 return notFoundPost(_that.data);case UBookmarkViewItemPostView():
 return postView(_that.data);case UBookmarkViewItemUnknown():
-return unknown(_that.data);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that.data);}
 }
 /// A variant of `when` that fallback to returning `null`
 ///

--- a/packages/bluesky/lib/src/services/codegen/app/bsky/embed/record/union_view_record.dart
+++ b/packages/bluesky/lib/src/services/codegen/app/bsky/embed/record/union_view_record.dart
@@ -28,7 +28,7 @@ part 'union_view_record.freezed.dart';
 // **************************************************************************
 
 @freezed
-abstract class UEmbedRecordViewRecord with _$UEmbedRecordViewRecord {
+sealed class UEmbedRecordViewRecord with _$UEmbedRecordViewRecord {
   const UEmbedRecordViewRecord._();
 
   const factory UEmbedRecordViewRecord.embedRecordViewRecord({

--- a/packages/bluesky/lib/src/services/codegen/app/bsky/embed/record/union_view_record.freezed.dart
+++ b/packages/bluesky/lib/src/services/codegen/app/bsky/embed/record/union_view_record.freezed.dart
@@ -97,10 +97,7 @@ return generatorView(_that);case UEmbedRecordViewRecordListView():
 return listView(_that);case UEmbedRecordViewRecordLabelerView():
 return labelerView(_that);case UEmbedRecordViewRecordStarterPackViewBasic():
 return starterPackViewBasic(_that);case UEmbedRecordViewRecordUnknown():
-return unknown(_that);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that);}
 }
 /// A variant of `map` that fallback to returning `null`.
 ///
@@ -183,10 +180,7 @@ return generatorView(_that.data);case UEmbedRecordViewRecordListView():
 return listView(_that.data);case UEmbedRecordViewRecordLabelerView():
 return labelerView(_that.data);case UEmbedRecordViewRecordStarterPackViewBasic():
 return starterPackViewBasic(_that.data);case UEmbedRecordViewRecordUnknown():
-return unknown(_that.data);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that.data);}
 }
 /// A variant of `when` that fallback to returning `null`
 ///

--- a/packages/bluesky/lib/src/services/codegen/app/bsky/embed/record/union_view_record_embeds.dart
+++ b/packages/bluesky/lib/src/services/codegen/app/bsky/embed/record/union_view_record_embeds.dart
@@ -25,8 +25,7 @@ part 'union_view_record_embeds.freezed.dart';
 // **************************************************************************
 
 @freezed
-abstract class UEmbedRecordViewRecordEmbeds
-    with _$UEmbedRecordViewRecordEmbeds {
+sealed class UEmbedRecordViewRecordEmbeds with _$UEmbedRecordViewRecordEmbeds {
   const UEmbedRecordViewRecordEmbeds._();
 
   const factory UEmbedRecordViewRecordEmbeds.embedImagesView({

--- a/packages/bluesky/lib/src/services/codegen/app/bsky/embed/record/union_view_record_embeds.freezed.dart
+++ b/packages/bluesky/lib/src/services/codegen/app/bsky/embed/record/union_view_record_embeds.freezed.dart
@@ -91,10 +91,7 @@ return embedVideoView(_that);case UEmbedRecordViewRecordEmbedsEmbedExternalView(
 return embedExternalView(_that);case UEmbedRecordViewRecordEmbedsEmbedRecordView():
 return embedRecordView(_that);case UEmbedRecordViewRecordEmbedsEmbedRecordWithMediaView():
 return embedRecordWithMediaView(_that);case UEmbedRecordViewRecordEmbedsUnknown():
-return unknown(_that);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that);}
 }
 /// A variant of `map` that fallback to returning `null`.
 ///
@@ -168,10 +165,7 @@ return embedVideoView(_that.data);case UEmbedRecordViewRecordEmbedsEmbedExternal
 return embedExternalView(_that.data);case UEmbedRecordViewRecordEmbedsEmbedRecordView():
 return embedRecordView(_that.data);case UEmbedRecordViewRecordEmbedsEmbedRecordWithMediaView():
 return embedRecordWithMediaView(_that.data);case UEmbedRecordViewRecordEmbedsUnknown():
-return unknown(_that.data);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that.data);}
 }
 /// A variant of `when` that fallback to returning `null`
 ///

--- a/packages/bluesky/lib/src/services/codegen/app/bsky/embed/recordWithMedia/union_main_media.dart
+++ b/packages/bluesky/lib/src/services/codegen/app/bsky/embed/recordWithMedia/union_main_media.dart
@@ -23,7 +23,7 @@ part 'union_main_media.freezed.dart';
 // **************************************************************************
 
 @freezed
-abstract class UEmbedRecordWithMediaMedia with _$UEmbedRecordWithMediaMedia {
+sealed class UEmbedRecordWithMediaMedia with _$UEmbedRecordWithMediaMedia {
   const UEmbedRecordWithMediaMedia._();
 
   const factory UEmbedRecordWithMediaMedia.embedImages({

--- a/packages/bluesky/lib/src/services/codegen/app/bsky/embed/recordWithMedia/union_main_media.freezed.dart
+++ b/packages/bluesky/lib/src/services/codegen/app/bsky/embed/recordWithMedia/union_main_media.freezed.dart
@@ -87,10 +87,7 @@ case UEmbedRecordWithMediaMediaEmbedImages():
 return embedImages(_that);case UEmbedRecordWithMediaMediaEmbedVideo():
 return embedVideo(_that);case UEmbedRecordWithMediaMediaEmbedExternal():
 return embedExternal(_that);case UEmbedRecordWithMediaMediaUnknown():
-return unknown(_that);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that);}
 }
 /// A variant of `map` that fallback to returning `null`.
 ///
@@ -158,10 +155,7 @@ case UEmbedRecordWithMediaMediaEmbedImages():
 return embedImages(_that.data);case UEmbedRecordWithMediaMediaEmbedVideo():
 return embedVideo(_that.data);case UEmbedRecordWithMediaMediaEmbedExternal():
 return embedExternal(_that.data);case UEmbedRecordWithMediaMediaUnknown():
-return unknown(_that.data);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that.data);}
 }
 /// A variant of `when` that fallback to returning `null`
 ///

--- a/packages/bluesky/lib/src/services/codegen/app/bsky/embed/recordWithMedia/union_view_media.dart
+++ b/packages/bluesky/lib/src/services/codegen/app/bsky/embed/recordWithMedia/union_view_media.dart
@@ -23,7 +23,7 @@ part 'union_view_media.freezed.dart';
 // **************************************************************************
 
 @freezed
-abstract class UEmbedRecordWithMediaViewMedia
+sealed class UEmbedRecordWithMediaViewMedia
     with _$UEmbedRecordWithMediaViewMedia {
   const UEmbedRecordWithMediaViewMedia._();
 

--- a/packages/bluesky/lib/src/services/codegen/app/bsky/embed/recordWithMedia/union_view_media.freezed.dart
+++ b/packages/bluesky/lib/src/services/codegen/app/bsky/embed/recordWithMedia/union_view_media.freezed.dart
@@ -87,10 +87,7 @@ case UEmbedRecordWithMediaViewMediaEmbedImagesView():
 return embedImagesView(_that);case UEmbedRecordWithMediaViewMediaEmbedVideoView():
 return embedVideoView(_that);case UEmbedRecordWithMediaViewMediaEmbedExternalView():
 return embedExternalView(_that);case UEmbedRecordWithMediaViewMediaUnknown():
-return unknown(_that);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that);}
 }
 /// A variant of `map` that fallback to returning `null`.
 ///
@@ -158,10 +155,7 @@ case UEmbedRecordWithMediaViewMediaEmbedImagesView():
 return embedImagesView(_that.data);case UEmbedRecordWithMediaViewMediaEmbedVideoView():
 return embedVideoView(_that.data);case UEmbedRecordWithMediaViewMediaEmbedExternalView():
 return embedExternalView(_that.data);case UEmbedRecordWithMediaViewMediaUnknown():
-return unknown(_that.data);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that.data);}
 }
 /// A variant of `when` that fallback to returning `null`
 ///

--- a/packages/bluesky/lib/src/services/codegen/app/bsky/feed/defs/union_feed_view_post_reason.dart
+++ b/packages/bluesky/lib/src/services/codegen/app/bsky/feed/defs/union_feed_view_post_reason.dart
@@ -22,7 +22,7 @@ part 'union_feed_view_post_reason.freezed.dart';
 // **************************************************************************
 
 @freezed
-abstract class UFeedViewPostReason with _$UFeedViewPostReason {
+sealed class UFeedViewPostReason with _$UFeedViewPostReason {
   const UFeedViewPostReason._();
 
   const factory UFeedViewPostReason.reasonRepost({required ReasonRepost data}) =

--- a/packages/bluesky/lib/src/services/codegen/app/bsky/feed/defs/union_feed_view_post_reason.freezed.dart
+++ b/packages/bluesky/lib/src/services/codegen/app/bsky/feed/defs/union_feed_view_post_reason.freezed.dart
@@ -85,10 +85,7 @@ switch (_that) {
 case UFeedViewPostReasonReasonRepost():
 return reasonRepost(_that);case UFeedViewPostReasonReasonPin():
 return reasonPin(_that);case UFeedViewPostReasonUnknown():
-return unknown(_that);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that);}
 }
 /// A variant of `map` that fallback to returning `null`.
 ///
@@ -153,10 +150,7 @@ switch (_that) {
 case UFeedViewPostReasonReasonRepost():
 return reasonRepost(_that.data);case UFeedViewPostReasonReasonPin():
 return reasonPin(_that.data);case UFeedViewPostReasonUnknown():
-return unknown(_that.data);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that.data);}
 }
 /// A variant of `when` that fallback to returning `null`
 ///

--- a/packages/bluesky/lib/src/services/codegen/app/bsky/feed/defs/union_post_view_embed.dart
+++ b/packages/bluesky/lib/src/services/codegen/app/bsky/feed/defs/union_post_view_embed.dart
@@ -25,7 +25,7 @@ part 'union_post_view_embed.freezed.dart';
 // **************************************************************************
 
 @freezed
-abstract class UPostViewEmbed with _$UPostViewEmbed {
+sealed class UPostViewEmbed with _$UPostViewEmbed {
   const UPostViewEmbed._();
 
   const factory UPostViewEmbed.embedImagesView({

--- a/packages/bluesky/lib/src/services/codegen/app/bsky/feed/defs/union_post_view_embed.freezed.dart
+++ b/packages/bluesky/lib/src/services/codegen/app/bsky/feed/defs/union_post_view_embed.freezed.dart
@@ -91,10 +91,7 @@ return embedVideoView(_that);case UPostViewEmbedEmbedExternalView():
 return embedExternalView(_that);case UPostViewEmbedEmbedRecordView():
 return embedRecordView(_that);case UPostViewEmbedEmbedRecordWithMediaView():
 return embedRecordWithMediaView(_that);case UPostViewEmbedUnknown():
-return unknown(_that);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that);}
 }
 /// A variant of `map` that fallback to returning `null`.
 ///
@@ -168,10 +165,7 @@ return embedVideoView(_that.data);case UPostViewEmbedEmbedExternalView():
 return embedExternalView(_that.data);case UPostViewEmbedEmbedRecordView():
 return embedRecordView(_that.data);case UPostViewEmbedEmbedRecordWithMediaView():
 return embedRecordWithMediaView(_that.data);case UPostViewEmbedUnknown():
-return unknown(_that.data);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that.data);}
 }
 /// A variant of `when` that fallback to returning `null`
 ///

--- a/packages/bluesky/lib/src/services/codegen/app/bsky/feed/defs/union_reply_ref_parent.dart
+++ b/packages/bluesky/lib/src/services/codegen/app/bsky/feed/defs/union_reply_ref_parent.dart
@@ -23,7 +23,7 @@ part 'union_reply_ref_parent.freezed.dart';
 // **************************************************************************
 
 @freezed
-abstract class UReplyRefParent with _$UReplyRefParent {
+sealed class UReplyRefParent with _$UReplyRefParent {
   const UReplyRefParent._();
 
   const factory UReplyRefParent.postView({required PostView data}) =

--- a/packages/bluesky/lib/src/services/codegen/app/bsky/feed/defs/union_reply_ref_parent.freezed.dart
+++ b/packages/bluesky/lib/src/services/codegen/app/bsky/feed/defs/union_reply_ref_parent.freezed.dart
@@ -87,10 +87,7 @@ case UReplyRefParentPostView():
 return postView(_that);case UReplyRefParentNotFoundPost():
 return notFoundPost(_that);case UReplyRefParentBlockedPost():
 return blockedPost(_that);case UReplyRefParentUnknown():
-return unknown(_that);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that);}
 }
 /// A variant of `map` that fallback to returning `null`.
 ///
@@ -158,10 +155,7 @@ case UReplyRefParentPostView():
 return postView(_that.data);case UReplyRefParentNotFoundPost():
 return notFoundPost(_that.data);case UReplyRefParentBlockedPost():
 return blockedPost(_that.data);case UReplyRefParentUnknown():
-return unknown(_that.data);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that.data);}
 }
 /// A variant of `when` that fallback to returning `null`
 ///

--- a/packages/bluesky/lib/src/services/codegen/app/bsky/feed/defs/union_reply_ref_root.dart
+++ b/packages/bluesky/lib/src/services/codegen/app/bsky/feed/defs/union_reply_ref_root.dart
@@ -23,7 +23,7 @@ part 'union_reply_ref_root.freezed.dart';
 // **************************************************************************
 
 @freezed
-abstract class UReplyRefRoot with _$UReplyRefRoot {
+sealed class UReplyRefRoot with _$UReplyRefRoot {
   const UReplyRefRoot._();
 
   const factory UReplyRefRoot.postView({required PostView data}) =

--- a/packages/bluesky/lib/src/services/codegen/app/bsky/feed/defs/union_reply_ref_root.freezed.dart
+++ b/packages/bluesky/lib/src/services/codegen/app/bsky/feed/defs/union_reply_ref_root.freezed.dart
@@ -87,10 +87,7 @@ case UReplyRefRootPostView():
 return postView(_that);case UReplyRefRootNotFoundPost():
 return notFoundPost(_that);case UReplyRefRootBlockedPost():
 return blockedPost(_that);case UReplyRefRootUnknown():
-return unknown(_that);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that);}
 }
 /// A variant of `map` that fallback to returning `null`.
 ///
@@ -158,10 +155,7 @@ case UReplyRefRootPostView():
 return postView(_that.data);case UReplyRefRootNotFoundPost():
 return notFoundPost(_that.data);case UReplyRefRootBlockedPost():
 return blockedPost(_that.data);case UReplyRefRootUnknown():
-return unknown(_that.data);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that.data);}
 }
 /// A variant of `when` that fallback to returning `null`
 ///

--- a/packages/bluesky/lib/src/services/codegen/app/bsky/feed/defs/union_skeleton_feed_post_reason.dart
+++ b/packages/bluesky/lib/src/services/codegen/app/bsky/feed/defs/union_skeleton_feed_post_reason.dart
@@ -22,7 +22,7 @@ part 'union_skeleton_feed_post_reason.freezed.dart';
 // **************************************************************************
 
 @freezed
-abstract class USkeletonFeedPostReason with _$USkeletonFeedPostReason {
+sealed class USkeletonFeedPostReason with _$USkeletonFeedPostReason {
   const USkeletonFeedPostReason._();
 
   const factory USkeletonFeedPostReason.skeletonReasonRepost({

--- a/packages/bluesky/lib/src/services/codegen/app/bsky/feed/defs/union_skeleton_feed_post_reason.freezed.dart
+++ b/packages/bluesky/lib/src/services/codegen/app/bsky/feed/defs/union_skeleton_feed_post_reason.freezed.dart
@@ -85,10 +85,7 @@ switch (_that) {
 case USkeletonFeedPostReasonSkeletonReasonRepost():
 return skeletonReasonRepost(_that);case USkeletonFeedPostReasonSkeletonReasonPin():
 return skeletonReasonPin(_that);case USkeletonFeedPostReasonUnknown():
-return unknown(_that);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that);}
 }
 /// A variant of `map` that fallback to returning `null`.
 ///
@@ -153,10 +150,7 @@ switch (_that) {
 case USkeletonFeedPostReasonSkeletonReasonRepost():
 return skeletonReasonRepost(_that.data);case USkeletonFeedPostReasonSkeletonReasonPin():
 return skeletonReasonPin(_that.data);case USkeletonFeedPostReasonUnknown():
-return unknown(_that.data);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that.data);}
 }
 /// A variant of `when` that fallback to returning `null`
 ///

--- a/packages/bluesky/lib/src/services/codegen/app/bsky/feed/defs/union_thread_view_post_parent.dart
+++ b/packages/bluesky/lib/src/services/codegen/app/bsky/feed/defs/union_thread_view_post_parent.dart
@@ -23,7 +23,7 @@ part 'union_thread_view_post_parent.freezed.dart';
 // **************************************************************************
 
 @freezed
-abstract class UThreadViewPostParent with _$UThreadViewPostParent {
+sealed class UThreadViewPostParent with _$UThreadViewPostParent {
   const UThreadViewPostParent._();
 
   const factory UThreadViewPostParent.threadViewPost({

--- a/packages/bluesky/lib/src/services/codegen/app/bsky/feed/defs/union_thread_view_post_parent.freezed.dart
+++ b/packages/bluesky/lib/src/services/codegen/app/bsky/feed/defs/union_thread_view_post_parent.freezed.dart
@@ -87,10 +87,7 @@ case UThreadViewPostParentThreadViewPost():
 return threadViewPost(_that);case UThreadViewPostParentNotFoundPost():
 return notFoundPost(_that);case UThreadViewPostParentBlockedPost():
 return blockedPost(_that);case UThreadViewPostParentUnknown():
-return unknown(_that);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that);}
 }
 /// A variant of `map` that fallback to returning `null`.
 ///
@@ -158,10 +155,7 @@ case UThreadViewPostParentThreadViewPost():
 return threadViewPost(_that.data);case UThreadViewPostParentNotFoundPost():
 return notFoundPost(_that.data);case UThreadViewPostParentBlockedPost():
 return blockedPost(_that.data);case UThreadViewPostParentUnknown():
-return unknown(_that.data);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that.data);}
 }
 /// A variant of `when` that fallback to returning `null`
 ///

--- a/packages/bluesky/lib/src/services/codegen/app/bsky/feed/defs/union_thread_view_post_replies.dart
+++ b/packages/bluesky/lib/src/services/codegen/app/bsky/feed/defs/union_thread_view_post_replies.dart
@@ -23,7 +23,7 @@ part 'union_thread_view_post_replies.freezed.dart';
 // **************************************************************************
 
 @freezed
-abstract class UThreadViewPostReplies with _$UThreadViewPostReplies {
+sealed class UThreadViewPostReplies with _$UThreadViewPostReplies {
   const UThreadViewPostReplies._();
 
   const factory UThreadViewPostReplies.threadViewPost({

--- a/packages/bluesky/lib/src/services/codegen/app/bsky/feed/defs/union_thread_view_post_replies.freezed.dart
+++ b/packages/bluesky/lib/src/services/codegen/app/bsky/feed/defs/union_thread_view_post_replies.freezed.dart
@@ -87,10 +87,7 @@ case UThreadViewPostRepliesThreadViewPost():
 return threadViewPost(_that);case UThreadViewPostRepliesNotFoundPost():
 return notFoundPost(_that);case UThreadViewPostRepliesBlockedPost():
 return blockedPost(_that);case UThreadViewPostRepliesUnknown():
-return unknown(_that);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that);}
 }
 /// A variant of `map` that fallback to returning `null`.
 ///
@@ -158,10 +155,7 @@ case UThreadViewPostRepliesThreadViewPost():
 return threadViewPost(_that.data);case UThreadViewPostRepliesNotFoundPost():
 return notFoundPost(_that.data);case UThreadViewPostRepliesBlockedPost():
 return blockedPost(_that.data);case UThreadViewPostRepliesUnknown():
-return unknown(_that.data);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that.data);}
 }
 /// A variant of `when` that fallback to returning `null`
 ///

--- a/packages/bluesky/lib/src/services/codegen/app/bsky/feed/generator/union_main_labels.dart
+++ b/packages/bluesky/lib/src/services/codegen/app/bsky/feed/generator/union_main_labels.dart
@@ -19,7 +19,7 @@ part 'union_main_labels.freezed.dart';
 // **************************************************************************
 
 @freezed
-abstract class UFeedGeneratorLabels with _$UFeedGeneratorLabels {
+sealed class UFeedGeneratorLabels with _$UFeedGeneratorLabels {
   const UFeedGeneratorLabels._();
 
   const factory UFeedGeneratorLabels.selfLabels({required SelfLabels data}) =

--- a/packages/bluesky/lib/src/services/codegen/app/bsky/feed/generator/union_main_labels.freezed.dart
+++ b/packages/bluesky/lib/src/services/codegen/app/bsky/feed/generator/union_main_labels.freezed.dart
@@ -83,10 +83,7 @@ final _that = this;
 switch (_that) {
 case UFeedGeneratorLabelsSelfLabels():
 return selfLabels(_that);case UFeedGeneratorLabelsUnknown():
-return unknown(_that);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that);}
 }
 /// A variant of `map` that fallback to returning `null`.
 ///
@@ -148,10 +145,7 @@ return unknown(_that.data);case _:
 switch (_that) {
 case UFeedGeneratorLabelsSelfLabels():
 return selfLabels(_that.data);case UFeedGeneratorLabelsUnknown():
-return unknown(_that.data);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that.data);}
 }
 /// A variant of `when` that fallback to returning `null`
 ///

--- a/packages/bluesky/lib/src/services/codegen/app/bsky/feed/getPostThread/union_main_thread.dart
+++ b/packages/bluesky/lib/src/services/codegen/app/bsky/feed/getPostThread/union_main_thread.dart
@@ -23,7 +23,7 @@ part 'union_main_thread.freezed.dart';
 // **************************************************************************
 
 @freezed
-abstract class UFeedGetPostThreadThread with _$UFeedGetPostThreadThread {
+sealed class UFeedGetPostThreadThread with _$UFeedGetPostThreadThread {
   const UFeedGetPostThreadThread._();
 
   const factory UFeedGetPostThreadThread.threadViewPost({

--- a/packages/bluesky/lib/src/services/codegen/app/bsky/feed/getPostThread/union_main_thread.freezed.dart
+++ b/packages/bluesky/lib/src/services/codegen/app/bsky/feed/getPostThread/union_main_thread.freezed.dart
@@ -87,10 +87,7 @@ case UFeedGetPostThreadThreadThreadViewPost():
 return threadViewPost(_that);case UFeedGetPostThreadThreadNotFoundPost():
 return notFoundPost(_that);case UFeedGetPostThreadThreadBlockedPost():
 return blockedPost(_that);case UFeedGetPostThreadThreadUnknown():
-return unknown(_that);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that);}
 }
 /// A variant of `map` that fallback to returning `null`.
 ///
@@ -158,10 +155,7 @@ case UFeedGetPostThreadThreadThreadViewPost():
 return threadViewPost(_that.data);case UFeedGetPostThreadThreadNotFoundPost():
 return notFoundPost(_that.data);case UFeedGetPostThreadThreadBlockedPost():
 return blockedPost(_that.data);case UFeedGetPostThreadThreadUnknown():
-return unknown(_that.data);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that.data);}
 }
 /// A variant of `when` that fallback to returning `null`
 ///

--- a/packages/bluesky/lib/src/services/codegen/app/bsky/feed/post/union_main_embed.dart
+++ b/packages/bluesky/lib/src/services/codegen/app/bsky/feed/post/union_main_embed.dart
@@ -25,7 +25,7 @@ part 'union_main_embed.freezed.dart';
 // **************************************************************************
 
 @freezed
-abstract class UFeedPostEmbed with _$UFeedPostEmbed {
+sealed class UFeedPostEmbed with _$UFeedPostEmbed {
   const UFeedPostEmbed._();
 
   const factory UFeedPostEmbed.embedImages({required EmbedImages data}) =

--- a/packages/bluesky/lib/src/services/codegen/app/bsky/feed/post/union_main_embed.freezed.dart
+++ b/packages/bluesky/lib/src/services/codegen/app/bsky/feed/post/union_main_embed.freezed.dart
@@ -91,10 +91,7 @@ return embedVideo(_that);case UFeedPostEmbedEmbedExternal():
 return embedExternal(_that);case UFeedPostEmbedEmbedRecord():
 return embedRecord(_that);case UFeedPostEmbedEmbedRecordWithMedia():
 return embedRecordWithMedia(_that);case UFeedPostEmbedUnknown():
-return unknown(_that);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that);}
 }
 /// A variant of `map` that fallback to returning `null`.
 ///
@@ -168,10 +165,7 @@ return embedVideo(_that.data);case UFeedPostEmbedEmbedExternal():
 return embedExternal(_that.data);case UFeedPostEmbedEmbedRecord():
 return embedRecord(_that.data);case UFeedPostEmbedEmbedRecordWithMedia():
 return embedRecordWithMedia(_that.data);case UFeedPostEmbedUnknown():
-return unknown(_that.data);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that.data);}
 }
 /// A variant of `when` that fallback to returning `null`
 ///

--- a/packages/bluesky/lib/src/services/codegen/app/bsky/feed/post/union_main_labels.dart
+++ b/packages/bluesky/lib/src/services/codegen/app/bsky/feed/post/union_main_labels.dart
@@ -19,7 +19,7 @@ part 'union_main_labels.freezed.dart';
 // **************************************************************************
 
 @freezed
-abstract class UFeedPostLabels with _$UFeedPostLabels {
+sealed class UFeedPostLabels with _$UFeedPostLabels {
   const UFeedPostLabels._();
 
   const factory UFeedPostLabels.selfLabels({required SelfLabels data}) =

--- a/packages/bluesky/lib/src/services/codegen/app/bsky/feed/post/union_main_labels.freezed.dart
+++ b/packages/bluesky/lib/src/services/codegen/app/bsky/feed/post/union_main_labels.freezed.dart
@@ -83,10 +83,7 @@ final _that = this;
 switch (_that) {
 case UFeedPostLabelsSelfLabels():
 return selfLabels(_that);case UFeedPostLabelsUnknown():
-return unknown(_that);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that);}
 }
 /// A variant of `map` that fallback to returning `null`.
 ///
@@ -148,10 +145,7 @@ return unknown(_that.data);case _:
 switch (_that) {
 case UFeedPostLabelsSelfLabels():
 return selfLabels(_that.data);case UFeedPostLabelsUnknown():
-return unknown(_that.data);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that.data);}
 }
 /// A variant of `when` that fallback to returning `null`
 ///

--- a/packages/bluesky/lib/src/services/codegen/app/bsky/feed/postgate/union_main_embedding_rules.dart
+++ b/packages/bluesky/lib/src/services/codegen/app/bsky/feed/postgate/union_main_embedding_rules.dart
@@ -21,7 +21,7 @@ part 'union_main_embedding_rules.freezed.dart';
 // **************************************************************************
 
 @freezed
-abstract class UFeedPostgateEmbeddingRules with _$UFeedPostgateEmbeddingRules {
+sealed class UFeedPostgateEmbeddingRules with _$UFeedPostgateEmbeddingRules {
   const UFeedPostgateEmbeddingRules._();
 
   const factory UFeedPostgateEmbeddingRules.disableRule({

--- a/packages/bluesky/lib/src/services/codegen/app/bsky/feed/postgate/union_main_embedding_rules.freezed.dart
+++ b/packages/bluesky/lib/src/services/codegen/app/bsky/feed/postgate/union_main_embedding_rules.freezed.dart
@@ -83,10 +83,7 @@ final _that = this;
 switch (_that) {
 case UFeedPostgateEmbeddingRulesDisableRule():
 return disableRule(_that);case UFeedPostgateEmbeddingRulesUnknown():
-return unknown(_that);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that);}
 }
 /// A variant of `map` that fallback to returning `null`.
 ///
@@ -148,10 +145,7 @@ return unknown(_that.data);case _:
 switch (_that) {
 case UFeedPostgateEmbeddingRulesDisableRule():
 return disableRule(_that.data);case UFeedPostgateEmbeddingRulesUnknown():
-return unknown(_that.data);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that.data);}
 }
 /// A variant of `when` that fallback to returning `null`
 ///

--- a/packages/bluesky/lib/src/services/codegen/app/bsky/feed/threadgate/union_main_allow.dart
+++ b/packages/bluesky/lib/src/services/codegen/app/bsky/feed/threadgate/union_main_allow.dart
@@ -24,7 +24,7 @@ part 'union_main_allow.freezed.dart';
 // **************************************************************************
 
 @freezed
-abstract class UFeedThreadgateAllow with _$UFeedThreadgateAllow {
+sealed class UFeedThreadgateAllow with _$UFeedThreadgateAllow {
   const UFeedThreadgateAllow._();
 
   const factory UFeedThreadgateAllow.mentionRule({required MentionRule data}) =

--- a/packages/bluesky/lib/src/services/codegen/app/bsky/feed/threadgate/union_main_allow.freezed.dart
+++ b/packages/bluesky/lib/src/services/codegen/app/bsky/feed/threadgate/union_main_allow.freezed.dart
@@ -89,10 +89,7 @@ return mentionRule(_that);case UFeedThreadgateAllowFollowerRule():
 return followerRule(_that);case UFeedThreadgateAllowFollowingRule():
 return followingRule(_that);case UFeedThreadgateAllowListRule():
 return listRule(_that);case UFeedThreadgateAllowUnknown():
-return unknown(_that);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that);}
 }
 /// A variant of `map` that fallback to returning `null`.
 ///
@@ -163,10 +160,7 @@ return mentionRule(_that.data);case UFeedThreadgateAllowFollowerRule():
 return followerRule(_that.data);case UFeedThreadgateAllowFollowingRule():
 return followingRule(_that.data);case UFeedThreadgateAllowListRule():
 return listRule(_that.data);case UFeedThreadgateAllowUnknown():
-return unknown(_that.data);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that.data);}
 }
 /// A variant of `when` that fallback to returning `null`
 ///

--- a/packages/bluesky/lib/src/services/codegen/app/bsky/graph/getRelationships/union_main_relationships.dart
+++ b/packages/bluesky/lib/src/services/codegen/app/bsky/graph/getRelationships/union_main_relationships.dart
@@ -22,7 +22,7 @@ part 'union_main_relationships.freezed.dart';
 // **************************************************************************
 
 @freezed
-abstract class UGraphGetRelationshipsRelationships
+sealed class UGraphGetRelationshipsRelationships
     with _$UGraphGetRelationshipsRelationships {
   const UGraphGetRelationshipsRelationships._();
 

--- a/packages/bluesky/lib/src/services/codegen/app/bsky/graph/getRelationships/union_main_relationships.freezed.dart
+++ b/packages/bluesky/lib/src/services/codegen/app/bsky/graph/getRelationships/union_main_relationships.freezed.dart
@@ -85,10 +85,7 @@ switch (_that) {
 case UGraphGetRelationshipsRelationshipsRelationship():
 return relationship(_that);case UGraphGetRelationshipsRelationshipsNotFoundActor():
 return notFoundActor(_that);case UGraphGetRelationshipsRelationshipsUnknown():
-return unknown(_that);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that);}
 }
 /// A variant of `map` that fallback to returning `null`.
 ///
@@ -153,10 +150,7 @@ switch (_that) {
 case UGraphGetRelationshipsRelationshipsRelationship():
 return relationship(_that.data);case UGraphGetRelationshipsRelationshipsNotFoundActor():
 return notFoundActor(_that.data);case UGraphGetRelationshipsRelationshipsUnknown():
-return unknown(_that.data);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that.data);}
 }
 /// A variant of `when` that fallback to returning `null`
 ///

--- a/packages/bluesky/lib/src/services/codegen/app/bsky/graph/list/union_main_labels.dart
+++ b/packages/bluesky/lib/src/services/codegen/app/bsky/graph/list/union_main_labels.dart
@@ -19,7 +19,7 @@ part 'union_main_labels.freezed.dart';
 // **************************************************************************
 
 @freezed
-abstract class UGraphListLabels with _$UGraphListLabels {
+sealed class UGraphListLabels with _$UGraphListLabels {
   const UGraphListLabels._();
 
   const factory UGraphListLabels.selfLabels({required SelfLabels data}) =

--- a/packages/bluesky/lib/src/services/codegen/app/bsky/graph/list/union_main_labels.freezed.dart
+++ b/packages/bluesky/lib/src/services/codegen/app/bsky/graph/list/union_main_labels.freezed.dart
@@ -83,10 +83,7 @@ final _that = this;
 switch (_that) {
 case UGraphListLabelsSelfLabels():
 return selfLabels(_that);case UGraphListLabelsUnknown():
-return unknown(_that);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that);}
 }
 /// A variant of `map` that fallback to returning `null`.
 ///
@@ -148,10 +145,7 @@ return unknown(_that.data);case _:
 switch (_that) {
 case UGraphListLabelsSelfLabels():
 return selfLabels(_that.data);case UGraphListLabelsUnknown():
-return unknown(_that.data);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that.data);}
 }
 /// A variant of `when` that fallback to returning `null`
 ///

--- a/packages/bluesky/lib/src/services/codegen/app/bsky/labeler/getServices/union_main_views.dart
+++ b/packages/bluesky/lib/src/services/codegen/app/bsky/labeler/getServices/union_main_views.dart
@@ -22,7 +22,7 @@ part 'union_main_views.freezed.dart';
 // **************************************************************************
 
 @freezed
-abstract class ULabelerGetServicesViews with _$ULabelerGetServicesViews {
+sealed class ULabelerGetServicesViews with _$ULabelerGetServicesViews {
   const ULabelerGetServicesViews._();
 
   const factory ULabelerGetServicesViews.labelerView({

--- a/packages/bluesky/lib/src/services/codegen/app/bsky/labeler/getServices/union_main_views.freezed.dart
+++ b/packages/bluesky/lib/src/services/codegen/app/bsky/labeler/getServices/union_main_views.freezed.dart
@@ -85,10 +85,7 @@ switch (_that) {
 case ULabelerGetServicesViewsLabelerView():
 return labelerView(_that);case ULabelerGetServicesViewsLabelerViewDetailed():
 return labelerViewDetailed(_that);case ULabelerGetServicesViewsUnknown():
-return unknown(_that);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that);}
 }
 /// A variant of `map` that fallback to returning `null`.
 ///
@@ -153,10 +150,7 @@ switch (_that) {
 case ULabelerGetServicesViewsLabelerView():
 return labelerView(_that.data);case ULabelerGetServicesViewsLabelerViewDetailed():
 return labelerViewDetailed(_that.data);case ULabelerGetServicesViewsUnknown():
-return unknown(_that.data);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that.data);}
 }
 /// A variant of `when` that fallback to returning `null`
 ///

--- a/packages/bluesky/lib/src/services/codegen/app/bsky/labeler/service/union_main_labels.dart
+++ b/packages/bluesky/lib/src/services/codegen/app/bsky/labeler/service/union_main_labels.dart
@@ -19,7 +19,7 @@ part 'union_main_labels.freezed.dart';
 // **************************************************************************
 
 @freezed
-abstract class ULabelerServiceLabels with _$ULabelerServiceLabels {
+sealed class ULabelerServiceLabels with _$ULabelerServiceLabels {
   const ULabelerServiceLabels._();
 
   const factory ULabelerServiceLabels.selfLabels({required SelfLabels data}) =

--- a/packages/bluesky/lib/src/services/codegen/app/bsky/labeler/service/union_main_labels.freezed.dart
+++ b/packages/bluesky/lib/src/services/codegen/app/bsky/labeler/service/union_main_labels.freezed.dart
@@ -83,10 +83,7 @@ final _that = this;
 switch (_that) {
 case ULabelerServiceLabelsSelfLabels():
 return selfLabels(_that);case ULabelerServiceLabelsUnknown():
-return unknown(_that);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that);}
 }
 /// A variant of `map` that fallback to returning `null`.
 ///
@@ -148,10 +145,7 @@ return unknown(_that.data);case _:
 switch (_that) {
 case ULabelerServiceLabelsSelfLabels():
 return selfLabels(_that.data);case ULabelerServiceLabelsUnknown():
-return unknown(_that.data);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that.data);}
 }
 /// A variant of `when` that fallback to returning `null`
 ///

--- a/packages/bluesky/lib/src/services/codegen/app/bsky/richtext/facet/union_main_features.dart
+++ b/packages/bluesky/lib/src/services/codegen/app/bsky/richtext/facet/union_main_features.dart
@@ -23,7 +23,7 @@ part 'union_main_features.freezed.dart';
 // **************************************************************************
 
 @freezed
-abstract class URichtextFacetFeatures with _$URichtextFacetFeatures {
+sealed class URichtextFacetFeatures with _$URichtextFacetFeatures {
   const URichtextFacetFeatures._();
 
   const factory URichtextFacetFeatures.richtextFacetMention({

--- a/packages/bluesky/lib/src/services/codegen/app/bsky/richtext/facet/union_main_features.freezed.dart
+++ b/packages/bluesky/lib/src/services/codegen/app/bsky/richtext/facet/union_main_features.freezed.dart
@@ -87,10 +87,7 @@ case URichtextFacetFeaturesRichtextFacetMention():
 return richtextFacetMention(_that);case URichtextFacetFeaturesRichtextFacetLink():
 return richtextFacetLink(_that);case URichtextFacetFeaturesRichtextFacetTag():
 return richtextFacetTag(_that);case URichtextFacetFeaturesUnknown():
-return unknown(_that);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that);}
 }
 /// A variant of `map` that fallback to returning `null`.
 ///
@@ -158,10 +155,7 @@ case URichtextFacetFeaturesRichtextFacetMention():
 return richtextFacetMention(_that.data);case URichtextFacetFeaturesRichtextFacetLink():
 return richtextFacetLink(_that.data);case URichtextFacetFeaturesRichtextFacetTag():
 return richtextFacetTag(_that.data);case URichtextFacetFeaturesUnknown():
-return unknown(_that.data);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that.data);}
 }
 /// A variant of `when` that fallback to returning `null`
 ///

--- a/packages/bluesky/lib/src/services/codegen/app/bsky/unspecced/getPostThreadOtherV2/union_thread_item_value.dart
+++ b/packages/bluesky/lib/src/services/codegen/app/bsky/unspecced/getPostThreadOtherV2/union_thread_item_value.dart
@@ -21,7 +21,7 @@ part 'union_thread_item_value.freezed.dart';
 // **************************************************************************
 
 @freezed
-abstract class UThreadItemValue with _$UThreadItemValue {
+sealed class UThreadItemValue with _$UThreadItemValue {
   const UThreadItemValue._();
 
   const factory UThreadItemValue.threadItemPost({

--- a/packages/bluesky/lib/src/services/codegen/app/bsky/unspecced/getPostThreadOtherV2/union_thread_item_value.freezed.dart
+++ b/packages/bluesky/lib/src/services/codegen/app/bsky/unspecced/getPostThreadOtherV2/union_thread_item_value.freezed.dart
@@ -83,10 +83,7 @@ final _that = this;
 switch (_that) {
 case UThreadItemValueThreadItemPost():
 return threadItemPost(_that);case UThreadItemValueUnknown():
-return unknown(_that);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that);}
 }
 /// A variant of `map` that fallback to returning `null`.
 ///
@@ -148,10 +145,7 @@ return unknown(_that.data);case _:
 switch (_that) {
 case UThreadItemValueThreadItemPost():
 return threadItemPost(_that.data);case UThreadItemValueUnknown():
-return unknown(_that.data);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that.data);}
 }
 /// A variant of `when` that fallback to returning `null`
 ///

--- a/packages/bluesky/lib/src/services/codegen/app/bsky/unspecced/getPostThreadV2/union_thread_item_value.dart
+++ b/packages/bluesky/lib/src/services/codegen/app/bsky/unspecced/getPostThreadV2/union_thread_item_value.dart
@@ -24,7 +24,7 @@ part 'union_thread_item_value.freezed.dart';
 // **************************************************************************
 
 @freezed
-abstract class UThreadItemValue with _$UThreadItemValue {
+sealed class UThreadItemValue with _$UThreadItemValue {
   const UThreadItemValue._();
 
   const factory UThreadItemValue.threadItemPost({

--- a/packages/bluesky/lib/src/services/codegen/app/bsky/unspecced/getPostThreadV2/union_thread_item_value.freezed.dart
+++ b/packages/bluesky/lib/src/services/codegen/app/bsky/unspecced/getPostThreadV2/union_thread_item_value.freezed.dart
@@ -89,10 +89,7 @@ return threadItemPost(_that);case UThreadItemValueThreadItemNoUnauthenticated():
 return threadItemNoUnauthenticated(_that);case UThreadItemValueThreadItemNotFound():
 return threadItemNotFound(_that);case UThreadItemValueThreadItemBlocked():
 return threadItemBlocked(_that);case UThreadItemValueUnknown():
-return unknown(_that);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that);}
 }
 /// A variant of `map` that fallback to returning `null`.
 ///
@@ -163,10 +160,7 @@ return threadItemPost(_that.data);case UThreadItemValueThreadItemNoUnauthenticat
 return threadItemNoUnauthenticated(_that.data);case UThreadItemValueThreadItemNotFound():
 return threadItemNotFound(_that.data);case UThreadItemValueThreadItemBlocked():
 return threadItemBlocked(_that.data);case UThreadItemValueUnknown():
-return unknown(_that.data);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that.data);}
 }
 /// A variant of `when` that fallback to returning `null`
 ///

--- a/packages/bluesky/lib/src/services/codegen/chat/bsky/convo/defs/union_convo_view_last_message.dart
+++ b/packages/bluesky/lib/src/services/codegen/chat/bsky/convo/defs/union_convo_view_last_message.dart
@@ -22,7 +22,7 @@ part 'union_convo_view_last_message.freezed.dart';
 // **************************************************************************
 
 @freezed
-abstract class UConvoViewLastMessage with _$UConvoViewLastMessage {
+sealed class UConvoViewLastMessage with _$UConvoViewLastMessage {
   const UConvoViewLastMessage._();
 
   const factory UConvoViewLastMessage.messageView({required MessageView data}) =

--- a/packages/bluesky/lib/src/services/codegen/chat/bsky/convo/defs/union_convo_view_last_message.freezed.dart
+++ b/packages/bluesky/lib/src/services/codegen/chat/bsky/convo/defs/union_convo_view_last_message.freezed.dart
@@ -85,10 +85,7 @@ switch (_that) {
 case UConvoViewLastMessageMessageView():
 return messageView(_that);case UConvoViewLastMessageDeletedMessageView():
 return deletedMessageView(_that);case UConvoViewLastMessageUnknown():
-return unknown(_that);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that);}
 }
 /// A variant of `map` that fallback to returning `null`.
 ///
@@ -153,10 +150,7 @@ switch (_that) {
 case UConvoViewLastMessageMessageView():
 return messageView(_that.data);case UConvoViewLastMessageDeletedMessageView():
 return deletedMessageView(_that.data);case UConvoViewLastMessageUnknown():
-return unknown(_that.data);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that.data);}
 }
 /// A variant of `when` that fallback to returning `null`
 ///

--- a/packages/bluesky/lib/src/services/codegen/chat/bsky/convo/defs/union_convo_view_last_reaction.dart
+++ b/packages/bluesky/lib/src/services/codegen/chat/bsky/convo/defs/union_convo_view_last_reaction.dart
@@ -21,7 +21,7 @@ part 'union_convo_view_last_reaction.freezed.dart';
 // **************************************************************************
 
 @freezed
-abstract class UConvoViewLastReaction with _$UConvoViewLastReaction {
+sealed class UConvoViewLastReaction with _$UConvoViewLastReaction {
   const UConvoViewLastReaction._();
 
   const factory UConvoViewLastReaction.messageAndReactionView({

--- a/packages/bluesky/lib/src/services/codegen/chat/bsky/convo/defs/union_convo_view_last_reaction.freezed.dart
+++ b/packages/bluesky/lib/src/services/codegen/chat/bsky/convo/defs/union_convo_view_last_reaction.freezed.dart
@@ -83,10 +83,7 @@ final _that = this;
 switch (_that) {
 case UConvoViewLastReactionMessageAndReactionView():
 return messageAndReactionView(_that);case UConvoViewLastReactionUnknown():
-return unknown(_that);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that);}
 }
 /// A variant of `map` that fallback to returning `null`.
 ///
@@ -148,10 +145,7 @@ return unknown(_that.data);case _:
 switch (_that) {
 case UConvoViewLastReactionMessageAndReactionView():
 return messageAndReactionView(_that.data);case UConvoViewLastReactionUnknown():
-return unknown(_that.data);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that.data);}
 }
 /// A variant of `when` that fallback to returning `null`
 ///

--- a/packages/bluesky/lib/src/services/codegen/chat/bsky/convo/defs/union_log_add_reaction_message.dart
+++ b/packages/bluesky/lib/src/services/codegen/chat/bsky/convo/defs/union_log_add_reaction_message.dart
@@ -22,7 +22,7 @@ part 'union_log_add_reaction_message.freezed.dart';
 // **************************************************************************
 
 @freezed
-abstract class ULogAddReactionMessage with _$ULogAddReactionMessage {
+sealed class ULogAddReactionMessage with _$ULogAddReactionMessage {
   const ULogAddReactionMessage._();
 
   const factory ULogAddReactionMessage.messageView({

--- a/packages/bluesky/lib/src/services/codegen/chat/bsky/convo/defs/union_log_add_reaction_message.freezed.dart
+++ b/packages/bluesky/lib/src/services/codegen/chat/bsky/convo/defs/union_log_add_reaction_message.freezed.dart
@@ -85,10 +85,7 @@ switch (_that) {
 case ULogAddReactionMessageMessageView():
 return messageView(_that);case ULogAddReactionMessageDeletedMessageView():
 return deletedMessageView(_that);case ULogAddReactionMessageUnknown():
-return unknown(_that);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that);}
 }
 /// A variant of `map` that fallback to returning `null`.
 ///
@@ -153,10 +150,7 @@ switch (_that) {
 case ULogAddReactionMessageMessageView():
 return messageView(_that.data);case ULogAddReactionMessageDeletedMessageView():
 return deletedMessageView(_that.data);case ULogAddReactionMessageUnknown():
-return unknown(_that.data);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that.data);}
 }
 /// A variant of `when` that fallback to returning `null`
 ///

--- a/packages/bluesky/lib/src/services/codegen/chat/bsky/convo/defs/union_log_create_message_message.dart
+++ b/packages/bluesky/lib/src/services/codegen/chat/bsky/convo/defs/union_log_create_message_message.dart
@@ -22,7 +22,7 @@ part 'union_log_create_message_message.freezed.dart';
 // **************************************************************************
 
 @freezed
-abstract class ULogCreateMessageMessage with _$ULogCreateMessageMessage {
+sealed class ULogCreateMessageMessage with _$ULogCreateMessageMessage {
   const ULogCreateMessageMessage._();
 
   const factory ULogCreateMessageMessage.messageView({

--- a/packages/bluesky/lib/src/services/codegen/chat/bsky/convo/defs/union_log_create_message_message.freezed.dart
+++ b/packages/bluesky/lib/src/services/codegen/chat/bsky/convo/defs/union_log_create_message_message.freezed.dart
@@ -85,10 +85,7 @@ switch (_that) {
 case ULogCreateMessageMessageMessageView():
 return messageView(_that);case ULogCreateMessageMessageDeletedMessageView():
 return deletedMessageView(_that);case ULogCreateMessageMessageUnknown():
-return unknown(_that);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that);}
 }
 /// A variant of `map` that fallback to returning `null`.
 ///
@@ -153,10 +150,7 @@ switch (_that) {
 case ULogCreateMessageMessageMessageView():
 return messageView(_that.data);case ULogCreateMessageMessageDeletedMessageView():
 return deletedMessageView(_that.data);case ULogCreateMessageMessageUnknown():
-return unknown(_that.data);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that.data);}
 }
 /// A variant of `when` that fallback to returning `null`
 ///

--- a/packages/bluesky/lib/src/services/codegen/chat/bsky/convo/defs/union_log_delete_message_message.dart
+++ b/packages/bluesky/lib/src/services/codegen/chat/bsky/convo/defs/union_log_delete_message_message.dart
@@ -22,7 +22,7 @@ part 'union_log_delete_message_message.freezed.dart';
 // **************************************************************************
 
 @freezed
-abstract class ULogDeleteMessageMessage with _$ULogDeleteMessageMessage {
+sealed class ULogDeleteMessageMessage with _$ULogDeleteMessageMessage {
   const ULogDeleteMessageMessage._();
 
   const factory ULogDeleteMessageMessage.messageView({

--- a/packages/bluesky/lib/src/services/codegen/chat/bsky/convo/defs/union_log_delete_message_message.freezed.dart
+++ b/packages/bluesky/lib/src/services/codegen/chat/bsky/convo/defs/union_log_delete_message_message.freezed.dart
@@ -85,10 +85,7 @@ switch (_that) {
 case ULogDeleteMessageMessageMessageView():
 return messageView(_that);case ULogDeleteMessageMessageDeletedMessageView():
 return deletedMessageView(_that);case ULogDeleteMessageMessageUnknown():
-return unknown(_that);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that);}
 }
 /// A variant of `map` that fallback to returning `null`.
 ///
@@ -153,10 +150,7 @@ switch (_that) {
 case ULogDeleteMessageMessageMessageView():
 return messageView(_that.data);case ULogDeleteMessageMessageDeletedMessageView():
 return deletedMessageView(_that.data);case ULogDeleteMessageMessageUnknown():
-return unknown(_that.data);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that.data);}
 }
 /// A variant of `when` that fallback to returning `null`
 ///

--- a/packages/bluesky/lib/src/services/codegen/chat/bsky/convo/defs/union_log_read_message_message.dart
+++ b/packages/bluesky/lib/src/services/codegen/chat/bsky/convo/defs/union_log_read_message_message.dart
@@ -22,7 +22,7 @@ part 'union_log_read_message_message.freezed.dart';
 // **************************************************************************
 
 @freezed
-abstract class ULogReadMessageMessage with _$ULogReadMessageMessage {
+sealed class ULogReadMessageMessage with _$ULogReadMessageMessage {
   const ULogReadMessageMessage._();
 
   const factory ULogReadMessageMessage.messageView({

--- a/packages/bluesky/lib/src/services/codegen/chat/bsky/convo/defs/union_log_read_message_message.freezed.dart
+++ b/packages/bluesky/lib/src/services/codegen/chat/bsky/convo/defs/union_log_read_message_message.freezed.dart
@@ -85,10 +85,7 @@ switch (_that) {
 case ULogReadMessageMessageMessageView():
 return messageView(_that);case ULogReadMessageMessageDeletedMessageView():
 return deletedMessageView(_that);case ULogReadMessageMessageUnknown():
-return unknown(_that);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that);}
 }
 /// A variant of `map` that fallback to returning `null`.
 ///
@@ -153,10 +150,7 @@ switch (_that) {
 case ULogReadMessageMessageMessageView():
 return messageView(_that.data);case ULogReadMessageMessageDeletedMessageView():
 return deletedMessageView(_that.data);case ULogReadMessageMessageUnknown():
-return unknown(_that.data);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that.data);}
 }
 /// A variant of `when` that fallback to returning `null`
 ///

--- a/packages/bluesky/lib/src/services/codegen/chat/bsky/convo/defs/union_log_remove_reaction_message.dart
+++ b/packages/bluesky/lib/src/services/codegen/chat/bsky/convo/defs/union_log_remove_reaction_message.dart
@@ -22,7 +22,7 @@ part 'union_log_remove_reaction_message.freezed.dart';
 // **************************************************************************
 
 @freezed
-abstract class ULogRemoveReactionMessage with _$ULogRemoveReactionMessage {
+sealed class ULogRemoveReactionMessage with _$ULogRemoveReactionMessage {
   const ULogRemoveReactionMessage._();
 
   const factory ULogRemoveReactionMessage.messageView({

--- a/packages/bluesky/lib/src/services/codegen/chat/bsky/convo/defs/union_log_remove_reaction_message.freezed.dart
+++ b/packages/bluesky/lib/src/services/codegen/chat/bsky/convo/defs/union_log_remove_reaction_message.freezed.dart
@@ -85,10 +85,7 @@ switch (_that) {
 case ULogRemoveReactionMessageMessageView():
 return messageView(_that);case ULogRemoveReactionMessageDeletedMessageView():
 return deletedMessageView(_that);case ULogRemoveReactionMessageUnknown():
-return unknown(_that);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that);}
 }
 /// A variant of `map` that fallback to returning `null`.
 ///
@@ -153,10 +150,7 @@ switch (_that) {
 case ULogRemoveReactionMessageMessageView():
 return messageView(_that.data);case ULogRemoveReactionMessageDeletedMessageView():
 return deletedMessageView(_that.data);case ULogRemoveReactionMessageUnknown():
-return unknown(_that.data);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that.data);}
 }
 /// A variant of `when` that fallback to returning `null`
 ///

--- a/packages/bluesky/lib/src/services/codegen/chat/bsky/convo/defs/union_message_input_embed.dart
+++ b/packages/bluesky/lib/src/services/codegen/chat/bsky/convo/defs/union_message_input_embed.dart
@@ -21,7 +21,7 @@ part 'union_message_input_embed.freezed.dart';
 // **************************************************************************
 
 @freezed
-abstract class UMessageInputEmbed with _$UMessageInputEmbed {
+sealed class UMessageInputEmbed with _$UMessageInputEmbed {
   const UMessageInputEmbed._();
 
   const factory UMessageInputEmbed.embedRecord({required EmbedRecord data}) =

--- a/packages/bluesky/lib/src/services/codegen/chat/bsky/convo/defs/union_message_input_embed.freezed.dart
+++ b/packages/bluesky/lib/src/services/codegen/chat/bsky/convo/defs/union_message_input_embed.freezed.dart
@@ -83,10 +83,7 @@ final _that = this;
 switch (_that) {
 case UMessageInputEmbedEmbedRecord():
 return embedRecord(_that);case UMessageInputEmbedUnknown():
-return unknown(_that);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that);}
 }
 /// A variant of `map` that fallback to returning `null`.
 ///
@@ -148,10 +145,7 @@ return unknown(_that.data);case _:
 switch (_that) {
 case UMessageInputEmbedEmbedRecord():
 return embedRecord(_that.data);case UMessageInputEmbedUnknown():
-return unknown(_that.data);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that.data);}
 }
 /// A variant of `when` that fallback to returning `null`
 ///

--- a/packages/bluesky/lib/src/services/codegen/chat/bsky/convo/defs/union_message_view_embed.dart
+++ b/packages/bluesky/lib/src/services/codegen/chat/bsky/convo/defs/union_message_view_embed.dart
@@ -21,7 +21,7 @@ part 'union_message_view_embed.freezed.dart';
 // **************************************************************************
 
 @freezed
-abstract class UMessageViewEmbed with _$UMessageViewEmbed {
+sealed class UMessageViewEmbed with _$UMessageViewEmbed {
   const UMessageViewEmbed._();
 
   const factory UMessageViewEmbed.embedRecordView({

--- a/packages/bluesky/lib/src/services/codegen/chat/bsky/convo/defs/union_message_view_embed.freezed.dart
+++ b/packages/bluesky/lib/src/services/codegen/chat/bsky/convo/defs/union_message_view_embed.freezed.dart
@@ -83,10 +83,7 @@ final _that = this;
 switch (_that) {
 case UMessageViewEmbedEmbedRecordView():
 return embedRecordView(_that);case UMessageViewEmbedUnknown():
-return unknown(_that);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that);}
 }
 /// A variant of `map` that fallback to returning `null`.
 ///
@@ -148,10 +145,7 @@ return unknown(_that.data);case _:
 switch (_that) {
 case UMessageViewEmbedEmbedRecordView():
 return embedRecordView(_that.data);case UMessageViewEmbedUnknown():
-return unknown(_that.data);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that.data);}
 }
 /// A variant of `when` that fallback to returning `null`
 ///

--- a/packages/bluesky/lib/src/services/codegen/chat/bsky/convo/getLog/union_main_logs.dart
+++ b/packages/bluesky/lib/src/services/codegen/chat/bsky/convo/getLog/union_main_logs.dart
@@ -30,7 +30,7 @@ part 'union_main_logs.freezed.dart';
 // **************************************************************************
 
 @freezed
-abstract class UConvoGetLogLogs with _$UConvoGetLogLogs {
+sealed class UConvoGetLogLogs with _$UConvoGetLogLogs {
   const UConvoGetLogLogs._();
 
   const factory UConvoGetLogLogs.logBeginConvo({required LogBeginConvo data}) =

--- a/packages/bluesky/lib/src/services/codegen/chat/bsky/convo/getLog/union_main_logs.freezed.dart
+++ b/packages/bluesky/lib/src/services/codegen/chat/bsky/convo/getLog/union_main_logs.freezed.dart
@@ -101,10 +101,7 @@ return logDeleteMessage(_that);case UConvoGetLogLogsLogReadMessage():
 return logReadMessage(_that);case UConvoGetLogLogsLogAddReaction():
 return logAddReaction(_that);case UConvoGetLogLogsLogRemoveReaction():
 return logRemoveReaction(_that);case UConvoGetLogLogsUnknown():
-return unknown(_that);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that);}
 }
 /// A variant of `map` that fallback to returning `null`.
 ///
@@ -193,10 +190,7 @@ return logDeleteMessage(_that.data);case UConvoGetLogLogsLogReadMessage():
 return logReadMessage(_that.data);case UConvoGetLogLogsLogAddReaction():
 return logAddReaction(_that.data);case UConvoGetLogLogsLogRemoveReaction():
 return logRemoveReaction(_that.data);case UConvoGetLogLogsUnknown():
-return unknown(_that.data);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that.data);}
 }
 /// A variant of `when` that fallback to returning `null`
 ///

--- a/packages/bluesky/lib/src/services/codegen/chat/bsky/convo/getMessages/union_main_messages.dart
+++ b/packages/bluesky/lib/src/services/codegen/chat/bsky/convo/getMessages/union_main_messages.dart
@@ -22,7 +22,7 @@ part 'union_main_messages.freezed.dart';
 // **************************************************************************
 
 @freezed
-abstract class UConvoGetMessagesMessages with _$UConvoGetMessagesMessages {
+sealed class UConvoGetMessagesMessages with _$UConvoGetMessagesMessages {
   const UConvoGetMessagesMessages._();
 
   const factory UConvoGetMessagesMessages.messageView({

--- a/packages/bluesky/lib/src/services/codegen/chat/bsky/convo/getMessages/union_main_messages.freezed.dart
+++ b/packages/bluesky/lib/src/services/codegen/chat/bsky/convo/getMessages/union_main_messages.freezed.dart
@@ -85,10 +85,7 @@ switch (_that) {
 case UConvoGetMessagesMessagesMessageView():
 return messageView(_that);case UConvoGetMessagesMessagesDeletedMessageView():
 return deletedMessageView(_that);case UConvoGetMessagesMessagesUnknown():
-return unknown(_that);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that);}
 }
 /// A variant of `map` that fallback to returning `null`.
 ///
@@ -153,10 +150,7 @@ switch (_that) {
 case UConvoGetMessagesMessagesMessageView():
 return messageView(_that.data);case UConvoGetMessagesMessagesDeletedMessageView():
 return deletedMessageView(_that.data);case UConvoGetMessagesMessagesUnknown():
-return unknown(_that.data);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that.data);}
 }
 /// A variant of `when` that fallback to returning `null`
 ///

--- a/packages/bluesky/lib/src/services/codegen/chat/bsky/moderation/getMessageContext/union_main_messages.dart
+++ b/packages/bluesky/lib/src/services/codegen/chat/bsky/moderation/getMessageContext/union_main_messages.dart
@@ -22,7 +22,7 @@ part 'union_main_messages.freezed.dart';
 // **************************************************************************
 
 @freezed
-abstract class UModerationGetMessageContextMessages
+sealed class UModerationGetMessageContextMessages
     with _$UModerationGetMessageContextMessages {
   const UModerationGetMessageContextMessages._();
 

--- a/packages/bluesky/lib/src/services/codegen/chat/bsky/moderation/getMessageContext/union_main_messages.freezed.dart
+++ b/packages/bluesky/lib/src/services/codegen/chat/bsky/moderation/getMessageContext/union_main_messages.freezed.dart
@@ -85,10 +85,7 @@ switch (_that) {
 case UModerationGetMessageContextMessagesMessageView():
 return messageView(_that);case UModerationGetMessageContextMessagesDeletedMessageView():
 return deletedMessageView(_that);case UModerationGetMessageContextMessagesUnknown():
-return unknown(_that);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that);}
 }
 /// A variant of `map` that fallback to returning `null`.
 ///
@@ -153,10 +150,7 @@ switch (_that) {
 case UModerationGetMessageContextMessagesMessageView():
 return messageView(_that.data);case UModerationGetMessageContextMessagesDeletedMessageView():
 return deletedMessageView(_that.data);case UModerationGetMessageContextMessagesUnknown():
-return unknown(_that.data);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that.data);}
 }
 /// A variant of `when` that fallback to returning `null`
 ///

--- a/packages/bluesky/lib/src/services/codegen/tools/ozone/hosting/getAccountHistory/union_event_details.dart
+++ b/packages/bluesky/lib/src/services/codegen/tools/ozone/hosting/getAccountHistory/union_event_details.dart
@@ -25,7 +25,7 @@ part 'union_event_details.freezed.dart';
 // **************************************************************************
 
 @freezed
-abstract class UEventDetails with _$UEventDetails {
+sealed class UEventDetails with _$UEventDetails {
   const UEventDetails._();
 
   const factory UEventDetails.accountCreated({required AccountCreated data}) =

--- a/packages/bluesky/lib/src/services/codegen/tools/ozone/hosting/getAccountHistory/union_event_details.freezed.dart
+++ b/packages/bluesky/lib/src/services/codegen/tools/ozone/hosting/getAccountHistory/union_event_details.freezed.dart
@@ -91,10 +91,7 @@ return emailUpdated(_that);case UEventDetailsEmailConfirmed():
 return emailConfirmed(_that);case UEventDetailsPasswordUpdated():
 return passwordUpdated(_that);case UEventDetailsHandleUpdated():
 return handleUpdated(_that);case UEventDetailsUnknown():
-return unknown(_that);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that);}
 }
 /// A variant of `map` that fallback to returning `null`.
 ///
@@ -168,10 +165,7 @@ return emailUpdated(_that.data);case UEventDetailsEmailConfirmed():
 return emailConfirmed(_that.data);case UEventDetailsPasswordUpdated():
 return passwordUpdated(_that.data);case UEventDetailsHandleUpdated():
 return handleUpdated(_that.data);case UEventDetailsUnknown():
-return unknown(_that.data);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that.data);}
 }
 /// A variant of `when` that fallback to returning `null`
 ///

--- a/packages/bluesky/lib/src/services/codegen/tools/ozone/moderation/defs/union_blob_view_details.dart
+++ b/packages/bluesky/lib/src/services/codegen/tools/ozone/moderation/defs/union_blob_view_details.dart
@@ -22,7 +22,7 @@ part 'union_blob_view_details.freezed.dart';
 // **************************************************************************
 
 @freezed
-abstract class UBlobViewDetails with _$UBlobViewDetails {
+sealed class UBlobViewDetails with _$UBlobViewDetails {
   const UBlobViewDetails._();
 
   const factory UBlobViewDetails.imageDetails({required ImageDetails data}) =

--- a/packages/bluesky/lib/src/services/codegen/tools/ozone/moderation/defs/union_blob_view_details.freezed.dart
+++ b/packages/bluesky/lib/src/services/codegen/tools/ozone/moderation/defs/union_blob_view_details.freezed.dart
@@ -85,10 +85,7 @@ switch (_that) {
 case UBlobViewDetailsImageDetails():
 return imageDetails(_that);case UBlobViewDetailsVideoDetails():
 return videoDetails(_that);case UBlobViewDetailsUnknown():
-return unknown(_that);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that);}
 }
 /// A variant of `map` that fallback to returning `null`.
 ///
@@ -153,10 +150,7 @@ switch (_that) {
 case UBlobViewDetailsImageDetails():
 return imageDetails(_that.data);case UBlobViewDetailsVideoDetails():
 return videoDetails(_that.data);case UBlobViewDetailsUnknown():
-return unknown(_that.data);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that.data);}
 }
 /// A variant of `when` that fallback to returning `null`
 ///

--- a/packages/bluesky/lib/src/services/codegen/tools/ozone/moderation/defs/union_mod_event_view_detail_event.dart
+++ b/packages/bluesky/lib/src/services/codegen/tools/ozone/moderation/defs/union_mod_event_view_detail_event.dart
@@ -42,7 +42,7 @@ part 'union_mod_event_view_detail_event.freezed.dart';
 // **************************************************************************
 
 @freezed
-abstract class UModEventViewDetailEvent with _$UModEventViewDetailEvent {
+sealed class UModEventViewDetailEvent with _$UModEventViewDetailEvent {
   const UModEventViewDetailEvent._();
 
   const factory UModEventViewDetailEvent.modEventTakedown({

--- a/packages/bluesky/lib/src/services/codegen/tools/ozone/moderation/defs/union_mod_event_view_detail_event.freezed.dart
+++ b/packages/bluesky/lib/src/services/codegen/tools/ozone/moderation/defs/union_mod_event_view_detail_event.freezed.dart
@@ -125,10 +125,7 @@ return modEventPriorityScore(_that);case UModEventViewDetailEventAgeAssuranceEve
 return ageAssuranceEvent(_that);case UModEventViewDetailEventAgeAssuranceOverrideEvent():
 return ageAssuranceOverrideEvent(_that);case UModEventViewDetailEventRevokeAccountCredentialsEvent():
 return revokeAccountCredentialsEvent(_that);case UModEventViewDetailEventUnknown():
-return unknown(_that);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that);}
 }
 /// A variant of `map` that fallback to returning `null`.
 ///
@@ -253,10 +250,7 @@ return modEventPriorityScore(_that.data);case UModEventViewDetailEventAgeAssuran
 return ageAssuranceEvent(_that.data);case UModEventViewDetailEventAgeAssuranceOverrideEvent():
 return ageAssuranceOverrideEvent(_that.data);case UModEventViewDetailEventRevokeAccountCredentialsEvent():
 return revokeAccountCredentialsEvent(_that.data);case UModEventViewDetailEventUnknown():
-return unknown(_that.data);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that.data);}
 }
 /// A variant of `when` that fallback to returning `null`
 ///

--- a/packages/bluesky/lib/src/services/codegen/tools/ozone/moderation/defs/union_mod_event_view_detail_subject.dart
+++ b/packages/bluesky/lib/src/services/codegen/tools/ozone/moderation/defs/union_mod_event_view_detail_subject.dart
@@ -24,7 +24,7 @@ part 'union_mod_event_view_detail_subject.freezed.dart';
 // **************************************************************************
 
 @freezed
-abstract class UModEventViewDetailSubject with _$UModEventViewDetailSubject {
+sealed class UModEventViewDetailSubject with _$UModEventViewDetailSubject {
   const UModEventViewDetailSubject._();
 
   const factory UModEventViewDetailSubject.repoView({required RepoView data}) =

--- a/packages/bluesky/lib/src/services/codegen/tools/ozone/moderation/defs/union_mod_event_view_detail_subject.freezed.dart
+++ b/packages/bluesky/lib/src/services/codegen/tools/ozone/moderation/defs/union_mod_event_view_detail_subject.freezed.dart
@@ -89,10 +89,7 @@ return repoView(_that);case UModEventViewDetailSubjectRepoViewNotFound():
 return repoViewNotFound(_that);case UModEventViewDetailSubjectRecordView():
 return recordView(_that);case UModEventViewDetailSubjectRecordViewNotFound():
 return recordViewNotFound(_that);case UModEventViewDetailSubjectUnknown():
-return unknown(_that);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that);}
 }
 /// A variant of `map` that fallback to returning `null`.
 ///
@@ -163,10 +160,7 @@ return repoView(_that.data);case UModEventViewDetailSubjectRepoViewNotFound():
 return repoViewNotFound(_that.data);case UModEventViewDetailSubjectRecordView():
 return recordView(_that.data);case UModEventViewDetailSubjectRecordViewNotFound():
 return recordViewNotFound(_that.data);case UModEventViewDetailSubjectUnknown():
-return unknown(_that.data);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that.data);}
 }
 /// A variant of `when` that fallback to returning `null`
 ///

--- a/packages/bluesky/lib/src/services/codegen/tools/ozone/moderation/defs/union_mod_event_view_event.dart
+++ b/packages/bluesky/lib/src/services/codegen/tools/ozone/moderation/defs/union_mod_event_view_event.dart
@@ -42,7 +42,7 @@ part 'union_mod_event_view_event.freezed.dart';
 // **************************************************************************
 
 @freezed
-abstract class UModEventViewEvent with _$UModEventViewEvent {
+sealed class UModEventViewEvent with _$UModEventViewEvent {
   const UModEventViewEvent._();
 
   const factory UModEventViewEvent.modEventTakedown({

--- a/packages/bluesky/lib/src/services/codegen/tools/ozone/moderation/defs/union_mod_event_view_event.freezed.dart
+++ b/packages/bluesky/lib/src/services/codegen/tools/ozone/moderation/defs/union_mod_event_view_event.freezed.dart
@@ -125,10 +125,7 @@ return modEventPriorityScore(_that);case UModEventViewEventAgeAssuranceEvent():
 return ageAssuranceEvent(_that);case UModEventViewEventAgeAssuranceOverrideEvent():
 return ageAssuranceOverrideEvent(_that);case UModEventViewEventRevokeAccountCredentialsEvent():
 return revokeAccountCredentialsEvent(_that);case UModEventViewEventUnknown():
-return unknown(_that);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that);}
 }
 /// A variant of `map` that fallback to returning `null`.
 ///
@@ -253,10 +250,7 @@ return modEventPriorityScore(_that.data);case UModEventViewEventAgeAssuranceEven
 return ageAssuranceEvent(_that.data);case UModEventViewEventAgeAssuranceOverrideEvent():
 return ageAssuranceOverrideEvent(_that.data);case UModEventViewEventRevokeAccountCredentialsEvent():
 return revokeAccountCredentialsEvent(_that.data);case UModEventViewEventUnknown():
-return unknown(_that.data);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that.data);}
 }
 /// A variant of `when` that fallback to returning `null`
 ///

--- a/packages/bluesky/lib/src/services/codegen/tools/ozone/moderation/defs/union_mod_event_view_subject.dart
+++ b/packages/bluesky/lib/src/services/codegen/tools/ozone/moderation/defs/union_mod_event_view_subject.dart
@@ -23,7 +23,7 @@ part 'union_mod_event_view_subject.freezed.dart';
 // **************************************************************************
 
 @freezed
-abstract class UModEventViewSubject with _$UModEventViewSubject {
+sealed class UModEventViewSubject with _$UModEventViewSubject {
   const UModEventViewSubject._();
 
   const factory UModEventViewSubject.repoRef({required RepoRef data}) =

--- a/packages/bluesky/lib/src/services/codegen/tools/ozone/moderation/defs/union_mod_event_view_subject.freezed.dart
+++ b/packages/bluesky/lib/src/services/codegen/tools/ozone/moderation/defs/union_mod_event_view_subject.freezed.dart
@@ -87,10 +87,7 @@ case UModEventViewSubjectRepoRef():
 return repoRef(_that);case UModEventViewSubjectRepoStrongRef():
 return repoStrongRef(_that);case UModEventViewSubjectMessageRef():
 return messageRef(_that);case UModEventViewSubjectUnknown():
-return unknown(_that);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that);}
 }
 /// A variant of `map` that fallback to returning `null`.
 ///
@@ -158,10 +155,7 @@ case UModEventViewSubjectRepoRef():
 return repoRef(_that.data);case UModEventViewSubjectRepoStrongRef():
 return repoStrongRef(_that.data);case UModEventViewSubjectMessageRef():
 return messageRef(_that.data);case UModEventViewSubjectUnknown():
-return unknown(_that.data);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that.data);}
 }
 /// A variant of `when` that fallback to returning `null`
 ///

--- a/packages/bluesky/lib/src/services/codegen/tools/ozone/moderation/defs/union_subject_status_view_hosting.dart
+++ b/packages/bluesky/lib/src/services/codegen/tools/ozone/moderation/defs/union_subject_status_view_hosting.dart
@@ -22,7 +22,7 @@ part 'union_subject_status_view_hosting.freezed.dart';
 // **************************************************************************
 
 @freezed
-abstract class USubjectStatusViewHosting with _$USubjectStatusViewHosting {
+sealed class USubjectStatusViewHosting with _$USubjectStatusViewHosting {
   const USubjectStatusViewHosting._();
 
   const factory USubjectStatusViewHosting.accountHosting({

--- a/packages/bluesky/lib/src/services/codegen/tools/ozone/moderation/defs/union_subject_status_view_hosting.freezed.dart
+++ b/packages/bluesky/lib/src/services/codegen/tools/ozone/moderation/defs/union_subject_status_view_hosting.freezed.dart
@@ -85,10 +85,7 @@ switch (_that) {
 case USubjectStatusViewHostingAccountHosting():
 return accountHosting(_that);case USubjectStatusViewHostingRecordHosting():
 return recordHosting(_that);case USubjectStatusViewHostingUnknown():
-return unknown(_that);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that);}
 }
 /// A variant of `map` that fallback to returning `null`.
 ///
@@ -153,10 +150,7 @@ switch (_that) {
 case USubjectStatusViewHostingAccountHosting():
 return accountHosting(_that.data);case USubjectStatusViewHostingRecordHosting():
 return recordHosting(_that.data);case USubjectStatusViewHostingUnknown():
-return unknown(_that.data);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that.data);}
 }
 /// A variant of `when` that fallback to returning `null`
 ///

--- a/packages/bluesky/lib/src/services/codegen/tools/ozone/moderation/defs/union_subject_status_view_subject.dart
+++ b/packages/bluesky/lib/src/services/codegen/tools/ozone/moderation/defs/union_subject_status_view_subject.dart
@@ -23,7 +23,7 @@ part 'union_subject_status_view_subject.freezed.dart';
 // **************************************************************************
 
 @freezed
-abstract class USubjectStatusViewSubject with _$USubjectStatusViewSubject {
+sealed class USubjectStatusViewSubject with _$USubjectStatusViewSubject {
   const USubjectStatusViewSubject._();
 
   const factory USubjectStatusViewSubject.repoRef({required RepoRef data}) =

--- a/packages/bluesky/lib/src/services/codegen/tools/ozone/moderation/defs/union_subject_status_view_subject.freezed.dart
+++ b/packages/bluesky/lib/src/services/codegen/tools/ozone/moderation/defs/union_subject_status_view_subject.freezed.dart
@@ -87,10 +87,7 @@ case USubjectStatusViewSubjectRepoRef():
 return repoRef(_that);case USubjectStatusViewSubjectRepoStrongRef():
 return repoStrongRef(_that);case USubjectStatusViewSubjectMessageRef():
 return messageRef(_that);case USubjectStatusViewSubjectUnknown():
-return unknown(_that);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that);}
 }
 /// A variant of `map` that fallback to returning `null`.
 ///
@@ -158,10 +155,7 @@ case USubjectStatusViewSubjectRepoRef():
 return repoRef(_that.data);case USubjectStatusViewSubjectRepoStrongRef():
 return repoStrongRef(_that.data);case USubjectStatusViewSubjectMessageRef():
 return messageRef(_that.data);case USubjectStatusViewSubjectUnknown():
-return unknown(_that.data);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that.data);}
 }
 /// A variant of `when` that fallback to returning `null`
 ///

--- a/packages/bluesky/lib/src/services/codegen/tools/ozone/moderation/defs/union_subject_view_profile.dart
+++ b/packages/bluesky/lib/src/services/codegen/tools/ozone/moderation/defs/union_subject_view_profile.dart
@@ -18,7 +18,7 @@ part 'union_subject_view_profile.freezed.dart';
 // **************************************************************************
 
 @freezed
-abstract class USubjectViewProfile with _$USubjectViewProfile {
+sealed class USubjectViewProfile with _$USubjectViewProfile {
   const USubjectViewProfile._();
 
   const factory USubjectViewProfile.unknown({

--- a/packages/bluesky/lib/src/services/codegen/tools/ozone/moderation/defs/union_subject_view_profile.freezed.dart
+++ b/packages/bluesky/lib/src/services/codegen/tools/ozone/moderation/defs/union_subject_view_profile.freezed.dart
@@ -112,10 +112,7 @@ return unknown(_that);case _:
 final _that = this;
 switch (_that) {
 case USubjectViewProfileUnknown():
-return unknown(_that);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that);}
 }
 /// A variant of `map` that fallback to returning `null`.
 ///
@@ -174,10 +171,7 @@ return unknown(_that.data);case _:
 @optionalTypeArgs TResult when<TResult extends Object?>({required TResult Function( Map<String, dynamic> data)  unknown,}) {final _that = this;
 switch (_that) {
 case USubjectViewProfileUnknown():
-return unknown(_that.data);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that.data);}
 }
 /// A variant of `when` that fallback to returning `null`
 ///

--- a/packages/bluesky/lib/src/services/codegen/tools/ozone/moderation/emitEvent/union_main_event.dart
+++ b/packages/bluesky/lib/src/services/codegen/tools/ozone/moderation/emitEvent/union_main_event.dart
@@ -42,7 +42,7 @@ part 'union_main_event.freezed.dart';
 // **************************************************************************
 
 @freezed
-abstract class UModerationEmitEventEvent with _$UModerationEmitEventEvent {
+sealed class UModerationEmitEventEvent with _$UModerationEmitEventEvent {
   const UModerationEmitEventEvent._();
 
   const factory UModerationEmitEventEvent.modEventTakedown({

--- a/packages/bluesky/lib/src/services/codegen/tools/ozone/moderation/emitEvent/union_main_event.freezed.dart
+++ b/packages/bluesky/lib/src/services/codegen/tools/ozone/moderation/emitEvent/union_main_event.freezed.dart
@@ -125,10 +125,7 @@ return modEventPriorityScore(_that);case UModerationEmitEventEventAgeAssuranceEv
 return ageAssuranceEvent(_that);case UModerationEmitEventEventAgeAssuranceOverrideEvent():
 return ageAssuranceOverrideEvent(_that);case UModerationEmitEventEventRevokeAccountCredentialsEvent():
 return revokeAccountCredentialsEvent(_that);case UModerationEmitEventEventUnknown():
-return unknown(_that);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that);}
 }
 /// A variant of `map` that fallback to returning `null`.
 ///
@@ -253,10 +250,7 @@ return modEventPriorityScore(_that.data);case UModerationEmitEventEventAgeAssura
 return ageAssuranceEvent(_that.data);case UModerationEmitEventEventAgeAssuranceOverrideEvent():
 return ageAssuranceOverrideEvent(_that.data);case UModerationEmitEventEventRevokeAccountCredentialsEvent():
 return revokeAccountCredentialsEvent(_that.data);case UModerationEmitEventEventUnknown():
-return unknown(_that.data);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that.data);}
 }
 /// A variant of `when` that fallback to returning `null`
 ///

--- a/packages/bluesky/lib/src/services/codegen/tools/ozone/moderation/emitEvent/union_main_subject.dart
+++ b/packages/bluesky/lib/src/services/codegen/tools/ozone/moderation/emitEvent/union_main_subject.dart
@@ -20,7 +20,7 @@ part 'union_main_subject.freezed.dart';
 // **************************************************************************
 
 @freezed
-abstract class UModerationEmitEventSubject with _$UModerationEmitEventSubject {
+sealed class UModerationEmitEventSubject with _$UModerationEmitEventSubject {
   const UModerationEmitEventSubject._();
 
   const factory UModerationEmitEventSubject.repoRef({required RepoRef data}) =

--- a/packages/bluesky/lib/src/services/codegen/tools/ozone/moderation/emitEvent/union_main_subject.freezed.dart
+++ b/packages/bluesky/lib/src/services/codegen/tools/ozone/moderation/emitEvent/union_main_subject.freezed.dart
@@ -85,10 +85,7 @@ switch (_that) {
 case UModerationEmitEventSubjectRepoRef():
 return repoRef(_that);case UModerationEmitEventSubjectRepoStrongRef():
 return repoStrongRef(_that);case UModerationEmitEventSubjectUnknown():
-return unknown(_that);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that);}
 }
 /// A variant of `map` that fallback to returning `null`.
 ///
@@ -153,10 +150,7 @@ switch (_that) {
 case UModerationEmitEventSubjectRepoRef():
 return repoRef(_that.data);case UModerationEmitEventSubjectRepoStrongRef():
 return repoStrongRef(_that.data);case UModerationEmitEventSubjectUnknown():
-return unknown(_that.data);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that.data);}
 }
 /// A variant of `when` that fallback to returning `null`
 ///

--- a/packages/bluesky/lib/src/services/codegen/tools/ozone/moderation/getRecords/union_main_records.dart
+++ b/packages/bluesky/lib/src/services/codegen/tools/ozone/moderation/getRecords/union_main_records.dart
@@ -22,8 +22,7 @@ part 'union_main_records.freezed.dart';
 // **************************************************************************
 
 @freezed
-abstract class UModerationGetRecordsRecords
-    with _$UModerationGetRecordsRecords {
+sealed class UModerationGetRecordsRecords with _$UModerationGetRecordsRecords {
   const UModerationGetRecordsRecords._();
 
   const factory UModerationGetRecordsRecords.recordViewDetail({

--- a/packages/bluesky/lib/src/services/codegen/tools/ozone/moderation/getRecords/union_main_records.freezed.dart
+++ b/packages/bluesky/lib/src/services/codegen/tools/ozone/moderation/getRecords/union_main_records.freezed.dart
@@ -85,10 +85,7 @@ switch (_that) {
 case UModerationGetRecordsRecordsRecordViewDetail():
 return recordViewDetail(_that);case UModerationGetRecordsRecordsRecordViewNotFound():
 return recordViewNotFound(_that);case UModerationGetRecordsRecordsUnknown():
-return unknown(_that);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that);}
 }
 /// A variant of `map` that fallback to returning `null`.
 ///
@@ -153,10 +150,7 @@ switch (_that) {
 case UModerationGetRecordsRecordsRecordViewDetail():
 return recordViewDetail(_that.data);case UModerationGetRecordsRecordsRecordViewNotFound():
 return recordViewNotFound(_that.data);case UModerationGetRecordsRecordsUnknown():
-return unknown(_that.data);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that.data);}
 }
 /// A variant of `when` that fallback to returning `null`
 ///

--- a/packages/bluesky/lib/src/services/codegen/tools/ozone/moderation/getRepos/union_main_repos.dart
+++ b/packages/bluesky/lib/src/services/codegen/tools/ozone/moderation/getRepos/union_main_repos.dart
@@ -22,7 +22,7 @@ part 'union_main_repos.freezed.dart';
 // **************************************************************************
 
 @freezed
-abstract class UModerationGetReposRepos with _$UModerationGetReposRepos {
+sealed class UModerationGetReposRepos with _$UModerationGetReposRepos {
   const UModerationGetReposRepos._();
 
   const factory UModerationGetReposRepos.repoViewDetail({

--- a/packages/bluesky/lib/src/services/codegen/tools/ozone/moderation/getRepos/union_main_repos.freezed.dart
+++ b/packages/bluesky/lib/src/services/codegen/tools/ozone/moderation/getRepos/union_main_repos.freezed.dart
@@ -85,10 +85,7 @@ switch (_that) {
 case UModerationGetReposReposRepoViewDetail():
 return repoViewDetail(_that);case UModerationGetReposReposRepoViewNotFound():
 return repoViewNotFound(_that);case UModerationGetReposReposUnknown():
-return unknown(_that);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that);}
 }
 /// A variant of `map` that fallback to returning `null`.
 ///
@@ -153,10 +150,7 @@ switch (_that) {
 case UModerationGetReposReposRepoViewDetail():
 return repoViewDetail(_that.data);case UModerationGetReposReposRepoViewNotFound():
 return repoViewNotFound(_that.data);case UModerationGetReposReposUnknown():
-return unknown(_that.data);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that.data);}
 }
 /// A variant of `when` that fallback to returning `null`
 ///

--- a/packages/bluesky/lib/src/services/codegen/tools/ozone/verification/defs/union_verification_view_issuer_profile.dart
+++ b/packages/bluesky/lib/src/services/codegen/tools/ozone/verification/defs/union_verification_view_issuer_profile.dart
@@ -18,7 +18,7 @@ part 'union_verification_view_issuer_profile.freezed.dart';
 // **************************************************************************
 
 @freezed
-abstract class UVerificationViewIssuerProfile
+sealed class UVerificationViewIssuerProfile
     with _$UVerificationViewIssuerProfile {
   const UVerificationViewIssuerProfile._();
 

--- a/packages/bluesky/lib/src/services/codegen/tools/ozone/verification/defs/union_verification_view_issuer_profile.freezed.dart
+++ b/packages/bluesky/lib/src/services/codegen/tools/ozone/verification/defs/union_verification_view_issuer_profile.freezed.dart
@@ -112,10 +112,7 @@ return unknown(_that);case _:
 final _that = this;
 switch (_that) {
 case UVerificationViewIssuerProfileUnknown():
-return unknown(_that);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that);}
 }
 /// A variant of `map` that fallback to returning `null`.
 ///
@@ -174,10 +171,7 @@ return unknown(_that.data);case _:
 @optionalTypeArgs TResult when<TResult extends Object?>({required TResult Function( Map<String, dynamic> data)  unknown,}) {final _that = this;
 switch (_that) {
 case UVerificationViewIssuerProfileUnknown():
-return unknown(_that.data);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that.data);}
 }
 /// A variant of `when` that fallback to returning `null`
 ///

--- a/packages/bluesky/lib/src/services/codegen/tools/ozone/verification/defs/union_verification_view_issuer_repo.dart
+++ b/packages/bluesky/lib/src/services/codegen/tools/ozone/verification/defs/union_verification_view_issuer_repo.dart
@@ -22,7 +22,7 @@ part 'union_verification_view_issuer_repo.freezed.dart';
 // **************************************************************************
 
 @freezed
-abstract class UVerificationViewIssuerRepo with _$UVerificationViewIssuerRepo {
+sealed class UVerificationViewIssuerRepo with _$UVerificationViewIssuerRepo {
   const UVerificationViewIssuerRepo._();
 
   const factory UVerificationViewIssuerRepo.repoViewDetail({

--- a/packages/bluesky/lib/src/services/codegen/tools/ozone/verification/defs/union_verification_view_issuer_repo.freezed.dart
+++ b/packages/bluesky/lib/src/services/codegen/tools/ozone/verification/defs/union_verification_view_issuer_repo.freezed.dart
@@ -85,10 +85,7 @@ switch (_that) {
 case UVerificationViewIssuerRepoRepoViewDetail():
 return repoViewDetail(_that);case UVerificationViewIssuerRepoRepoViewNotFound():
 return repoViewNotFound(_that);case UVerificationViewIssuerRepoUnknown():
-return unknown(_that);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that);}
 }
 /// A variant of `map` that fallback to returning `null`.
 ///
@@ -153,10 +150,7 @@ switch (_that) {
 case UVerificationViewIssuerRepoRepoViewDetail():
 return repoViewDetail(_that.data);case UVerificationViewIssuerRepoRepoViewNotFound():
 return repoViewNotFound(_that.data);case UVerificationViewIssuerRepoUnknown():
-return unknown(_that.data);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that.data);}
 }
 /// A variant of `when` that fallback to returning `null`
 ///

--- a/packages/bluesky/lib/src/services/codegen/tools/ozone/verification/defs/union_verification_view_subject_profile.dart
+++ b/packages/bluesky/lib/src/services/codegen/tools/ozone/verification/defs/union_verification_view_subject_profile.dart
@@ -18,7 +18,7 @@ part 'union_verification_view_subject_profile.freezed.dart';
 // **************************************************************************
 
 @freezed
-abstract class UVerificationViewSubjectProfile
+sealed class UVerificationViewSubjectProfile
     with _$UVerificationViewSubjectProfile {
   const UVerificationViewSubjectProfile._();
 

--- a/packages/bluesky/lib/src/services/codegen/tools/ozone/verification/defs/union_verification_view_subject_profile.freezed.dart
+++ b/packages/bluesky/lib/src/services/codegen/tools/ozone/verification/defs/union_verification_view_subject_profile.freezed.dart
@@ -112,10 +112,7 @@ return unknown(_that);case _:
 final _that = this;
 switch (_that) {
 case UVerificationViewSubjectProfileUnknown():
-return unknown(_that);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that);}
 }
 /// A variant of `map` that fallback to returning `null`.
 ///
@@ -174,10 +171,7 @@ return unknown(_that.data);case _:
 @optionalTypeArgs TResult when<TResult extends Object?>({required TResult Function( Map<String, dynamic> data)  unknown,}) {final _that = this;
 switch (_that) {
 case UVerificationViewSubjectProfileUnknown():
-return unknown(_that.data);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that.data);}
 }
 /// A variant of `when` that fallback to returning `null`
 ///

--- a/packages/bluesky/lib/src/services/codegen/tools/ozone/verification/defs/union_verification_view_subject_repo.dart
+++ b/packages/bluesky/lib/src/services/codegen/tools/ozone/verification/defs/union_verification_view_subject_repo.dart
@@ -22,8 +22,7 @@ part 'union_verification_view_subject_repo.freezed.dart';
 // **************************************************************************
 
 @freezed
-abstract class UVerificationViewSubjectRepo
-    with _$UVerificationViewSubjectRepo {
+sealed class UVerificationViewSubjectRepo with _$UVerificationViewSubjectRepo {
   const UVerificationViewSubjectRepo._();
 
   const factory UVerificationViewSubjectRepo.repoViewDetail({

--- a/packages/bluesky/lib/src/services/codegen/tools/ozone/verification/defs/union_verification_view_subject_repo.freezed.dart
+++ b/packages/bluesky/lib/src/services/codegen/tools/ozone/verification/defs/union_verification_view_subject_repo.freezed.dart
@@ -85,10 +85,7 @@ switch (_that) {
 case UVerificationViewSubjectRepoRepoViewDetail():
 return repoViewDetail(_that);case UVerificationViewSubjectRepoRepoViewNotFound():
 return repoViewNotFound(_that);case UVerificationViewSubjectRepoUnknown():
-return unknown(_that);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that);}
 }
 /// A variant of `map` that fallback to returning `null`.
 ///
@@ -153,10 +150,7 @@ switch (_that) {
 case UVerificationViewSubjectRepoRepoViewDetail():
 return repoViewDetail(_that.data);case UVerificationViewSubjectRepoRepoViewNotFound():
 return repoViewNotFound(_that.data);case UVerificationViewSubjectRepoUnknown():
-return unknown(_that.data);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return unknown(_that.data);}
 }
 /// A variant of `when` that fallback to returning `null`
 ///

--- a/packages/bluesky/pubspec.yaml
+++ b/packages/bluesky/pubspec.yaml
@@ -1,6 +1,6 @@
 name: bluesky
 description: The most famous and powerful Dart/Flutter library for Bluesky Social.
-version: 1.2.2
+version: 1.2.3
 homepage: https://atprotodart.com
 documentation: https://atprotodart.com/docs/packages/bluesky
 repository: https://github.com/myConsciousness/atproto.dart/tree/main/packages/bluesky
@@ -18,7 +18,7 @@ topics:
 
 dependencies:
   atproto_core: ^1.0.7
-  atproto: ^1.2.0
+  atproto: ^1.2.1
   freezed_annotation: ^3.1.0
   json_annotation: ^4.9.0
   characters: ^1.4.1

--- a/packages/lex_gen/lib/src/services/object/lex_union.dart
+++ b/packages/lex_gen/lib/src/services/object/lex_union.dart
@@ -63,7 +63,7 @@ part '$fileName.freezed.dart';
 $kHeader
 
 @freezed
-abstract class $name with _\$$name {
+sealed class $name with _\$$name {
   const $name._();
 
   $factories


### PR DESCRIPTION
- Enhanced union type classes to use sealed classes instead of abstract classes
- Enabled Dart's exhaustiveness checking for switch statements on union types
- Improved compile-time safety by ensuring all union cases are handled
- Prevents runtime errors from unhandled union variants through static analysis
- Updated atproto to v1.2.1 and bluesky to v1.2.3
- Updated bluesky dependency to use atproto ^1.2.1

Fixes #2155