### PR TITLE
chore: bump versions to atproto 1.2.4 and bluesky 1.2.6

### DIFF
--- a/packages/atproto/CHANGELOG.md
+++ b/packages/atproto/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Release Note
 
+## v1.2.4
+
+- chore: Sync Lexicon Data.
+  - ([#2173](https://github.com/myConsciousness/atproto.dart/pull/2173))
+  - ([#2175](https://github.com/myConsciousness/atproto.dart/pull/2175))
+  - ([#2177](https://github.com/myConsciousness/atproto.dart/pull/2177))
+- fix: Codegen errors. ([#2182](https://github.com/myConsciousness/atproto.dart/pull/2182))
+
 ## v1.2.3
 
 - chore: Sync Lexicon Data. ([#2165](https://github.com/myConsciousness/atproto.dart/pull/2165))

--- a/packages/atproto/pubspec.yaml
+++ b/packages/atproto/pubspec.yaml
@@ -1,6 +1,6 @@
 name: atproto
 description: The most famous and powerful Dart/Flutter library for AT Protocol.
-version: 1.2.3
+version: 1.2.4
 homepage: https://atprotodart.com
 documentation: https://atprotodart.com/docs/packages/atproto
 repository: https://github.com/myConsciousness/atproto.dart/tree/main/packages/atproto

--- a/packages/bluesky/CHANGELOG.md
+++ b/packages/bluesky/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Release Note
 
+## v1.2.6
+
+- chore: Sync Lexicon Data.
+  - ([#2173](https://github.com/myConsciousness/atproto.dart/pull/2173))
+  - ([#2175](https://github.com/myConsciousness/atproto.dart/pull/2175))
+  - ([#2177](https://github.com/myConsciousness/atproto.dart/pull/2177))
+- fix: Codegen errors. ([#2182](https://github.com/myConsciousness/atproto.dart/pull/2182))
+
 ## v1.2.5
 
 - chore: Sync Lexicon Data.

--- a/packages/bluesky/pubspec.yaml
+++ b/packages/bluesky/pubspec.yaml
@@ -1,6 +1,6 @@
 name: bluesky
 description: The most famous and powerful Dart/Flutter library for Bluesky Social.
-version: 1.2.5
+version: 1.2.6
 homepage: https://atprotodart.com
 documentation: https://atprotodart.com/docs/packages/bluesky
 repository: https://github.com/myConsciousness/atproto.dart/tree/main/packages/bluesky
@@ -18,7 +18,7 @@ topics:
 
 dependencies:
   atproto_core: ^1.0.7
-  atproto: ^1.2.3
+  atproto: ^1.2.4
   freezed_annotation: ^3.1.0
   json_annotation: ^4.9.0
   characters: ^1.4.0


### PR DESCRIPTION
## Changes

- Bump atproto version from 1.2.3 to 1.2.4
- Bump bluesky version from 1.2.5 to 1.2.6
- Update changelog entries for both packages

## Related PRs

- #2173 - Sync Lexicon Data (tools.ozone.moderation)
- #2175 - Sync Lexicon Data (app.bsky.actor, app.bsky.feed)
- #2177 - Sync Lexicon Data (app.bsky.graph.follow)
- #2182 - Fix codegen errors

## Changelog Updates

### atproto v1.2.4
- chore: Sync Lexicon Data (#2173, #2175, #2177)
- fix: Codegen errors (#2182)

### bluesky v1.2.6
- chore: Sync Lexicon Data (#2173, #2175, #2177)
- fix: Codegen errors (#2182)