### PR TITLE
Add chat.bsky.group.listMutualGroups

### DIFF
--- a/packages/atproto_core/test/src/clients/service_context_test.dart
+++ b/packages/atproto_core/test/src/clients/service_context_test.dart
@@ -7,8 +7,6 @@ import 'dart:convert';
 import 'package:at_primitives/nsid.dart';
 import 'package:atproto_oauth/atproto_oauth.dart';
 import 'package:atproto_oauth/src/helper/helper.dart' show getKeyPair;
-import 'package:atproto_oauth/src/helper/private_key.dart'
-    show encodePrivateKey;
 import 'package:atproto_oauth/src/helper/public_key.dart' show encodePublicKey;
 import 'package:http/http.dart' as http;
 import 'package:test/test.dart';
@@ -16,6 +14,9 @@ import 'package:test/test.dart';
 // Project imports:
 import 'package:atproto_core/src/clients/service_context.dart';
 import 'package:atproto_core/src/types/session.dart';
+
+import 'package:atproto_oauth/src/helper/private_key.dart'
+    show encodePrivateKey;
 
 void main() {
   group('.headers', () {

--- a/packages/bluesky/CHANGELOG.md
+++ b/packages/bluesky/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Note
 
+## v1.4.3
+
+- core: generated code. ([#2337](https://github.com/myConsciousness/atproto.dart/pull/2337))
+
 ## v1.4.2
 
 - core: generated code. ([#2333](https://github.com/myConsciousness/atproto.dart/pull/2333))

--- a/packages/bluesky/lib/chat_bsky_group_listmutualgroups.dart
+++ b/packages/bluesky/lib/chat_bsky_group_listmutualgroups.dart
@@ -1,0 +1,15 @@
+// Copyright (c) 2023-2026, Shinya Kato.
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+// **************************************************************************
+// LexGenerator
+// **************************************************************************
+
+export 'package:bluesky/src/services/codegen/chat/bsky/group/listMutualGroups/input.dart';
+export 'package:bluesky/src/services/codegen/chat/bsky/group/listMutualGroups/output.dart';

--- a/packages/bluesky/lib/src/ids.g.dart
+++ b/packages/bluesky/lib/src/ids.g.dart
@@ -1405,6 +1405,9 @@ const chatBskyGroupGetJoinLinkPreview = 'chat.bsky.group.getJoinLinkPreview';
 /// `chat.bsky.group.listJoinRequests`
 const chatBskyGroupListJoinRequests = 'chat.bsky.group.listJoinRequests';
 
+/// `chat.bsky.group.listMutualGroups`
+const chatBskyGroupListMutualGroups = 'chat.bsky.group.listMutualGroups';
+
 /// `chat.bsky.group.rejectJoinRequest`
 const chatBskyGroupRejectJoinRequest = 'chat.bsky.group.rejectJoinRequest';
 

--- a/packages/bluesky/lib/src/nsids.g.dart
+++ b/packages/bluesky/lib/src/nsids.g.dart
@@ -760,6 +760,9 @@ const chatBskyGroupGetJoinLinkPreview = NSID(
 /// `chat.bsky.group.listJoinRequests`
 const chatBskyGroupListJoinRequests = NSID(ids.chatBskyGroupListJoinRequests);
 
+/// `chat.bsky.group.listMutualGroups`
+const chatBskyGroupListMutualGroups = NSID(ids.chatBskyGroupListMutualGroups);
+
 /// `chat.bsky.group.rejectJoinRequest`
 const chatBskyGroupRejectJoinRequest = NSID(ids.chatBskyGroupRejectJoinRequest);
 

--- a/packages/bluesky/lib/src/services/codegen/chat/bsky/group/listMutualGroups/input.dart
+++ b/packages/bluesky/lib/src/services/codegen/chat/bsky/group/listMutualGroups/input.dart
@@ -1,0 +1,57 @@
+// Copyright (c) 2023-2026, Shinya Kato.
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+// Package imports:
+import 'package:atproto_core/internals.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'input.freezed.dart';
+part 'input.g.dart';
+
+// **************************************************************************
+// LexGenerator
+// **************************************************************************
+
+@freezed
+abstract class GroupListMutualGroupsInput with _$GroupListMutualGroupsInput {
+  static const knownProps = <String>['subject', 'limit', 'cursor'];
+
+  @JsonSerializable(includeIfNull: false)
+  const factory GroupListMutualGroupsInput({
+    required String subject,
+    @Default(50) int limit,
+    String? cursor,
+
+    Map<String, dynamic>? $unknown,
+  }) = _GroupListMutualGroupsInput;
+
+  factory GroupListMutualGroupsInput.fromJson(Map<String, Object?> json) =>
+      _$GroupListMutualGroupsInputFromJson(json);
+}
+
+extension GroupListMutualGroupsInputExtension on GroupListMutualGroupsInput {
+  bool get hasCursor => cursor != null;
+  bool get hasNotCursor => !hasCursor;
+}
+
+final class GroupListMutualGroupsInputConverter
+    extends JsonConverter<GroupListMutualGroupsInput, Map<String, dynamic>> {
+  const GroupListMutualGroupsInputConverter();
+
+  @override
+  GroupListMutualGroupsInput fromJson(Map<String, dynamic> json) {
+    return GroupListMutualGroupsInput.fromJson(
+      translate(json, GroupListMutualGroupsInput.knownProps),
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson(GroupListMutualGroupsInput object) =>
+      untranslate(object.toJson());
+}

--- a/packages/bluesky/lib/src/services/codegen/chat/bsky/group/listMutualGroups/input.freezed.dart
+++ b/packages/bluesky/lib/src/services/codegen/chat/bsky/group/listMutualGroups/input.freezed.dart
@@ -1,0 +1,294 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'input.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$GroupListMutualGroupsInput {
+
+ String get subject; int get limit; String? get cursor; Map<String, dynamic>? get $unknown;
+/// Create a copy of GroupListMutualGroupsInput
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$GroupListMutualGroupsInputCopyWith<GroupListMutualGroupsInput> get copyWith => _$GroupListMutualGroupsInputCopyWithImpl<GroupListMutualGroupsInput>(this as GroupListMutualGroupsInput, _$identity);
+
+  /// Serializes this GroupListMutualGroupsInput to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is GroupListMutualGroupsInput&&(identical(other.subject, subject) || other.subject == subject)&&(identical(other.limit, limit) || other.limit == limit)&&(identical(other.cursor, cursor) || other.cursor == cursor)&&const DeepCollectionEquality().equals(other.$unknown, $unknown));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,subject,limit,cursor,const DeepCollectionEquality().hash($unknown));
+
+@override
+String toString() {
+  return 'GroupListMutualGroupsInput(subject: $subject, limit: $limit, cursor: $cursor, \$unknown: ${$unknown})';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $GroupListMutualGroupsInputCopyWith<$Res>  {
+  factory $GroupListMutualGroupsInputCopyWith(GroupListMutualGroupsInput value, $Res Function(GroupListMutualGroupsInput) _then) = _$GroupListMutualGroupsInputCopyWithImpl;
+@useResult
+$Res call({
+ String subject, int limit, String? cursor, Map<String, dynamic>? $unknown
+});
+
+
+
+
+}
+/// @nodoc
+class _$GroupListMutualGroupsInputCopyWithImpl<$Res>
+    implements $GroupListMutualGroupsInputCopyWith<$Res> {
+  _$GroupListMutualGroupsInputCopyWithImpl(this._self, this._then);
+
+  final GroupListMutualGroupsInput _self;
+  final $Res Function(GroupListMutualGroupsInput) _then;
+
+/// Create a copy of GroupListMutualGroupsInput
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? subject = null,Object? limit = null,Object? cursor = freezed,Object? $unknown = freezed,}) {
+  return _then(_self.copyWith(
+subject: null == subject ? _self.subject : subject // ignore: cast_nullable_to_non_nullable
+as String,limit: null == limit ? _self.limit : limit // ignore: cast_nullable_to_non_nullable
+as int,cursor: freezed == cursor ? _self.cursor : cursor // ignore: cast_nullable_to_non_nullable
+as String?,$unknown: freezed == $unknown ? _self.$unknown : $unknown // ignore: cast_nullable_to_non_nullable
+as Map<String, dynamic>?,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [GroupListMutualGroupsInput].
+extension GroupListMutualGroupsInputPatterns on GroupListMutualGroupsInput {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _GroupListMutualGroupsInput value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _GroupListMutualGroupsInput() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _GroupListMutualGroupsInput value)  $default,){
+final _that = this;
+switch (_that) {
+case _GroupListMutualGroupsInput():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _GroupListMutualGroupsInput value)?  $default,){
+final _that = this;
+switch (_that) {
+case _GroupListMutualGroupsInput() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String subject,  int limit,  String? cursor,  Map<String, dynamic>? $unknown)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _GroupListMutualGroupsInput() when $default != null:
+return $default(_that.subject,_that.limit,_that.cursor,_that.$unknown);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String subject,  int limit,  String? cursor,  Map<String, dynamic>? $unknown)  $default,) {final _that = this;
+switch (_that) {
+case _GroupListMutualGroupsInput():
+return $default(_that.subject,_that.limit,_that.cursor,_that.$unknown);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String subject,  int limit,  String? cursor,  Map<String, dynamic>? $unknown)?  $default,) {final _that = this;
+switch (_that) {
+case _GroupListMutualGroupsInput() when $default != null:
+return $default(_that.subject,_that.limit,_that.cursor,_that.$unknown);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+
+@JsonSerializable(includeIfNull: false)
+class _GroupListMutualGroupsInput implements GroupListMutualGroupsInput {
+  const _GroupListMutualGroupsInput({required this.subject, this.limit = 50, this.cursor, final  Map<String, dynamic>? $unknown}): _$unknown = $unknown;
+  factory _GroupListMutualGroupsInput.fromJson(Map<String, dynamic> json) => _$GroupListMutualGroupsInputFromJson(json);
+
+@override final  String subject;
+@override@JsonKey() final  int limit;
+@override final  String? cursor;
+ final  Map<String, dynamic>? _$unknown;
+@override Map<String, dynamic>? get $unknown {
+  final value = _$unknown;
+  if (value == null) return null;
+  if (_$unknown is EqualUnmodifiableMapView) return _$unknown;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableMapView(value);
+}
+
+
+/// Create a copy of GroupListMutualGroupsInput
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$GroupListMutualGroupsInputCopyWith<_GroupListMutualGroupsInput> get copyWith => __$GroupListMutualGroupsInputCopyWithImpl<_GroupListMutualGroupsInput>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$GroupListMutualGroupsInputToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _GroupListMutualGroupsInput&&(identical(other.subject, subject) || other.subject == subject)&&(identical(other.limit, limit) || other.limit == limit)&&(identical(other.cursor, cursor) || other.cursor == cursor)&&const DeepCollectionEquality().equals(other._$unknown, _$unknown));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,subject,limit,cursor,const DeepCollectionEquality().hash(_$unknown));
+
+@override
+String toString() {
+  return 'GroupListMutualGroupsInput(subject: $subject, limit: $limit, cursor: $cursor, \$unknown: ${$unknown})';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$GroupListMutualGroupsInputCopyWith<$Res> implements $GroupListMutualGroupsInputCopyWith<$Res> {
+  factory _$GroupListMutualGroupsInputCopyWith(_GroupListMutualGroupsInput value, $Res Function(_GroupListMutualGroupsInput) _then) = __$GroupListMutualGroupsInputCopyWithImpl;
+@override @useResult
+$Res call({
+ String subject, int limit, String? cursor, Map<String, dynamic>? $unknown
+});
+
+
+
+
+}
+/// @nodoc
+class __$GroupListMutualGroupsInputCopyWithImpl<$Res>
+    implements _$GroupListMutualGroupsInputCopyWith<$Res> {
+  __$GroupListMutualGroupsInputCopyWithImpl(this._self, this._then);
+
+  final _GroupListMutualGroupsInput _self;
+  final $Res Function(_GroupListMutualGroupsInput) _then;
+
+/// Create a copy of GroupListMutualGroupsInput
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? subject = null,Object? limit = null,Object? cursor = freezed,Object? $unknown = freezed,}) {
+  return _then(_GroupListMutualGroupsInput(
+subject: null == subject ? _self.subject : subject // ignore: cast_nullable_to_non_nullable
+as String,limit: null == limit ? _self.limit : limit // ignore: cast_nullable_to_non_nullable
+as int,cursor: freezed == cursor ? _self.cursor : cursor // ignore: cast_nullable_to_non_nullable
+as String?,$unknown: freezed == $unknown ? _self._$unknown : $unknown // ignore: cast_nullable_to_non_nullable
+as Map<String, dynamic>?,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/packages/bluesky/lib/src/services/codegen/chat/bsky/group/listMutualGroups/input.g.dart
+++ b/packages/bluesky/lib/src/services/codegen/chat/bsky/group/listMutualGroups/input.g.dart
@@ -1,0 +1,32 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: non_constant_identifier_names
+
+part of 'input.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_GroupListMutualGroupsInput _$GroupListMutualGroupsInputFromJson(Map json) =>
+    $checkedCreate('_GroupListMutualGroupsInput', json, ($checkedConvert) {
+      final val = _GroupListMutualGroupsInput(
+        subject: $checkedConvert('subject', (v) => v as String),
+        limit: $checkedConvert('limit', (v) => (v as num?)?.toInt() ?? 50),
+        cursor: $checkedConvert('cursor', (v) => v as String?),
+        $unknown: $checkedConvert(
+          r'$unknown',
+          (v) => (v as Map?)?.map((k, e) => MapEntry(k as String, e)),
+        ),
+      );
+      return val;
+    });
+
+Map<String, dynamic> _$GroupListMutualGroupsInputToJson(
+  _GroupListMutualGroupsInput instance,
+) => <String, dynamic>{
+  'subject': instance.subject,
+  'limit': instance.limit,
+  'cursor': ?instance.cursor,
+  r'$unknown': ?instance.$unknown,
+};

--- a/packages/bluesky/lib/src/services/codegen/chat/bsky/group/listMutualGroups/output.dart
+++ b/packages/bluesky/lib/src/services/codegen/chat/bsky/group/listMutualGroups/output.dart
@@ -1,0 +1,59 @@
+// Copyright (c) 2023-2026, Shinya Kato.
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+// Package imports:
+import 'package:atproto_core/internals.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+// Project imports:
+import '../../../../chat/bsky/convo/defs/convo_view.dart';
+
+part 'output.freezed.dart';
+part 'output.g.dart';
+
+// **************************************************************************
+// LexGenerator
+// **************************************************************************
+
+@freezed
+abstract class GroupListMutualGroupsOutput with _$GroupListMutualGroupsOutput {
+  static const knownProps = <String>['cursor', 'convos'];
+
+  @JsonSerializable(includeIfNull: false)
+  const factory GroupListMutualGroupsOutput({
+    String? cursor,
+    @ConvoViewConverter() required List<ConvoView> convos,
+
+    Map<String, dynamic>? $unknown,
+  }) = _GroupListMutualGroupsOutput;
+
+  factory GroupListMutualGroupsOutput.fromJson(Map<String, Object?> json) =>
+      _$GroupListMutualGroupsOutputFromJson(json);
+}
+
+extension GroupListMutualGroupsOutputExtension on GroupListMutualGroupsOutput {
+  bool get hasCursor => cursor != null;
+  bool get hasNotCursor => !hasCursor;
+}
+
+final class GroupListMutualGroupsOutputConverter
+    extends JsonConverter<GroupListMutualGroupsOutput, Map<String, dynamic>> {
+  const GroupListMutualGroupsOutputConverter();
+
+  @override
+  GroupListMutualGroupsOutput fromJson(Map<String, dynamic> json) {
+    return GroupListMutualGroupsOutput.fromJson(
+      translate(json, GroupListMutualGroupsOutput.knownProps),
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson(GroupListMutualGroupsOutput object) =>
+      untranslate(object.toJson());
+}

--- a/packages/bluesky/lib/src/services/codegen/chat/bsky/group/listMutualGroups/output.freezed.dart
+++ b/packages/bluesky/lib/src/services/codegen/chat/bsky/group/listMutualGroups/output.freezed.dart
@@ -1,0 +1,297 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'output.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$GroupListMutualGroupsOutput {
+
+ String? get cursor;@ConvoViewConverter() List<ConvoView> get convos; Map<String, dynamic>? get $unknown;
+/// Create a copy of GroupListMutualGroupsOutput
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$GroupListMutualGroupsOutputCopyWith<GroupListMutualGroupsOutput> get copyWith => _$GroupListMutualGroupsOutputCopyWithImpl<GroupListMutualGroupsOutput>(this as GroupListMutualGroupsOutput, _$identity);
+
+  /// Serializes this GroupListMutualGroupsOutput to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is GroupListMutualGroupsOutput&&(identical(other.cursor, cursor) || other.cursor == cursor)&&const DeepCollectionEquality().equals(other.convos, convos)&&const DeepCollectionEquality().equals(other.$unknown, $unknown));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,cursor,const DeepCollectionEquality().hash(convos),const DeepCollectionEquality().hash($unknown));
+
+@override
+String toString() {
+  return 'GroupListMutualGroupsOutput(cursor: $cursor, convos: $convos, \$unknown: ${$unknown})';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $GroupListMutualGroupsOutputCopyWith<$Res>  {
+  factory $GroupListMutualGroupsOutputCopyWith(GroupListMutualGroupsOutput value, $Res Function(GroupListMutualGroupsOutput) _then) = _$GroupListMutualGroupsOutputCopyWithImpl;
+@useResult
+$Res call({
+ String? cursor,@ConvoViewConverter() List<ConvoView> convos, Map<String, dynamic>? $unknown
+});
+
+
+
+
+}
+/// @nodoc
+class _$GroupListMutualGroupsOutputCopyWithImpl<$Res>
+    implements $GroupListMutualGroupsOutputCopyWith<$Res> {
+  _$GroupListMutualGroupsOutputCopyWithImpl(this._self, this._then);
+
+  final GroupListMutualGroupsOutput _self;
+  final $Res Function(GroupListMutualGroupsOutput) _then;
+
+/// Create a copy of GroupListMutualGroupsOutput
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? cursor = freezed,Object? convos = null,Object? $unknown = freezed,}) {
+  return _then(_self.copyWith(
+cursor: freezed == cursor ? _self.cursor : cursor // ignore: cast_nullable_to_non_nullable
+as String?,convos: null == convos ? _self.convos : convos // ignore: cast_nullable_to_non_nullable
+as List<ConvoView>,$unknown: freezed == $unknown ? _self.$unknown : $unknown // ignore: cast_nullable_to_non_nullable
+as Map<String, dynamic>?,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [GroupListMutualGroupsOutput].
+extension GroupListMutualGroupsOutputPatterns on GroupListMutualGroupsOutput {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _GroupListMutualGroupsOutput value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _GroupListMutualGroupsOutput() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _GroupListMutualGroupsOutput value)  $default,){
+final _that = this;
+switch (_that) {
+case _GroupListMutualGroupsOutput():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _GroupListMutualGroupsOutput value)?  $default,){
+final _that = this;
+switch (_that) {
+case _GroupListMutualGroupsOutput() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String? cursor, @ConvoViewConverter()  List<ConvoView> convos,  Map<String, dynamic>? $unknown)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _GroupListMutualGroupsOutput() when $default != null:
+return $default(_that.cursor,_that.convos,_that.$unknown);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String? cursor, @ConvoViewConverter()  List<ConvoView> convos,  Map<String, dynamic>? $unknown)  $default,) {final _that = this;
+switch (_that) {
+case _GroupListMutualGroupsOutput():
+return $default(_that.cursor,_that.convos,_that.$unknown);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String? cursor, @ConvoViewConverter()  List<ConvoView> convos,  Map<String, dynamic>? $unknown)?  $default,) {final _that = this;
+switch (_that) {
+case _GroupListMutualGroupsOutput() when $default != null:
+return $default(_that.cursor,_that.convos,_that.$unknown);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+
+@JsonSerializable(includeIfNull: false)
+class _GroupListMutualGroupsOutput implements GroupListMutualGroupsOutput {
+  const _GroupListMutualGroupsOutput({this.cursor, @ConvoViewConverter() required final  List<ConvoView> convos, final  Map<String, dynamic>? $unknown}): _convos = convos,_$unknown = $unknown;
+  factory _GroupListMutualGroupsOutput.fromJson(Map<String, dynamic> json) => _$GroupListMutualGroupsOutputFromJson(json);
+
+@override final  String? cursor;
+ final  List<ConvoView> _convos;
+@override@ConvoViewConverter() List<ConvoView> get convos {
+  if (_convos is EqualUnmodifiableListView) return _convos;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_convos);
+}
+
+ final  Map<String, dynamic>? _$unknown;
+@override Map<String, dynamic>? get $unknown {
+  final value = _$unknown;
+  if (value == null) return null;
+  if (_$unknown is EqualUnmodifiableMapView) return _$unknown;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableMapView(value);
+}
+
+
+/// Create a copy of GroupListMutualGroupsOutput
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$GroupListMutualGroupsOutputCopyWith<_GroupListMutualGroupsOutput> get copyWith => __$GroupListMutualGroupsOutputCopyWithImpl<_GroupListMutualGroupsOutput>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$GroupListMutualGroupsOutputToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _GroupListMutualGroupsOutput&&(identical(other.cursor, cursor) || other.cursor == cursor)&&const DeepCollectionEquality().equals(other._convos, _convos)&&const DeepCollectionEquality().equals(other._$unknown, _$unknown));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,cursor,const DeepCollectionEquality().hash(_convos),const DeepCollectionEquality().hash(_$unknown));
+
+@override
+String toString() {
+  return 'GroupListMutualGroupsOutput(cursor: $cursor, convos: $convos, \$unknown: ${$unknown})';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$GroupListMutualGroupsOutputCopyWith<$Res> implements $GroupListMutualGroupsOutputCopyWith<$Res> {
+  factory _$GroupListMutualGroupsOutputCopyWith(_GroupListMutualGroupsOutput value, $Res Function(_GroupListMutualGroupsOutput) _then) = __$GroupListMutualGroupsOutputCopyWithImpl;
+@override @useResult
+$Res call({
+ String? cursor,@ConvoViewConverter() List<ConvoView> convos, Map<String, dynamic>? $unknown
+});
+
+
+
+
+}
+/// @nodoc
+class __$GroupListMutualGroupsOutputCopyWithImpl<$Res>
+    implements _$GroupListMutualGroupsOutputCopyWith<$Res> {
+  __$GroupListMutualGroupsOutputCopyWithImpl(this._self, this._then);
+
+  final _GroupListMutualGroupsOutput _self;
+  final $Res Function(_GroupListMutualGroupsOutput) _then;
+
+/// Create a copy of GroupListMutualGroupsOutput
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? cursor = freezed,Object? convos = null,Object? $unknown = freezed,}) {
+  return _then(_GroupListMutualGroupsOutput(
+cursor: freezed == cursor ? _self.cursor : cursor // ignore: cast_nullable_to_non_nullable
+as String?,convos: null == convos ? _self._convos : convos // ignore: cast_nullable_to_non_nullable
+as List<ConvoView>,$unknown: freezed == $unknown ? _self._$unknown : $unknown // ignore: cast_nullable_to_non_nullable
+as Map<String, dynamic>?,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/packages/bluesky/lib/src/services/codegen/chat/bsky/group/listMutualGroups/output.g.dart
+++ b/packages/bluesky/lib/src/services/codegen/chat/bsky/group/listMutualGroups/output.g.dart
@@ -1,0 +1,39 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: non_constant_identifier_names
+
+part of 'output.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_GroupListMutualGroupsOutput _$GroupListMutualGroupsOutputFromJson(Map json) =>
+    $checkedCreate('_GroupListMutualGroupsOutput', json, ($checkedConvert) {
+      final val = _GroupListMutualGroupsOutput(
+        cursor: $checkedConvert('cursor', (v) => v as String?),
+        convos: $checkedConvert(
+          'convos',
+          (v) => (v as List<dynamic>)
+              .map(
+                (e) => const ConvoViewConverter().fromJson(
+                  e as Map<String, dynamic>,
+                ),
+              )
+              .toList(),
+        ),
+        $unknown: $checkedConvert(
+          r'$unknown',
+          (v) => (v as Map?)?.map((k, e) => MapEntry(k as String, e)),
+        ),
+      );
+      return val;
+    });
+
+Map<String, dynamic> _$GroupListMutualGroupsOutputToJson(
+  _GroupListMutualGroupsOutput instance,
+) => <String, dynamic>{
+  'cursor': ?instance.cursor,
+  'convos': instance.convos.map(const ConvoViewConverter().toJson).toList(),
+  r'$unknown': ?instance.$unknown,
+};

--- a/packages/bluesky/lib/src/services/codegen/chat/bsky/group_service.dart
+++ b/packages/bluesky/lib/src/services/codegen/chat/bsky/group_service.dart
@@ -24,6 +24,7 @@ import 'group/editJoinLink/output.dart';
 import 'group/enableJoinLink/output.dart';
 import 'group/getJoinLinkPreview/output.dart';
 import 'group/listJoinRequests/output.dart';
+import 'group/listMutualGroups/output.dart';
 import 'group/removeMembers/output.dart';
 import 'group/requestJoin/output.dart';
 
@@ -207,6 +208,29 @@ chatBskyGroupListJoinRequests({
     if (cursor != null) 'cursor': cursor,
   },
   to: const GroupListJoinRequestsOutputConverter().fromJson,
+);
+
+/// [NOTE: This is under active development and should be considered unstable while this note is here]. Returns a page of group conversations that both the requester and the specified actor are members of.
+Future<XRPCResponse<GroupListMutualGroupsOutput>>
+chatBskyGroupListMutualGroups({
+  required String subject,
+  int? limit,
+  String? cursor,
+  required ServiceContext $ctx,
+  String? $service,
+  Map<String, String>? $headers,
+  Map<String, String>? $unknown,
+}) async => await $ctx.get(
+  ns.chatBskyGroupListMutualGroups,
+  service: $service,
+  headers: $headers,
+  parameters: {
+    ...?$unknown,
+    'subject': subject,
+    if (limit != null) 'limit': limit,
+    if (cursor != null) 'cursor': cursor,
+  },
+  to: const GroupListMutualGroupsOutputConverter().fromJson,
 );
 
 /// [NOTE: This is under active development and should be considered unstable while this note is here]. Rejects a request to join a group (via join link) the user owns. Action taken by the group owner.
@@ -414,6 +438,24 @@ base class GroupService {
     Map<String, String>? $unknown,
   }) async => await chatBskyGroupListJoinRequests(
     convoId: convoId,
+    limit: limit,
+    cursor: cursor,
+    $ctx: ctx,
+    $service: $service,
+    $headers: $headers,
+    $unknown: $unknown,
+  );
+
+  /// [NOTE: This is under active development and should be considered unstable while this note is here]. Returns a page of group conversations that both the requester and the specified actor are members of.
+  Future<XRPCResponse<GroupListMutualGroupsOutput>> listMutualGroups({
+    required String subject,
+    int? limit,
+    String? cursor,
+    String? $service,
+    Map<String, String>? $headers,
+    Map<String, String>? $unknown,
+  }) async => await chatBskyGroupListMutualGroups(
+    subject: subject,
     limit: limit,
     cursor: cursor,
     $ctx: ctx,

--- a/packages/bluesky/lib/src/services/codegen/chat/bsky/moderation/subscribeModEvents/event_group_chat_updated_lock_reason.dart
+++ b/packages/bluesky/lib/src/services/codegen/chat/bsky/moderation/subscribeModEvents/event_group_chat_updated_lock_reason.dart
@@ -87,6 +87,8 @@ enum KnownEventGroupChatUpdatedLockReason implements Serializable {
   owner_deactivated('owner_deactivated'),
   @JsonValue('owner_deleted')
   owner_deleted('owner_deleted'),
+  @JsonValue('owner_suspended')
+  owner_suspended('owner_suspended'),
   @JsonValue('owner_taken_down')
   owner_taken_down('owner_taken_down'),
   @JsonValue('label_applied')

--- a/packages/bluesky/pubspec.yaml
+++ b/packages/bluesky/pubspec.yaml
@@ -1,7 +1,7 @@
 name: bluesky
 resolution: workspace
 description: The most famous and powerful Dart/Flutter library for Bluesky Social.
-version: 1.4.2
+version: 1.4.3
 homepage: https://atprotodart.com
 documentation: https://atprotodart.com/docs/packages/bluesky
 repository: https://github.com/myConsciousness/atproto.dart/tree/main/packages/bluesky

--- a/packages/bluesky_cli/lib/src/commands/codegen/chat/bsky/convo/list_convos.dart
+++ b/packages/bluesky_cli/lib/src/commands/codegen/chat/bsky/convo/list_convos.dart
@@ -7,10 +7,6 @@
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
-
-// Dart imports:
-import 'dart:convert';
-
 // Project imports:
 import '../../../../query_command.dart';
 
@@ -18,26 +14,35 @@ import '../../../../query_command.dart';
 // LexGenerator
 // **************************************************************************
 
-
 final class ListConvosCommand extends QueryCommand {
   ListConvosCommand() {
-    argParser..addOption("limit",defaultsTo: "50",)
-..addOption("cursor",)
-..addOption("readState",)
-..addOption("status",help: r"Filter convos by their status. It is discouraged to call with \"request\" and preferred to call chat.bsky.convo.listConvoRequests, which also includes group join requests made by the user.",)
-..addOption("kind",help: r"Filter by conversation kind.",)
-..addOption("lockStatus",help: r"Filter by conversation lock status. Values follow chat.bsky.convo.defs#convoLockStatus.",)
-;
+    argParser
+      ..addOption("limit", defaultsTo: "50")
+      ..addOption("cursor")
+      ..addOption("readState")
+      ..addOption(
+        "status",
+        help:
+            r"Filter convos by their status. It is discouraged to call with 'request' and preferred to call chat.bsky.convo.listConvoRequests, which also includes group join requests made by the user.",
+      )
+      ..addOption("kind", help: r"Filter by conversation kind.")
+      ..addOption(
+        "lockStatus",
+        help:
+            r"Filter by conversation lock status. Values follow chat.bsky.convo.defs#convoLockStatus.",
+      );
   }
 
   @override
   final String name = "list-convos";
 
   @override
-  final String description = r"Returns a page of conversations (direct or group) for the user.";
+  final String description =
+      r"Returns a page of conversations (direct or group) for the user.";
 
   @override
-  final String invocation = "bsky chat-bsky-convo list-convos [limit] [cursor] [readState] [status] [kind] [lockStatus]";
+  final String invocation =
+      "bsky chat-bsky-convo list-convos [limit] [cursor] [readState] [status] [kind] [lockStatus]";
 
   @override
   String get methodId => "chat.bsky.convo.listConvos";
@@ -45,11 +50,11 @@ final class ListConvosCommand extends QueryCommand {
   @override
   Map<String, dynamic>? get parameters => {
     "limit": argResults!["limit"],
-if (argResults!["cursor"] != null)"cursor": argResults!["cursor"],
-if (argResults!["readState"] != null)"readState": argResults!["readState"],
-if (argResults!["status"] != null)"status": argResults!["status"],
-if (argResults!["kind"] != null)"kind": argResults!["kind"],
-if (argResults!["lockStatus"] != null)"lockStatus": argResults!["lockStatus"],
-
+    if (argResults!["cursor"] != null) "cursor": argResults!["cursor"],
+    if (argResults!["readState"] != null) "readState": argResults!["readState"],
+    if (argResults!["status"] != null) "status": argResults!["status"],
+    if (argResults!["kind"] != null) "kind": argResults!["kind"],
+    if (argResults!["lockStatus"] != null)
+      "lockStatus": argResults!["lockStatus"],
   };
 }

--- a/packages/bluesky_cli/lib/src/commands/codegen/chat/bsky/group.dart
+++ b/packages/bluesky_cli/lib/src/commands/codegen/chat/bsky/group.dart
@@ -21,6 +21,7 @@ import 'group/edit_join_link.dart';
 import 'group/enable_join_link.dart';
 import 'group/get_join_link_preview.dart';
 import 'group/list_join_requests.dart';
+import 'group/list_mutual_groups.dart';
 import 'group/reject_join_request.dart';
 import 'group/remove_members.dart';
 import 'group/request_join.dart';
@@ -41,6 +42,7 @@ final class ChatBskyGroupCommand extends Command<void> {
     addSubcommand(EnableJoinLinkCommand());
     addSubcommand(GetJoinLinkPreviewCommand());
     addSubcommand(ListJoinRequestsCommand());
+    addSubcommand(ListMutualGroupsCommand());
     addSubcommand(RejectJoinRequestCommand());
     addSubcommand(RemoveMembersCommand());
     addSubcommand(RequestJoinCommand());

--- a/packages/bluesky_cli/lib/src/commands/codegen/chat/bsky/group/list_mutual_groups.dart
+++ b/packages/bluesky_cli/lib/src/commands/codegen/chat/bsky/group/list_mutual_groups.dart
@@ -1,0 +1,45 @@
+// Copyright (c) 2023-2026, Shinya Kato.
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+// Project imports:
+import '../../../../query_command.dart';
+
+// **************************************************************************
+// LexGenerator
+// **************************************************************************
+
+final class ListMutualGroupsCommand extends QueryCommand {
+  ListMutualGroupsCommand() {
+    argParser
+      ..addOption("subject", mandatory: true)
+      ..addOption("limit", defaultsTo: "50")
+      ..addOption("cursor");
+  }
+
+  @override
+  final String name = "list-mutual-groups";
+
+  @override
+  final String description =
+      r"[NOTE: This is under active development and should be considered unstable while this note is here]. Returns a page of group conversations that both the requester and the specified actor are members of.";
+
+  @override
+  final String invocation =
+      "bsky chat-bsky-group list-mutual-groups [subject] [limit] [cursor]";
+
+  @override
+  String get methodId => "chat.bsky.group.listMutualGroups";
+
+  @override
+  Map<String, dynamic>? get parameters => {
+    "subject": argResults!["subject"],
+    "limit": argResults!["limit"],
+    if (argResults!["cursor"] != null) "cursor": argResults!["cursor"],
+  };
+}

--- a/packages/lex_gen/CHANGELOG.md
+++ b/packages/lex_gen/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Note
 
+## v0.1.1
+
+- Fixd minor functions.
+
 ## v0.1.0
 
 - First release.

--- a/packages/lex_gen/lib/src/commands/types/lex_parameter.dart
+++ b/packages/lex_gen/lib/src/commands/types/lex_parameter.dart
@@ -67,6 +67,6 @@ final class LexParameter {
   }
 
   String _escapeQuotes(String str) {
-    return str.replaceAll('"', '\\"');
+    return str.replaceAll('"', "'");
   }
 }

--- a/packages/lex_gen/pubspec.yaml
+++ b/packages/lex_gen/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lex_gen
 resolution: workspace
 description: Provides a generator that automatically generates source code from the Lexicon in the AT Protocol.
-version: 0.1.0
+version: 0.1.1
 homepage: https://atprotodart.com
 repository: https://github.com/myConsciousness/atproto.dart/tree/main/packages/lex_gen
 issue_tracker: https://github.com/myConsciousness/atproto.dart/issues

--- a/packages/lexicon/lib/src/lexicons.g.dart
+++ b/packages/lexicon/lib/src/lexicons.g.dart
@@ -14389,6 +14389,47 @@ const chatBskyGroupDefs = <String, dynamic>{
   },
 };
 
+/// `chat.bsky.group.listMutualGroups`
+const chatBskyGroupListMutualGroups = <String, dynamic>{
+  "lexicon": 1,
+  "id": "chat.bsky.group.listMutualGroups",
+  "defs": {
+    "main": {
+      "type": "query",
+      "description":
+          "[NOTE: This is under active development and should be considered unstable while this note is here]. Returns a page of group conversations that both the requester and the specified actor are members of.",
+      "parameters": {
+        "type": "params",
+        "required": ["subject"],
+        "properties": {
+          "subject": {"type": "string", "format": "did"},
+          "limit": {
+            "type": "integer",
+            "default": 50,
+            "minimum": 1,
+            "maximum": 100,
+          },
+          "cursor": {"type": "string"},
+        },
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["convos"],
+          "properties": {
+            "cursor": {"type": "string"},
+            "convos": {
+              "type": "array",
+              "items": {"type": "ref", "ref": "chat.bsky.convo.defs#convoView"},
+            },
+          },
+        },
+      },
+    },
+  },
+};
+
 /// `chat.bsky.group.editGroup`
 const chatBskyGroupEditGroup = <String, dynamic>{
   "lexicon": 1,
@@ -15582,6 +15623,7 @@ const chatBskyModerationSubscribeModEvents = <String, dynamic>{
             "owner_left",
             "owner_deactivated",
             "owner_deleted",
+            "owner_suspended",
             "owner_taken_down",
             "label_applied",
           ],
@@ -22122,6 +22164,7 @@ const lexicons = <Map<String, dynamic>>[
   chatBskyConvoSendMessageBatch,
   chatBskyGroupApproveJoinRequest,
   chatBskyGroupDefs,
+  chatBskyGroupListMutualGroups,
   chatBskyGroupEditGroup,
   chatBskyGroupRemoveMembers,
   chatBskyGroupRequestJoin,

--- a/website/docs/lexicons/chat/bsky/group/listMutualGroups.md
+++ b/website/docs/lexicons/chat/bsky/group/listMutualGroups.md
@@ -1,0 +1,27 @@
+---
+title: listMutualGroups
+description: chat.bsky.group.listMutualGroups
+---
+
+# [chat.bsky.group.listMutualGroups](https://github.com/myConsciousness/atproto.dart/blob/main/lexicons/chat/bsky/group/listMutualGroups.json)
+
+## #main
+
+[NOTE: This is under active development and should be considered unstable while this note is here]. Returns a page of group conversations that both the requester and the specified actor are members of.
+
+### Parameters
+
+| Property | Type | Known Values | Required | Description |
+| --- | --- | --- | :---: | --- |
+| **subject** | string ([did](https://atproto.com/specs/did)) | - | ✅ | - |
+| **limit** | integer | - | ❌ | - |
+| **cursor** | string | - | ❌ | - |
+
+### Output
+
+- **Encoding**: application/json
+
+| Property | Type | Known Values | Required | Description |
+| --- | --- | --- | :---: | --- |
+| **cursor** | string | - | ❌ | - |
+| **convos** | array of [chat.bsky.convo.defs#convoView](../../../../lexicons/chat/bsky/convo/defs.md#convoview) | - | ✅ | - |

--- a/website/docs/lexicons/chat/bsky/moderation/subscribeModEvents.md
+++ b/website/docs/lexicons/chat/bsky/moderation/subscribeModEvents.md
@@ -182,7 +182,7 @@ Fired when a group chat's metadata or status changes.
 | **joinLinkCode** | string | - | ❌ | The code of the join link. Only present when updateType is join-link-related. |
 | **joinLinkFollowersOnly** | boolean | - | ❌ | Whether the join link is restricted to followers of the owner. Only present when updateType is join-link-related. |
 | **joinLinkRequiresApproval** | boolean | - | ❌ | Whether the join link requires owner approval to join. Only present when updateType is join-link-related. |
-| **lockReason** | string | owner_action<br/>owner_left<br/>owner_deactivated<br/>owner_deleted<br/>owner_taken_down<br/>label_applied | ❌ | Why the group was locked. Only present when updateType is 'locked'. |
+| **lockReason** | string | owner_action<br/>owner_left<br/>owner_deactivated<br/>owner_deleted<br/>owner_suspended<br/>owner_taken_down<br/>label_applied | ❌ | Why the group was locked. Only present when updateType is 'locked'. |
 | **newName** | string | - | ❌ | The new group name. Only present when updateType is 'name_changed'. |
 | **oldName** | string | - | ❌ | The previous group name. Only present when updateType is 'name_changed'. |
 | **ownerDid** | string ([did](https://atproto.com/specs/did)) | - | ✅ | The DID of the group chat owner. |

--- a/website/docs/supported_api.md
+++ b/website/docs/supported_api.md
@@ -371,6 +371,7 @@ So all endpoints in the [atproto](#atproto) table are also available from [blues
 | **[chat.bsky.group.enableJoinLink](https://pub.dev/documentation/bluesky/latest/chat_bsky_services/GroupService/enableJoinLink.html)** | [Reference](lexicons/chat/bsky/group/enableJoinLink.md) | ❌ |
 | **[chat.bsky.group.getJoinLinkPreview](https://pub.dev/documentation/bluesky/latest/chat_bsky_services/GroupService/getJoinLinkPreview.html)** | [Reference](lexicons/chat/bsky/group/getJoinLinkPreview.md) | ❌ |
 | **[chat.bsky.group.listJoinRequests](https://pub.dev/documentation/bluesky/latest/chat_bsky_services/GroupService/listJoinRequests.html)** | [Reference](lexicons/chat/bsky/group/listJoinRequests.md) | ✅ |
+| **[chat.bsky.group.listMutualGroups](https://pub.dev/documentation/bluesky/latest/chat_bsky_services/GroupService/listMutualGroups.html)** | [Reference](lexicons/chat/bsky/group/listMutualGroups.md) | ✅ |
 | **[chat.bsky.group.rejectJoinRequest](https://pub.dev/documentation/bluesky/latest/chat_bsky_services/GroupService/rejectJoinRequest.html)** | [Reference](lexicons/chat/bsky/group/rejectJoinRequest.md) | ❌ |
 | **[chat.bsky.group.removeMembers](https://pub.dev/documentation/bluesky/latest/chat_bsky_services/GroupService/removeMembers.html)** | [Reference](lexicons/chat/bsky/group/removeMembers.md) | ❌ |
 | **[chat.bsky.group.requestJoin](https://pub.dev/documentation/bluesky/latest/chat_bsky_services/GroupService/requestJoin.html)** | [Reference](lexicons/chat/bsky/group/requestJoin.md) | ❌ |


### PR DESCRIPTION
Introduce the chat.bsky.group.listMutualGroups endpoint and include generated client, models, converters, and docs. Adds input/output Freezed/JsonSerializable models, service and GroupService methods, CLI command (list-mutual-groups), lexicon entry, and website docs. Also bumps bluesky package version to v1.4.3, updates changelogs, adds owner_suspended enum value, and includes minor formatting and helper fixes (import reorder in a test, quote escaping change in lex_gen).