### PR TITLE
Add http to dev_dependencies

### DIFF
--- a/packages/atproto_core/pubspec.yaml
+++ b/packages/atproto_core/pubspec.yaml
@@ -35,6 +35,7 @@ dev_dependencies:
   build_runner: ^2.5.4
   json_serializable: ^6.9.5
   freezed: ^3.2.0
+  http: ^1.4.0
   import_sorter:
     git:
       url: https://github.com/myConsciousness/import_sorter.git


### PR DESCRIPTION
Add the http package (^1.4.0) to dev_dependencies in packages/atproto_core/pubspec.yaml so the HTTP client library is available for development tooling or tests that rely on it.