### PR TITLE
fix: downgrade characters dependency from ^1.4.1 to ^1.4.0

### DIFF
--- a/packages/bluesky/CHANGELOG.md
+++ b/packages/bluesky/CHANGELOG.md
@@ -7,6 +7,7 @@
   - Enabled Dart's exhaustiveness checking for switch statements on union types
   - Improved compile-time safety by ensuring all union cases are handled
   - Prevents runtime errors from unhandled union variants through static analysis
+- **FIX**: Downgraded characters dependency from ^1.4.1 to ^1.4.0 for compatibility
 
 ## v1.2.2
 

--- a/packages/bluesky/pubspec.yaml
+++ b/packages/bluesky/pubspec.yaml
@@ -21,7 +21,7 @@ dependencies:
   atproto: ^1.2.1
   freezed_annotation: ^3.1.0
   json_annotation: ^4.9.0
-  characters: ^1.4.1
+  characters: ^1.4.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/packages/bluesky_cli/pubspec.yaml
+++ b/packages/bluesky_cli/pubspec.yaml
@@ -26,7 +26,7 @@ dependencies:
   args: ^2.7.0
   cli_launcher: ^0.3.1
   cli_util: ^0.4.2
-  bluesky_text: ^1.1.0
+  bluesky_text: ^1.1.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/packages/bluesky_text/CHANGELOG.md
+++ b/packages/bluesky_text/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Note
 
+## v1.1.1
+
+- **FIX**: Downgraded characters dependency from ^1.4.1 to ^1.4.0 for compatibility
+
 ## v1.1.0
 
 - **FEATURE**: Added support for Unicode space characters as hashtag delimiters. ([#1933](https://github.com/myConsciousness/atproto.dart/issues/1933))

--- a/packages/bluesky_text/pubspec.yaml
+++ b/packages/bluesky_text/pubspec.yaml
@@ -1,6 +1,6 @@
 name: bluesky_text
 description: Provides the easiest and most powerful way to analyze the text for Bluesky Social.
-version: 1.1.0
+version: 1.1.1
 homepage: https://atprotodart.com
 repository: https://github.com/myConsciousness/atproto.dart/tree/main/packages/bluesky_text
 issue_tracker: https://github.com/myConsciousness/atproto.dart/issues
@@ -17,7 +17,7 @@ topics:
 
 dependencies:
   xrpc: ^1.0.3
-  characters: ^1.4.1
+  characters: ^1.4.0
   freezed_annotation: ^3.1.0
   json_annotation: ^4.9.0
 


### PR DESCRIPTION
- Downgraded characters dependency in bluesky and bluesky_text packages
- Updated bluesky_text version to 1.1.1 (patch release)
- Updated changelogs with compatibility fix information

Fixes #2153