### PR TITLE
Bump atproto/bluesky to v1.4.2; add lex_gen

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2023-2025, Shinya Kato
+Copyright (c) 2023-2026, Shinya Kato
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/packages/atproto/CHANGELOG.md
+++ b/packages/atproto/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Note
 
+## v1.4.2
+
+- core: generated code. ([#2333](https://github.com/myConsciousness/atproto.dart/pull/2333))
+
 ## v1.4.1
 
 - fix: optional jwt scope and auth identity. ([#2224](https://github.com/myConsciousness/atproto.dart/pull/2224))

--- a/packages/atproto/pubspec.yaml
+++ b/packages/atproto/pubspec.yaml
@@ -1,7 +1,7 @@
 name: atproto
 resolution: workspace
 description: The most famous and powerful Dart/Flutter library for AT Protocol.
-version: 1.4.1
+version: 1.4.2
 homepage: https://atprotodart.com
 documentation: https://atprotodart.com/docs/packages/atproto
 repository: https://github.com/myConsciousness/atproto.dart/tree/main/packages/atproto

--- a/packages/bluesky/CHANGELOG.md
+++ b/packages/bluesky/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Note
 
+## v1.4.2
+
+- core: generated code. ([#2333](https://github.com/myConsciousness/atproto.dart/pull/2333))
+
 ## v1.4.1
 
 - fix: optional jwt scope and auth identity. ([#2224](https://github.com/myConsciousness/atproto.dart/pull/2224))

--- a/packages/bluesky/pubspec.yaml
+++ b/packages/bluesky/pubspec.yaml
@@ -1,7 +1,7 @@
 name: bluesky
 resolution: workspace
 description: The most famous and powerful Dart/Flutter library for Bluesky Social.
-version: 1.4.1
+version: 1.4.2
 homepage: https://atprotodart.com
 documentation: https://atprotodart.com/docs/packages/bluesky
 repository: https://github.com/myConsciousness/atproto.dart/tree/main/packages/bluesky
@@ -19,7 +19,7 @@ topics:
 
 dependencies:
   atproto_core: ^1.2.0
-  atproto: ^1.4.1
+  atproto: ^1.4.2
   freezed_annotation: ^3.1.0
   json_annotation: ^4.9.0
   characters: ^1.4.0

--- a/packages/lex_gen/CHANGELOG.md
+++ b/packages/lex_gen/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Release Note
+
+## v0.1.0
+
+- First release.

--- a/packages/lex_gen/README.md
+++ b/packages/lex_gen/README.md
@@ -1,0 +1,9 @@
+<p align="center">
+  <a href="https://github.com/myConsciousness/atproto.dart">
+    <img alt="atproto_core" width="50%" height="auto" src="https://raw.githubusercontent.com/myConsciousness/atproto.dart/main/resources/pkg_logo.png">
+  </a>
+</p>
+
+# LexGen
+
+This package provides a generator that automatically generates source code from the Lexicon in the AT Protocol.

--- a/packages/lex_gen/lib/src/services/lex_type_generator.dart
+++ b/packages/lex_gen/lib/src/services/lex_type_generator.dart
@@ -19,7 +19,6 @@ import 'fmt/lex_xrpc_query_generator.dart';
 import 'fmt/lex_xrpc_subscription_generator.dart';
 import 'object/lex_package.dart';
 import 'object/lex_type.dart';
-import 'rule.dart' as rule;
 
 List<LexType> generateLexTypes(
   final List<String> services,
@@ -49,8 +48,6 @@ final class _LexTypeGenerator {
       // Generate LexObjects for each definition in the lexicon
       for (final def in doc.defs.entries) {
         if (def.value is lex.ULexUserTypeObject) {
-          final data = def.value.data as lex.LexObject;
-
           _aggregateTypes(
             types,
             generateLexObject(
@@ -74,8 +71,6 @@ final class _LexTypeGenerator {
             generateLexUnion(doc.id, def.key, '', refUnion, mainVariants),
           );
         } else if (def.value is lex.ULexUserTypeRecord) {
-          final data = def.value.data as lex.LexRecord;
-
           _aggregateTypes(
             types,
             generateLexRecord(

--- a/packages/lex_gen/pubspec.yaml
+++ b/packages/lex_gen/pubspec.yaml
@@ -1,12 +1,18 @@
 name: lex_gen
 resolution: workspace
-publish_to: none
+description: Provides a generator that automatically generates source code from the Lexicon in the AT Protocol.
+version: 0.1.0
+homepage: https://atprotodart.com
+repository: https://github.com/myConsciousness/atproto.dart/tree/main/packages/lex_gen
+issue_tracker: https://github.com/myConsciousness/atproto.dart/issues
+funding:
+  - https://github.com/sponsors/myConsciousness
 
 environment:
   sdk: ">=3.8.0 <4.0.0"
 
 dependencies:
- lexicon: ^1.0.3
+  lexicon: ^1.0.3
 
 dev_dependencies:
   lints: ^6.0.0


### PR DESCRIPTION
Update release versions and metadata: bump atproto and bluesky packages to v1.4.2 and add corresponding changelog entries (core: generated code, PR #2333). Update bluesky dependency to atproto ^1.4.2. Add new lex_gen package (version 0.1.0) with pubspec, README, and changelog for initial release. Also update LICENSE copyright year to 2026.