### PR TITLE
Add embed.external types and actor.getStatus

### DIFF
--- a/packages/bluesky/CHANGELOG.md
+++ b/packages/bluesky/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Note
 
+## v1.4.4
+
+- core: generated code. ([#2340](https://github.com/myConsciousness/atproto.dart/pull/2340))
+
 ## v1.4.3
 
 - core: generated code. ([#2337](https://github.com/myConsciousness/atproto.dart/pull/2337))

--- a/packages/bluesky/lib/app_bsky_embed_external.dart
+++ b/packages/bluesky/lib/app_bsky_embed_external.dart
@@ -15,3 +15,6 @@ export 'package:bluesky/src/services/codegen/app/bsky/embed/external/main.dart';
 export 'package:bluesky/src/services/codegen/app/bsky/embed/external/external.dart';
 export 'package:bluesky/src/services/codegen/app/bsky/embed/external/view.dart';
 export 'package:bluesky/src/services/codegen/app/bsky/embed/external/view_external.dart';
+export 'package:bluesky/src/services/codegen/app/bsky/embed/external/view_external_source.dart';
+export 'package:bluesky/src/services/codegen/app/bsky/embed/external/view_external_source_theme.dart';
+export 'package:bluesky/src/services/codegen/app/bsky/embed/external/color_r_g_b.dart';

--- a/packages/bluesky/lib/app_bsky_embed_getembedexternalview.dart
+++ b/packages/bluesky/lib/app_bsky_embed_getembedexternalview.dart
@@ -7,28 +7,9 @@
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
-// Package imports:
-import 'package:args/command_runner.dart';
-
-// Project imports:
-import 'actor/declaration.dart';
-import 'actor/export_account_data.dart';
-import 'actor/get_status.dart';
-
 // **************************************************************************
 // LexGenerator
 // **************************************************************************
 
-final class ChatBskyActorCommand extends Command<void> {
-  ChatBskyActorCommand() {
-    addSubcommand(DeclarationCommand());
-    addSubcommand(ExportAccountDataCommand());
-    addSubcommand(GetStatusCommand());
-  }
-
-  @override
-  String get name => "chat-bsky-actor";
-
-  @override
-  String get description => "Provides commands for chat.bsky.actor.*";
-}
+export 'package:bluesky/src/services/codegen/app/bsky/embed/getEmbedExternalView/input.dart';
+export 'package:bluesky/src/services/codegen/app/bsky/embed/getEmbedExternalView/output.dart';

--- a/packages/bluesky/lib/app_bsky_services.dart
+++ b/packages/bluesky/lib/app_bsky_services.dart
@@ -16,6 +16,7 @@ export 'package:bluesky/src/services/codegen/app/bsky/ageassurance_service.dart'
 export 'package:bluesky/src/services/codegen/app/bsky/bookmark_service.dart';
 export 'package:bluesky/src/services/codegen/app/bsky/contact_service.dart';
 export 'package:bluesky/src/services/codegen/app/bsky/draft_service.dart';
+export 'package:bluesky/src/services/codegen/app/bsky/embed_service.dart';
 export 'package:bluesky/src/services/codegen/app/bsky/feed_service.dart';
 export 'package:bluesky/src/services/codegen/app/bsky/graph_service.dart';
 export 'package:bluesky/src/services/codegen/app/bsky/labeler_service.dart';

--- a/packages/bluesky/lib/chat_bsky_actor_getstatus.dart
+++ b/packages/bluesky/lib/chat_bsky_actor_getstatus.dart
@@ -7,28 +7,8 @@
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
-// Package imports:
-import 'package:args/command_runner.dart';
-
-// Project imports:
-import 'actor/declaration.dart';
-import 'actor/export_account_data.dart';
-import 'actor/get_status.dart';
-
 // **************************************************************************
 // LexGenerator
 // **************************************************************************
 
-final class ChatBskyActorCommand extends Command<void> {
-  ChatBskyActorCommand() {
-    addSubcommand(DeclarationCommand());
-    addSubcommand(ExportAccountDataCommand());
-    addSubcommand(GetStatusCommand());
-  }
-
-  @override
-  String get name => "chat-bsky-actor";
-
-  @override
-  String get description => "Provides commands for chat.bsky.actor.*";
-}
+export 'package:bluesky/src/services/codegen/chat/bsky/actor/getStatus/output.dart';

--- a/packages/bluesky/lib/src/ids.g.dart
+++ b/packages/bluesky/lib/src/ids.g.dart
@@ -332,6 +332,9 @@ const appBskyEmbedDefsAspectRatio = 'app.bsky.embed.defs#aspectRatio';
 /// `app.bsky.embed.external`
 const appBskyEmbedExternal = 'app.bsky.embed.external';
 
+/// `app.bsky.embed.external#colorRGB`
+const appBskyEmbedExternalColorRGB = 'app.bsky.embed.external#colorRGB';
+
 /// `app.bsky.embed.external#external`
 const appBskyEmbedExternalExternal = 'app.bsky.embed.external#external';
 
@@ -340,6 +343,17 @@ const appBskyEmbedExternalView = 'app.bsky.embed.external#view';
 
 /// `app.bsky.embed.external#viewExternal`
 const appBskyEmbedExternalViewExternal = 'app.bsky.embed.external#viewExternal';
+
+/// `app.bsky.embed.external#viewExternalSource`
+const appBskyEmbedExternalViewExternalSource =
+    'app.bsky.embed.external#viewExternalSource';
+
+/// `app.bsky.embed.external#viewExternalSourceTheme`
+const appBskyEmbedExternalViewExternalSourceTheme =
+    'app.bsky.embed.external#viewExternalSourceTheme';
+
+/// `app.bsky.embed.getEmbedExternalView`
+const appBskyEmbedGetEmbedExternalView = 'app.bsky.embed.getEmbedExternalView';
 
 /// `app.bsky.embed.images`
 const appBskyEmbedImages = 'app.bsky.embed.images';
@@ -1085,6 +1099,9 @@ const chatBskyActorDeleteAccount = 'chat.bsky.actor.deleteAccount';
 
 /// `chat.bsky.actor.exportAccountData`
 const chatBskyActorExportAccountData = 'chat.bsky.actor.exportAccountData';
+
+/// `chat.bsky.actor.getStatus`
+const chatBskyActorGetStatus = 'chat.bsky.actor.getStatus';
 
 /// `chat.bsky.convo.acceptConvo`
 const chatBskyConvoAcceptConvo = 'chat.bsky.convo.acceptConvo';

--- a/packages/bluesky/lib/src/nsids.g.dart
+++ b/packages/bluesky/lib/src/nsids.g.dart
@@ -103,6 +103,9 @@ const appBskyDraftUpdateDraft = NSID(ids.appBskyDraftUpdateDraft);
 /// `app.bsky.embed.external`
 const appBskyEmbedExternal = NSID(ids.appBskyEmbedExternal);
 
+/// `app.bsky.embed.external#colorRGB`
+const appBskyEmbedExternalColorRGB = NSID(ids.appBskyEmbedExternalColorRGB);
+
 /// `app.bsky.embed.external#external`
 const appBskyEmbedExternalExternal = NSID(ids.appBskyEmbedExternalExternal);
 
@@ -112,6 +115,21 @@ const appBskyEmbedExternalView = NSID(ids.appBskyEmbedExternalView);
 /// `app.bsky.embed.external#viewExternal`
 const appBskyEmbedExternalViewExternal = NSID(
   ids.appBskyEmbedExternalViewExternal,
+);
+
+/// `app.bsky.embed.external#viewExternalSource`
+const appBskyEmbedExternalViewExternalSource = NSID(
+  ids.appBskyEmbedExternalViewExternalSource,
+);
+
+/// `app.bsky.embed.external#viewExternalSourceTheme`
+const appBskyEmbedExternalViewExternalSourceTheme = NSID(
+  ids.appBskyEmbedExternalViewExternalSourceTheme,
+);
+
+/// `app.bsky.embed.getEmbedExternalView`
+const appBskyEmbedGetEmbedExternalView = NSID(
+  ids.appBskyEmbedGetEmbedExternalView,
 );
 
 /// `app.bsky.embed.images`
@@ -651,6 +669,9 @@ const chatBskyActorDeleteAccount = NSID(ids.chatBskyActorDeleteAccount);
 
 /// `chat.bsky.actor.exportAccountData`
 const chatBskyActorExportAccountData = NSID(ids.chatBskyActorExportAccountData);
+
+/// `chat.bsky.actor.getStatus`
+const chatBskyActorGetStatus = NSID(ids.chatBskyActorGetStatus);
 
 /// `chat.bsky.convo.acceptConvo`
 const chatBskyConvoAcceptConvo = NSID(ids.chatBskyConvoAcceptConvo);

--- a/packages/bluesky/lib/src/services/codegen/app/bsky/embed/external/color_r_g_b.dart
+++ b/packages/bluesky/lib/src/services/codegen/app/bsky/embed/external/color_r_g_b.dart
@@ -1,0 +1,59 @@
+// Copyright (c) 2023-2026, Shinya Kato.
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+// Package imports:
+import 'package:atproto_core/internals.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'color_r_g_b.freezed.dart';
+part 'color_r_g_b.g.dart';
+
+// **************************************************************************
+// LexGenerator
+// **************************************************************************
+
+/// RGB color definition, inspired by site.standard.theme.color#rgb
+@freezed
+abstract class EmbedExternalColorRGB with _$EmbedExternalColorRGB {
+  static const knownProps = <String>['r', 'g', 'b'];
+
+  @JsonSerializable(includeIfNull: false)
+  const factory EmbedExternalColorRGB({
+    @Default('app.bsky.embed.external#colorRGB') String $type,
+    required int r,
+    required int g,
+    required int b,
+
+    Map<String, dynamic>? $unknown,
+  }) = _EmbedExternalColorRGB;
+
+  factory EmbedExternalColorRGB.fromJson(Map<String, Object?> json) =>
+      _$EmbedExternalColorRGBFromJson(json);
+
+  static bool validate(final Map<String, dynamic> object) {
+    if (!object.containsKey('\$type')) return false;
+    return object['\$type'] == 'app.bsky.embed.external#colorRGB';
+  }
+}
+
+final class EmbedExternalColorRGBConverter
+    extends JsonConverter<EmbedExternalColorRGB, Map<String, dynamic>> {
+  const EmbedExternalColorRGBConverter();
+
+  @override
+  EmbedExternalColorRGB fromJson(Map<String, dynamic> json) {
+    return EmbedExternalColorRGB.fromJson(
+      translate(json, EmbedExternalColorRGB.knownProps),
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson(EmbedExternalColorRGB object) =>
+      untranslate(object.toJson());
+}

--- a/packages/bluesky/lib/src/services/codegen/app/bsky/embed/external/color_r_g_b.freezed.dart
+++ b/packages/bluesky/lib/src/services/codegen/app/bsky/embed/external/color_r_g_b.freezed.dart
@@ -1,0 +1,297 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'color_r_g_b.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$EmbedExternalColorRGB {
+
+ String get $type; int get r; int get g; int get b; Map<String, dynamic>? get $unknown;
+/// Create a copy of EmbedExternalColorRGB
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$EmbedExternalColorRGBCopyWith<EmbedExternalColorRGB> get copyWith => _$EmbedExternalColorRGBCopyWithImpl<EmbedExternalColorRGB>(this as EmbedExternalColorRGB, _$identity);
+
+  /// Serializes this EmbedExternalColorRGB to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is EmbedExternalColorRGB&&(identical(other.$type, $type) || other.$type == $type)&&(identical(other.r, r) || other.r == r)&&(identical(other.g, g) || other.g == g)&&(identical(other.b, b) || other.b == b)&&const DeepCollectionEquality().equals(other.$unknown, $unknown));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,$type,r,g,b,const DeepCollectionEquality().hash($unknown));
+
+@override
+String toString() {
+  return 'EmbedExternalColorRGB(\$type: ${$type}, r: $r, g: $g, b: $b, \$unknown: ${$unknown})';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $EmbedExternalColorRGBCopyWith<$Res>  {
+  factory $EmbedExternalColorRGBCopyWith(EmbedExternalColorRGB value, $Res Function(EmbedExternalColorRGB) _then) = _$EmbedExternalColorRGBCopyWithImpl;
+@useResult
+$Res call({
+ String $type, int r, int g, int b, Map<String, dynamic>? $unknown
+});
+
+
+
+
+}
+/// @nodoc
+class _$EmbedExternalColorRGBCopyWithImpl<$Res>
+    implements $EmbedExternalColorRGBCopyWith<$Res> {
+  _$EmbedExternalColorRGBCopyWithImpl(this._self, this._then);
+
+  final EmbedExternalColorRGB _self;
+  final $Res Function(EmbedExternalColorRGB) _then;
+
+/// Create a copy of EmbedExternalColorRGB
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? $type = null,Object? r = null,Object? g = null,Object? b = null,Object? $unknown = freezed,}) {
+  return _then(_self.copyWith(
+$type: null == $type ? _self.$type : $type // ignore: cast_nullable_to_non_nullable
+as String,r: null == r ? _self.r : r // ignore: cast_nullable_to_non_nullable
+as int,g: null == g ? _self.g : g // ignore: cast_nullable_to_non_nullable
+as int,b: null == b ? _self.b : b // ignore: cast_nullable_to_non_nullable
+as int,$unknown: freezed == $unknown ? _self.$unknown : $unknown // ignore: cast_nullable_to_non_nullable
+as Map<String, dynamic>?,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [EmbedExternalColorRGB].
+extension EmbedExternalColorRGBPatterns on EmbedExternalColorRGB {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _EmbedExternalColorRGB value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _EmbedExternalColorRGB() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _EmbedExternalColorRGB value)  $default,){
+final _that = this;
+switch (_that) {
+case _EmbedExternalColorRGB():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _EmbedExternalColorRGB value)?  $default,){
+final _that = this;
+switch (_that) {
+case _EmbedExternalColorRGB() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String $type,  int r,  int g,  int b,  Map<String, dynamic>? $unknown)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _EmbedExternalColorRGB() when $default != null:
+return $default(_that.$type,_that.r,_that.g,_that.b,_that.$unknown);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String $type,  int r,  int g,  int b,  Map<String, dynamic>? $unknown)  $default,) {final _that = this;
+switch (_that) {
+case _EmbedExternalColorRGB():
+return $default(_that.$type,_that.r,_that.g,_that.b,_that.$unknown);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String $type,  int r,  int g,  int b,  Map<String, dynamic>? $unknown)?  $default,) {final _that = this;
+switch (_that) {
+case _EmbedExternalColorRGB() when $default != null:
+return $default(_that.$type,_that.r,_that.g,_that.b,_that.$unknown);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+
+@JsonSerializable(includeIfNull: false)
+class _EmbedExternalColorRGB implements EmbedExternalColorRGB {
+  const _EmbedExternalColorRGB({this.$type = 'app.bsky.embed.external#colorRGB', required this.r, required this.g, required this.b, final  Map<String, dynamic>? $unknown}): _$unknown = $unknown;
+  factory _EmbedExternalColorRGB.fromJson(Map<String, dynamic> json) => _$EmbedExternalColorRGBFromJson(json);
+
+@override@JsonKey() final  String $type;
+@override final  int r;
+@override final  int g;
+@override final  int b;
+ final  Map<String, dynamic>? _$unknown;
+@override Map<String, dynamic>? get $unknown {
+  final value = _$unknown;
+  if (value == null) return null;
+  if (_$unknown is EqualUnmodifiableMapView) return _$unknown;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableMapView(value);
+}
+
+
+/// Create a copy of EmbedExternalColorRGB
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$EmbedExternalColorRGBCopyWith<_EmbedExternalColorRGB> get copyWith => __$EmbedExternalColorRGBCopyWithImpl<_EmbedExternalColorRGB>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$EmbedExternalColorRGBToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _EmbedExternalColorRGB&&(identical(other.$type, $type) || other.$type == $type)&&(identical(other.r, r) || other.r == r)&&(identical(other.g, g) || other.g == g)&&(identical(other.b, b) || other.b == b)&&const DeepCollectionEquality().equals(other._$unknown, _$unknown));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,$type,r,g,b,const DeepCollectionEquality().hash(_$unknown));
+
+@override
+String toString() {
+  return 'EmbedExternalColorRGB(\$type: ${$type}, r: $r, g: $g, b: $b, \$unknown: ${$unknown})';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$EmbedExternalColorRGBCopyWith<$Res> implements $EmbedExternalColorRGBCopyWith<$Res> {
+  factory _$EmbedExternalColorRGBCopyWith(_EmbedExternalColorRGB value, $Res Function(_EmbedExternalColorRGB) _then) = __$EmbedExternalColorRGBCopyWithImpl;
+@override @useResult
+$Res call({
+ String $type, int r, int g, int b, Map<String, dynamic>? $unknown
+});
+
+
+
+
+}
+/// @nodoc
+class __$EmbedExternalColorRGBCopyWithImpl<$Res>
+    implements _$EmbedExternalColorRGBCopyWith<$Res> {
+  __$EmbedExternalColorRGBCopyWithImpl(this._self, this._then);
+
+  final _EmbedExternalColorRGB _self;
+  final $Res Function(_EmbedExternalColorRGB) _then;
+
+/// Create a copy of EmbedExternalColorRGB
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? $type = null,Object? r = null,Object? g = null,Object? b = null,Object? $unknown = freezed,}) {
+  return _then(_EmbedExternalColorRGB(
+$type: null == $type ? _self.$type : $type // ignore: cast_nullable_to_non_nullable
+as String,r: null == r ? _self.r : r // ignore: cast_nullable_to_non_nullable
+as int,g: null == g ? _self.g : g // ignore: cast_nullable_to_non_nullable
+as int,b: null == b ? _self.b : b // ignore: cast_nullable_to_non_nullable
+as int,$unknown: freezed == $unknown ? _self._$unknown : $unknown // ignore: cast_nullable_to_non_nullable
+as Map<String, dynamic>?,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/packages/bluesky/lib/src/services/codegen/app/bsky/embed/external/color_r_g_b.g.dart
+++ b/packages/bluesky/lib/src/services/codegen/app/bsky/embed/external/color_r_g_b.g.dart
@@ -1,0 +1,37 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: non_constant_identifier_names
+
+part of 'color_r_g_b.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_EmbedExternalColorRGB _$EmbedExternalColorRGBFromJson(Map json) =>
+    $checkedCreate('_EmbedExternalColorRGB', json, ($checkedConvert) {
+      final val = _EmbedExternalColorRGB(
+        $type: $checkedConvert(
+          r'$type',
+          (v) => v as String? ?? 'app.bsky.embed.external#colorRGB',
+        ),
+        r: $checkedConvert('r', (v) => (v as num).toInt()),
+        g: $checkedConvert('g', (v) => (v as num).toInt()),
+        b: $checkedConvert('b', (v) => (v as num).toInt()),
+        $unknown: $checkedConvert(
+          r'$unknown',
+          (v) => (v as Map?)?.map((k, e) => MapEntry(k as String, e)),
+        ),
+      );
+      return val;
+    });
+
+Map<String, dynamic> _$EmbedExternalColorRGBToJson(
+  _EmbedExternalColorRGB instance,
+) => <String, dynamic>{
+  r'$type': instance.$type,
+  'r': instance.r,
+  'g': instance.g,
+  'b': instance.b,
+  r'$unknown': ?instance.$unknown,
+};

--- a/packages/bluesky/lib/src/services/codegen/app/bsky/embed/external/external.dart
+++ b/packages/bluesky/lib/src/services/codegen/app/bsky/embed/external/external.dart
@@ -27,7 +27,7 @@ abstract class EmbedExternalExternal with _$EmbedExternalExternal {
     'title',
     'description',
     'thumb',
-    'associatedRecords',
+    'associatedRefs',
   ];
 
   @JsonSerializable(includeIfNull: false)
@@ -37,7 +37,7 @@ abstract class EmbedExternalExternal with _$EmbedExternalExternal {
     required String title,
     required String description,
     @BlobConverter() Blob? thumb,
-    @RepoStrongRefConverter() List<RepoStrongRef>? associatedRecords,
+    @RepoStrongRefConverter() List<RepoStrongRef>? associatedRefs,
 
     Map<String, dynamic>? $unknown,
   }) = _EmbedExternalExternal;

--- a/packages/bluesky/lib/src/services/codegen/app/bsky/embed/external/external.freezed.dart
+++ b/packages/bluesky/lib/src/services/codegen/app/bsky/embed/external/external.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$EmbedExternalExternal {
 
- String get $type; String get uri; String get title; String get description;@BlobConverter() Blob? get thumb;@RepoStrongRefConverter() List<RepoStrongRef>? get associatedRecords; Map<String, dynamic>? get $unknown;
+ String get $type; String get uri; String get title; String get description;@BlobConverter() Blob? get thumb;@RepoStrongRefConverter() List<RepoStrongRef>? get associatedRefs; Map<String, dynamic>? get $unknown;
 /// Create a copy of EmbedExternalExternal
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -28,16 +28,16 @@ $EmbedExternalExternalCopyWith<EmbedExternalExternal> get copyWith => _$EmbedExt
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is EmbedExternalExternal&&(identical(other.$type, $type) || other.$type == $type)&&(identical(other.uri, uri) || other.uri == uri)&&(identical(other.title, title) || other.title == title)&&(identical(other.description, description) || other.description == description)&&(identical(other.thumb, thumb) || other.thumb == thumb)&&const DeepCollectionEquality().equals(other.associatedRecords, associatedRecords)&&const DeepCollectionEquality().equals(other.$unknown, $unknown));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is EmbedExternalExternal&&(identical(other.$type, $type) || other.$type == $type)&&(identical(other.uri, uri) || other.uri == uri)&&(identical(other.title, title) || other.title == title)&&(identical(other.description, description) || other.description == description)&&(identical(other.thumb, thumb) || other.thumb == thumb)&&const DeepCollectionEquality().equals(other.associatedRefs, associatedRefs)&&const DeepCollectionEquality().equals(other.$unknown, $unknown));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,$type,uri,title,description,thumb,const DeepCollectionEquality().hash(associatedRecords),const DeepCollectionEquality().hash($unknown));
+int get hashCode => Object.hash(runtimeType,$type,uri,title,description,thumb,const DeepCollectionEquality().hash(associatedRefs),const DeepCollectionEquality().hash($unknown));
 
 @override
 String toString() {
-  return 'EmbedExternalExternal(\$type: ${$type}, uri: $uri, title: $title, description: $description, thumb: $thumb, associatedRecords: $associatedRecords, \$unknown: ${$unknown})';
+  return 'EmbedExternalExternal(\$type: ${$type}, uri: $uri, title: $title, description: $description, thumb: $thumb, associatedRefs: $associatedRefs, \$unknown: ${$unknown})';
 }
 
 
@@ -48,7 +48,7 @@ abstract mixin class $EmbedExternalExternalCopyWith<$Res>  {
   factory $EmbedExternalExternalCopyWith(EmbedExternalExternal value, $Res Function(EmbedExternalExternal) _then) = _$EmbedExternalExternalCopyWithImpl;
 @useResult
 $Res call({
- String $type, String uri, String title, String description,@BlobConverter() Blob? thumb,@RepoStrongRefConverter() List<RepoStrongRef>? associatedRecords, Map<String, dynamic>? $unknown
+ String $type, String uri, String title, String description,@BlobConverter() Blob? thumb,@RepoStrongRefConverter() List<RepoStrongRef>? associatedRefs, Map<String, dynamic>? $unknown
 });
 
 
@@ -65,14 +65,14 @@ class _$EmbedExternalExternalCopyWithImpl<$Res>
 
 /// Create a copy of EmbedExternalExternal
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? $type = null,Object? uri = null,Object? title = null,Object? description = null,Object? thumb = freezed,Object? associatedRecords = freezed,Object? $unknown = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? $type = null,Object? uri = null,Object? title = null,Object? description = null,Object? thumb = freezed,Object? associatedRefs = freezed,Object? $unknown = freezed,}) {
   return _then(_self.copyWith(
 $type: null == $type ? _self.$type : $type // ignore: cast_nullable_to_non_nullable
 as String,uri: null == uri ? _self.uri : uri // ignore: cast_nullable_to_non_nullable
 as String,title: null == title ? _self.title : title // ignore: cast_nullable_to_non_nullable
 as String,description: null == description ? _self.description : description // ignore: cast_nullable_to_non_nullable
 as String,thumb: freezed == thumb ? _self.thumb : thumb // ignore: cast_nullable_to_non_nullable
-as Blob?,associatedRecords: freezed == associatedRecords ? _self.associatedRecords : associatedRecords // ignore: cast_nullable_to_non_nullable
+as Blob?,associatedRefs: freezed == associatedRefs ? _self.associatedRefs : associatedRefs // ignore: cast_nullable_to_non_nullable
 as List<RepoStrongRef>?,$unknown: freezed == $unknown ? _self.$unknown : $unknown // ignore: cast_nullable_to_non_nullable
 as Map<String, dynamic>?,
   ));
@@ -171,10 +171,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String $type,  String uri,  String title,  String description, @BlobConverter()  Blob? thumb, @RepoStrongRefConverter()  List<RepoStrongRef>? associatedRecords,  Map<String, dynamic>? $unknown)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String $type,  String uri,  String title,  String description, @BlobConverter()  Blob? thumb, @RepoStrongRefConverter()  List<RepoStrongRef>? associatedRefs,  Map<String, dynamic>? $unknown)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _EmbedExternalExternal() when $default != null:
-return $default(_that.$type,_that.uri,_that.title,_that.description,_that.thumb,_that.associatedRecords,_that.$unknown);case _:
+return $default(_that.$type,_that.uri,_that.title,_that.description,_that.thumb,_that.associatedRefs,_that.$unknown);case _:
   return orElse();
 
 }
@@ -192,10 +192,10 @@ return $default(_that.$type,_that.uri,_that.title,_that.description,_that.thumb,
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String $type,  String uri,  String title,  String description, @BlobConverter()  Blob? thumb, @RepoStrongRefConverter()  List<RepoStrongRef>? associatedRecords,  Map<String, dynamic>? $unknown)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String $type,  String uri,  String title,  String description, @BlobConverter()  Blob? thumb, @RepoStrongRefConverter()  List<RepoStrongRef>? associatedRefs,  Map<String, dynamic>? $unknown)  $default,) {final _that = this;
 switch (_that) {
 case _EmbedExternalExternal():
-return $default(_that.$type,_that.uri,_that.title,_that.description,_that.thumb,_that.associatedRecords,_that.$unknown);case _:
+return $default(_that.$type,_that.uri,_that.title,_that.description,_that.thumb,_that.associatedRefs,_that.$unknown);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -212,10 +212,10 @@ return $default(_that.$type,_that.uri,_that.title,_that.description,_that.thumb,
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String $type,  String uri,  String title,  String description, @BlobConverter()  Blob? thumb, @RepoStrongRefConverter()  List<RepoStrongRef>? associatedRecords,  Map<String, dynamic>? $unknown)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String $type,  String uri,  String title,  String description, @BlobConverter()  Blob? thumb, @RepoStrongRefConverter()  List<RepoStrongRef>? associatedRefs,  Map<String, dynamic>? $unknown)?  $default,) {final _that = this;
 switch (_that) {
 case _EmbedExternalExternal() when $default != null:
-return $default(_that.$type,_that.uri,_that.title,_that.description,_that.thumb,_that.associatedRecords,_that.$unknown);case _:
+return $default(_that.$type,_that.uri,_that.title,_that.description,_that.thumb,_that.associatedRefs,_that.$unknown);case _:
   return null;
 
 }
@@ -227,7 +227,7 @@ return $default(_that.$type,_that.uri,_that.title,_that.description,_that.thumb,
 
 @JsonSerializable(includeIfNull: false)
 class _EmbedExternalExternal implements EmbedExternalExternal {
-  const _EmbedExternalExternal({this.$type = 'app.bsky.embed.external#external', required this.uri, required this.title, required this.description, @BlobConverter() this.thumb, @RepoStrongRefConverter() final  List<RepoStrongRef>? associatedRecords, final  Map<String, dynamic>? $unknown}): _associatedRecords = associatedRecords,_$unknown = $unknown;
+  const _EmbedExternalExternal({this.$type = 'app.bsky.embed.external#external', required this.uri, required this.title, required this.description, @BlobConverter() this.thumb, @RepoStrongRefConverter() final  List<RepoStrongRef>? associatedRefs, final  Map<String, dynamic>? $unknown}): _associatedRefs = associatedRefs,_$unknown = $unknown;
   factory _EmbedExternalExternal.fromJson(Map<String, dynamic> json) => _$EmbedExternalExternalFromJson(json);
 
 @override@JsonKey() final  String $type;
@@ -235,11 +235,11 @@ class _EmbedExternalExternal implements EmbedExternalExternal {
 @override final  String title;
 @override final  String description;
 @override@BlobConverter() final  Blob? thumb;
- final  List<RepoStrongRef>? _associatedRecords;
-@override@RepoStrongRefConverter() List<RepoStrongRef>? get associatedRecords {
-  final value = _associatedRecords;
+ final  List<RepoStrongRef>? _associatedRefs;
+@override@RepoStrongRefConverter() List<RepoStrongRef>? get associatedRefs {
+  final value = _associatedRefs;
   if (value == null) return null;
-  if (_associatedRecords is EqualUnmodifiableListView) return _associatedRecords;
+  if (_associatedRefs is EqualUnmodifiableListView) return _associatedRefs;
   // ignore: implicit_dynamic_type
   return EqualUnmodifiableListView(value);
 }
@@ -267,16 +267,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _EmbedExternalExternal&&(identical(other.$type, $type) || other.$type == $type)&&(identical(other.uri, uri) || other.uri == uri)&&(identical(other.title, title) || other.title == title)&&(identical(other.description, description) || other.description == description)&&(identical(other.thumb, thumb) || other.thumb == thumb)&&const DeepCollectionEquality().equals(other._associatedRecords, _associatedRecords)&&const DeepCollectionEquality().equals(other._$unknown, _$unknown));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _EmbedExternalExternal&&(identical(other.$type, $type) || other.$type == $type)&&(identical(other.uri, uri) || other.uri == uri)&&(identical(other.title, title) || other.title == title)&&(identical(other.description, description) || other.description == description)&&(identical(other.thumb, thumb) || other.thumb == thumb)&&const DeepCollectionEquality().equals(other._associatedRefs, _associatedRefs)&&const DeepCollectionEquality().equals(other._$unknown, _$unknown));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,$type,uri,title,description,thumb,const DeepCollectionEquality().hash(_associatedRecords),const DeepCollectionEquality().hash(_$unknown));
+int get hashCode => Object.hash(runtimeType,$type,uri,title,description,thumb,const DeepCollectionEquality().hash(_associatedRefs),const DeepCollectionEquality().hash(_$unknown));
 
 @override
 String toString() {
-  return 'EmbedExternalExternal(\$type: ${$type}, uri: $uri, title: $title, description: $description, thumb: $thumb, associatedRecords: $associatedRecords, \$unknown: ${$unknown})';
+  return 'EmbedExternalExternal(\$type: ${$type}, uri: $uri, title: $title, description: $description, thumb: $thumb, associatedRefs: $associatedRefs, \$unknown: ${$unknown})';
 }
 
 
@@ -287,7 +287,7 @@ abstract mixin class _$EmbedExternalExternalCopyWith<$Res> implements $EmbedExte
   factory _$EmbedExternalExternalCopyWith(_EmbedExternalExternal value, $Res Function(_EmbedExternalExternal) _then) = __$EmbedExternalExternalCopyWithImpl;
 @override @useResult
 $Res call({
- String $type, String uri, String title, String description,@BlobConverter() Blob? thumb,@RepoStrongRefConverter() List<RepoStrongRef>? associatedRecords, Map<String, dynamic>? $unknown
+ String $type, String uri, String title, String description,@BlobConverter() Blob? thumb,@RepoStrongRefConverter() List<RepoStrongRef>? associatedRefs, Map<String, dynamic>? $unknown
 });
 
 
@@ -304,14 +304,14 @@ class __$EmbedExternalExternalCopyWithImpl<$Res>
 
 /// Create a copy of EmbedExternalExternal
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? $type = null,Object? uri = null,Object? title = null,Object? description = null,Object? thumb = freezed,Object? associatedRecords = freezed,Object? $unknown = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? $type = null,Object? uri = null,Object? title = null,Object? description = null,Object? thumb = freezed,Object? associatedRefs = freezed,Object? $unknown = freezed,}) {
   return _then(_EmbedExternalExternal(
 $type: null == $type ? _self.$type : $type // ignore: cast_nullable_to_non_nullable
 as String,uri: null == uri ? _self.uri : uri // ignore: cast_nullable_to_non_nullable
 as String,title: null == title ? _self.title : title // ignore: cast_nullable_to_non_nullable
 as String,description: null == description ? _self.description : description // ignore: cast_nullable_to_non_nullable
 as String,thumb: freezed == thumb ? _self.thumb : thumb // ignore: cast_nullable_to_non_nullable
-as Blob?,associatedRecords: freezed == associatedRecords ? _self._associatedRecords : associatedRecords // ignore: cast_nullable_to_non_nullable
+as Blob?,associatedRefs: freezed == associatedRefs ? _self._associatedRefs : associatedRefs // ignore: cast_nullable_to_non_nullable
 as List<RepoStrongRef>?,$unknown: freezed == $unknown ? _self._$unknown : $unknown // ignore: cast_nullable_to_non_nullable
 as Map<String, dynamic>?,
   ));

--- a/packages/bluesky/lib/src/services/codegen/app/bsky/embed/external/external.g.dart
+++ b/packages/bluesky/lib/src/services/codegen/app/bsky/embed/external/external.g.dart
@@ -25,8 +25,8 @@ _EmbedExternalExternal _$EmbedExternalExternalFromJson(Map json) =>
             const BlobConverter().fromJson,
           ),
         ),
-        associatedRecords: $checkedConvert(
-          'associatedRecords',
+        associatedRefs: $checkedConvert(
+          'associatedRefs',
           (v) => (v as List<dynamic>?)
               ?.map(
                 (e) => const RepoStrongRefConverter().fromJson(
@@ -54,7 +54,7 @@ Map<String, dynamic> _$EmbedExternalExternalToJson(
     instance.thumb,
     const BlobConverter().toJson,
   ),
-  'associatedRecords': ?instance.associatedRecords
+  'associatedRefs': ?instance.associatedRefs
       ?.map(const RepoStrongRefConverter().toJson)
       .toList(),
   r'$unknown': ?instance.$unknown,

--- a/packages/bluesky/lib/src/services/codegen/app/bsky/embed/external/view_external.dart
+++ b/packages/bluesky/lib/src/services/codegen/app/bsky/embed/external/view_external.dart
@@ -8,8 +8,13 @@
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
 // Package imports:
+import 'package:atproto/com_atproto_label_defs.dart';
+import 'package:atproto/com_atproto_repo_strongref.dart';
 import 'package:atproto_core/internals.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
+
+// Project imports:
+import './view_external_source.dart';
 
 part 'view_external.freezed.dart';
 part 'view_external.g.dart';
@@ -20,7 +25,18 @@ part 'view_external.g.dart';
 
 @freezed
 abstract class EmbedExternalViewExternal with _$EmbedExternalViewExternal {
-  static const knownProps = <String>['uri', 'title', 'description', 'thumb'];
+  static const knownProps = <String>[
+    'uri',
+    'title',
+    'description',
+    'thumb',
+    'createdAt',
+    'updatedAt',
+    'readingTime',
+    'labels',
+    'source',
+    'associatedRefs',
+  ];
 
   @JsonSerializable(includeIfNull: false)
   const factory EmbedExternalViewExternal({
@@ -29,6 +45,19 @@ abstract class EmbedExternalViewExternal with _$EmbedExternalViewExternal {
     required String title,
     required String description,
     String? thumb,
+
+    /// When the external content was created, if available. Example: a publication date, for an article.
+    DateTime? createdAt,
+
+    /// When the external content was updated, if available.
+    DateTime? updatedAt,
+
+    /// Estimated reading time in minutes, if applicable and available.
+    int? readingTime,
+    @LabelConverter() List<Label>? labels,
+    @EmbedExternalViewExternalSourceConverter()
+    EmbedExternalViewExternalSource? source,
+    @RepoStrongRefConverter() List<RepoStrongRef>? associatedRefs,
 
     Map<String, dynamic>? $unknown,
   }) = _EmbedExternalViewExternal;
@@ -45,6 +74,14 @@ abstract class EmbedExternalViewExternal with _$EmbedExternalViewExternal {
 extension EmbedExternalViewExternalExtension on EmbedExternalViewExternal {
   bool get hasThumb => thumb != null;
   bool get hasNotThumb => !hasThumb;
+  bool get hasCreatedAt => createdAt != null;
+  bool get hasNotCreatedAt => !hasCreatedAt;
+  bool get hasUpdatedAt => updatedAt != null;
+  bool get hasNotUpdatedAt => !hasUpdatedAt;
+  bool get hasReadingTime => readingTime != null;
+  bool get hasNotReadingTime => !hasReadingTime;
+  bool get hasSource => source != null;
+  bool get hasNotSource => !hasSource;
 }
 
 final class EmbedExternalViewExternalConverter

--- a/packages/bluesky/lib/src/services/codegen/app/bsky/embed/external/view_external.freezed.dart
+++ b/packages/bluesky/lib/src/services/codegen/app/bsky/embed/external/view_external.freezed.dart
@@ -15,7 +15,10 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$EmbedExternalViewExternal {
 
- String get $type; String get uri; String get title; String get description; String? get thumb; Map<String, dynamic>? get $unknown;
+ String get $type; String get uri; String get title; String get description; String? get thumb;/// When the external content was created, if available. Example: a publication date, for an article.
+ DateTime? get createdAt;/// When the external content was updated, if available.
+ DateTime? get updatedAt;/// Estimated reading time in minutes, if applicable and available.
+ int? get readingTime;@LabelConverter() List<Label>? get labels;@EmbedExternalViewExternalSourceConverter() EmbedExternalViewExternalSource? get source;@RepoStrongRefConverter() List<RepoStrongRef>? get associatedRefs; Map<String, dynamic>? get $unknown;
 /// Create a copy of EmbedExternalViewExternal
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -28,16 +31,16 @@ $EmbedExternalViewExternalCopyWith<EmbedExternalViewExternal> get copyWith => _$
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is EmbedExternalViewExternal&&(identical(other.$type, $type) || other.$type == $type)&&(identical(other.uri, uri) || other.uri == uri)&&(identical(other.title, title) || other.title == title)&&(identical(other.description, description) || other.description == description)&&(identical(other.thumb, thumb) || other.thumb == thumb)&&const DeepCollectionEquality().equals(other.$unknown, $unknown));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is EmbedExternalViewExternal&&(identical(other.$type, $type) || other.$type == $type)&&(identical(other.uri, uri) || other.uri == uri)&&(identical(other.title, title) || other.title == title)&&(identical(other.description, description) || other.description == description)&&(identical(other.thumb, thumb) || other.thumb == thumb)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt)&&(identical(other.readingTime, readingTime) || other.readingTime == readingTime)&&const DeepCollectionEquality().equals(other.labels, labels)&&(identical(other.source, source) || other.source == source)&&const DeepCollectionEquality().equals(other.associatedRefs, associatedRefs)&&const DeepCollectionEquality().equals(other.$unknown, $unknown));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,$type,uri,title,description,thumb,const DeepCollectionEquality().hash($unknown));
+int get hashCode => Object.hash(runtimeType,$type,uri,title,description,thumb,createdAt,updatedAt,readingTime,const DeepCollectionEquality().hash(labels),source,const DeepCollectionEquality().hash(associatedRefs),const DeepCollectionEquality().hash($unknown));
 
 @override
 String toString() {
-  return 'EmbedExternalViewExternal(\$type: ${$type}, uri: $uri, title: $title, description: $description, thumb: $thumb, \$unknown: ${$unknown})';
+  return 'EmbedExternalViewExternal(\$type: ${$type}, uri: $uri, title: $title, description: $description, thumb: $thumb, createdAt: $createdAt, updatedAt: $updatedAt, readingTime: $readingTime, labels: $labels, source: $source, associatedRefs: $associatedRefs, \$unknown: ${$unknown})';
 }
 
 
@@ -48,11 +51,11 @@ abstract mixin class $EmbedExternalViewExternalCopyWith<$Res>  {
   factory $EmbedExternalViewExternalCopyWith(EmbedExternalViewExternal value, $Res Function(EmbedExternalViewExternal) _then) = _$EmbedExternalViewExternalCopyWithImpl;
 @useResult
 $Res call({
- String $type, String uri, String title, String description, String? thumb, Map<String, dynamic>? $unknown
+ String $type, String uri, String title, String description, String? thumb, DateTime? createdAt, DateTime? updatedAt, int? readingTime,@LabelConverter() List<Label>? labels,@EmbedExternalViewExternalSourceConverter() EmbedExternalViewExternalSource? source,@RepoStrongRefConverter() List<RepoStrongRef>? associatedRefs, Map<String, dynamic>? $unknown
 });
 
 
-
+$EmbedExternalViewExternalSourceCopyWith<$Res>? get source;
 
 }
 /// @nodoc
@@ -65,18 +68,36 @@ class _$EmbedExternalViewExternalCopyWithImpl<$Res>
 
 /// Create a copy of EmbedExternalViewExternal
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? $type = null,Object? uri = null,Object? title = null,Object? description = null,Object? thumb = freezed,Object? $unknown = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? $type = null,Object? uri = null,Object? title = null,Object? description = null,Object? thumb = freezed,Object? createdAt = freezed,Object? updatedAt = freezed,Object? readingTime = freezed,Object? labels = freezed,Object? source = freezed,Object? associatedRefs = freezed,Object? $unknown = freezed,}) {
   return _then(_self.copyWith(
 $type: null == $type ? _self.$type : $type // ignore: cast_nullable_to_non_nullable
 as String,uri: null == uri ? _self.uri : uri // ignore: cast_nullable_to_non_nullable
 as String,title: null == title ? _self.title : title // ignore: cast_nullable_to_non_nullable
 as String,description: null == description ? _self.description : description // ignore: cast_nullable_to_non_nullable
 as String,thumb: freezed == thumb ? _self.thumb : thumb // ignore: cast_nullable_to_non_nullable
-as String?,$unknown: freezed == $unknown ? _self.$unknown : $unknown // ignore: cast_nullable_to_non_nullable
+as String?,createdAt: freezed == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
+as DateTime?,updatedAt: freezed == updatedAt ? _self.updatedAt : updatedAt // ignore: cast_nullable_to_non_nullable
+as DateTime?,readingTime: freezed == readingTime ? _self.readingTime : readingTime // ignore: cast_nullable_to_non_nullable
+as int?,labels: freezed == labels ? _self.labels : labels // ignore: cast_nullable_to_non_nullable
+as List<Label>?,source: freezed == source ? _self.source : source // ignore: cast_nullable_to_non_nullable
+as EmbedExternalViewExternalSource?,associatedRefs: freezed == associatedRefs ? _self.associatedRefs : associatedRefs // ignore: cast_nullable_to_non_nullable
+as List<RepoStrongRef>?,$unknown: freezed == $unknown ? _self.$unknown : $unknown // ignore: cast_nullable_to_non_nullable
 as Map<String, dynamic>?,
   ));
 }
+/// Create a copy of EmbedExternalViewExternal
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$EmbedExternalViewExternalSourceCopyWith<$Res>? get source {
+    if (_self.source == null) {
+    return null;
+  }
 
+  return $EmbedExternalViewExternalSourceCopyWith<$Res>(_self.source!, (value) {
+    return _then(_self.copyWith(source: value));
+  });
+}
 }
 
 
@@ -158,10 +179,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String $type,  String uri,  String title,  String description,  String? thumb,  Map<String, dynamic>? $unknown)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String $type,  String uri,  String title,  String description,  String? thumb,  DateTime? createdAt,  DateTime? updatedAt,  int? readingTime, @LabelConverter()  List<Label>? labels, @EmbedExternalViewExternalSourceConverter()  EmbedExternalViewExternalSource? source, @RepoStrongRefConverter()  List<RepoStrongRef>? associatedRefs,  Map<String, dynamic>? $unknown)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _EmbedExternalViewExternal() when $default != null:
-return $default(_that.$type,_that.uri,_that.title,_that.description,_that.thumb,_that.$unknown);case _:
+return $default(_that.$type,_that.uri,_that.title,_that.description,_that.thumb,_that.createdAt,_that.updatedAt,_that.readingTime,_that.labels,_that.source,_that.associatedRefs,_that.$unknown);case _:
   return orElse();
 
 }
@@ -179,10 +200,10 @@ return $default(_that.$type,_that.uri,_that.title,_that.description,_that.thumb,
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String $type,  String uri,  String title,  String description,  String? thumb,  Map<String, dynamic>? $unknown)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String $type,  String uri,  String title,  String description,  String? thumb,  DateTime? createdAt,  DateTime? updatedAt,  int? readingTime, @LabelConverter()  List<Label>? labels, @EmbedExternalViewExternalSourceConverter()  EmbedExternalViewExternalSource? source, @RepoStrongRefConverter()  List<RepoStrongRef>? associatedRefs,  Map<String, dynamic>? $unknown)  $default,) {final _that = this;
 switch (_that) {
 case _EmbedExternalViewExternal():
-return $default(_that.$type,_that.uri,_that.title,_that.description,_that.thumb,_that.$unknown);case _:
+return $default(_that.$type,_that.uri,_that.title,_that.description,_that.thumb,_that.createdAt,_that.updatedAt,_that.readingTime,_that.labels,_that.source,_that.associatedRefs,_that.$unknown);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -199,10 +220,10 @@ return $default(_that.$type,_that.uri,_that.title,_that.description,_that.thumb,
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String $type,  String uri,  String title,  String description,  String? thumb,  Map<String, dynamic>? $unknown)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String $type,  String uri,  String title,  String description,  String? thumb,  DateTime? createdAt,  DateTime? updatedAt,  int? readingTime, @LabelConverter()  List<Label>? labels, @EmbedExternalViewExternalSourceConverter()  EmbedExternalViewExternalSource? source, @RepoStrongRefConverter()  List<RepoStrongRef>? associatedRefs,  Map<String, dynamic>? $unknown)?  $default,) {final _that = this;
 switch (_that) {
 case _EmbedExternalViewExternal() when $default != null:
-return $default(_that.$type,_that.uri,_that.title,_that.description,_that.thumb,_that.$unknown);case _:
+return $default(_that.$type,_that.uri,_that.title,_that.description,_that.thumb,_that.createdAt,_that.updatedAt,_that.readingTime,_that.labels,_that.source,_that.associatedRefs,_that.$unknown);case _:
   return null;
 
 }
@@ -214,7 +235,7 @@ return $default(_that.$type,_that.uri,_that.title,_that.description,_that.thumb,
 
 @JsonSerializable(includeIfNull: false)
 class _EmbedExternalViewExternal implements EmbedExternalViewExternal {
-  const _EmbedExternalViewExternal({this.$type = 'app.bsky.embed.external#viewExternal', required this.uri, required this.title, required this.description, this.thumb, final  Map<String, dynamic>? $unknown}): _$unknown = $unknown;
+  const _EmbedExternalViewExternal({this.$type = 'app.bsky.embed.external#viewExternal', required this.uri, required this.title, required this.description, this.thumb, this.createdAt, this.updatedAt, this.readingTime, @LabelConverter() final  List<Label>? labels, @EmbedExternalViewExternalSourceConverter() this.source, @RepoStrongRefConverter() final  List<RepoStrongRef>? associatedRefs, final  Map<String, dynamic>? $unknown}): _labels = labels,_associatedRefs = associatedRefs,_$unknown = $unknown;
   factory _EmbedExternalViewExternal.fromJson(Map<String, dynamic> json) => _$EmbedExternalViewExternalFromJson(json);
 
 @override@JsonKey() final  String $type;
@@ -222,6 +243,31 @@ class _EmbedExternalViewExternal implements EmbedExternalViewExternal {
 @override final  String title;
 @override final  String description;
 @override final  String? thumb;
+/// When the external content was created, if available. Example: a publication date, for an article.
+@override final  DateTime? createdAt;
+/// When the external content was updated, if available.
+@override final  DateTime? updatedAt;
+/// Estimated reading time in minutes, if applicable and available.
+@override final  int? readingTime;
+ final  List<Label>? _labels;
+@override@LabelConverter() List<Label>? get labels {
+  final value = _labels;
+  if (value == null) return null;
+  if (_labels is EqualUnmodifiableListView) return _labels;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(value);
+}
+
+@override@EmbedExternalViewExternalSourceConverter() final  EmbedExternalViewExternalSource? source;
+ final  List<RepoStrongRef>? _associatedRefs;
+@override@RepoStrongRefConverter() List<RepoStrongRef>? get associatedRefs {
+  final value = _associatedRefs;
+  if (value == null) return null;
+  if (_associatedRefs is EqualUnmodifiableListView) return _associatedRefs;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(value);
+}
+
  final  Map<String, dynamic>? _$unknown;
 @override Map<String, dynamic>? get $unknown {
   final value = _$unknown;
@@ -245,16 +291,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _EmbedExternalViewExternal&&(identical(other.$type, $type) || other.$type == $type)&&(identical(other.uri, uri) || other.uri == uri)&&(identical(other.title, title) || other.title == title)&&(identical(other.description, description) || other.description == description)&&(identical(other.thumb, thumb) || other.thumb == thumb)&&const DeepCollectionEquality().equals(other._$unknown, _$unknown));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _EmbedExternalViewExternal&&(identical(other.$type, $type) || other.$type == $type)&&(identical(other.uri, uri) || other.uri == uri)&&(identical(other.title, title) || other.title == title)&&(identical(other.description, description) || other.description == description)&&(identical(other.thumb, thumb) || other.thumb == thumb)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt)&&(identical(other.readingTime, readingTime) || other.readingTime == readingTime)&&const DeepCollectionEquality().equals(other._labels, _labels)&&(identical(other.source, source) || other.source == source)&&const DeepCollectionEquality().equals(other._associatedRefs, _associatedRefs)&&const DeepCollectionEquality().equals(other._$unknown, _$unknown));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,$type,uri,title,description,thumb,const DeepCollectionEquality().hash(_$unknown));
+int get hashCode => Object.hash(runtimeType,$type,uri,title,description,thumb,createdAt,updatedAt,readingTime,const DeepCollectionEquality().hash(_labels),source,const DeepCollectionEquality().hash(_associatedRefs),const DeepCollectionEquality().hash(_$unknown));
 
 @override
 String toString() {
-  return 'EmbedExternalViewExternal(\$type: ${$type}, uri: $uri, title: $title, description: $description, thumb: $thumb, \$unknown: ${$unknown})';
+  return 'EmbedExternalViewExternal(\$type: ${$type}, uri: $uri, title: $title, description: $description, thumb: $thumb, createdAt: $createdAt, updatedAt: $updatedAt, readingTime: $readingTime, labels: $labels, source: $source, associatedRefs: $associatedRefs, \$unknown: ${$unknown})';
 }
 
 
@@ -265,11 +311,11 @@ abstract mixin class _$EmbedExternalViewExternalCopyWith<$Res> implements $Embed
   factory _$EmbedExternalViewExternalCopyWith(_EmbedExternalViewExternal value, $Res Function(_EmbedExternalViewExternal) _then) = __$EmbedExternalViewExternalCopyWithImpl;
 @override @useResult
 $Res call({
- String $type, String uri, String title, String description, String? thumb, Map<String, dynamic>? $unknown
+ String $type, String uri, String title, String description, String? thumb, DateTime? createdAt, DateTime? updatedAt, int? readingTime,@LabelConverter() List<Label>? labels,@EmbedExternalViewExternalSourceConverter() EmbedExternalViewExternalSource? source,@RepoStrongRefConverter() List<RepoStrongRef>? associatedRefs, Map<String, dynamic>? $unknown
 });
 
 
-
+@override $EmbedExternalViewExternalSourceCopyWith<$Res>? get source;
 
 }
 /// @nodoc
@@ -282,19 +328,37 @@ class __$EmbedExternalViewExternalCopyWithImpl<$Res>
 
 /// Create a copy of EmbedExternalViewExternal
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? $type = null,Object? uri = null,Object? title = null,Object? description = null,Object? thumb = freezed,Object? $unknown = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? $type = null,Object? uri = null,Object? title = null,Object? description = null,Object? thumb = freezed,Object? createdAt = freezed,Object? updatedAt = freezed,Object? readingTime = freezed,Object? labels = freezed,Object? source = freezed,Object? associatedRefs = freezed,Object? $unknown = freezed,}) {
   return _then(_EmbedExternalViewExternal(
 $type: null == $type ? _self.$type : $type // ignore: cast_nullable_to_non_nullable
 as String,uri: null == uri ? _self.uri : uri // ignore: cast_nullable_to_non_nullable
 as String,title: null == title ? _self.title : title // ignore: cast_nullable_to_non_nullable
 as String,description: null == description ? _self.description : description // ignore: cast_nullable_to_non_nullable
 as String,thumb: freezed == thumb ? _self.thumb : thumb // ignore: cast_nullable_to_non_nullable
-as String?,$unknown: freezed == $unknown ? _self._$unknown : $unknown // ignore: cast_nullable_to_non_nullable
+as String?,createdAt: freezed == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
+as DateTime?,updatedAt: freezed == updatedAt ? _self.updatedAt : updatedAt // ignore: cast_nullable_to_non_nullable
+as DateTime?,readingTime: freezed == readingTime ? _self.readingTime : readingTime // ignore: cast_nullable_to_non_nullable
+as int?,labels: freezed == labels ? _self._labels : labels // ignore: cast_nullable_to_non_nullable
+as List<Label>?,source: freezed == source ? _self.source : source // ignore: cast_nullable_to_non_nullable
+as EmbedExternalViewExternalSource?,associatedRefs: freezed == associatedRefs ? _self._associatedRefs : associatedRefs // ignore: cast_nullable_to_non_nullable
+as List<RepoStrongRef>?,$unknown: freezed == $unknown ? _self._$unknown : $unknown // ignore: cast_nullable_to_non_nullable
 as Map<String, dynamic>?,
   ));
 }
 
+/// Create a copy of EmbedExternalViewExternal
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$EmbedExternalViewExternalSourceCopyWith<$Res>? get source {
+    if (_self.source == null) {
+    return null;
+  }
 
+  return $EmbedExternalViewExternalSourceCopyWith<$Res>(_self.source!, (value) {
+    return _then(_self.copyWith(source: value));
+  });
+}
 }
 
 // dart format on

--- a/packages/bluesky/lib/src/services/codegen/app/bsky/embed/external/view_external.g.dart
+++ b/packages/bluesky/lib/src/services/codegen/app/bsky/embed/external/view_external.g.dart
@@ -8,24 +8,60 @@ part of 'view_external.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_EmbedExternalViewExternal _$EmbedExternalViewExternalFromJson(Map json) =>
-    $checkedCreate('_EmbedExternalViewExternal', json, ($checkedConvert) {
-      final val = _EmbedExternalViewExternal(
-        $type: $checkedConvert(
-          r'$type',
-          (v) => v as String? ?? 'app.bsky.embed.external#viewExternal',
-        ),
-        uri: $checkedConvert('uri', (v) => v as String),
-        title: $checkedConvert('title', (v) => v as String),
-        description: $checkedConvert('description', (v) => v as String),
-        thumb: $checkedConvert('thumb', (v) => v as String?),
-        $unknown: $checkedConvert(
-          r'$unknown',
-          (v) => (v as Map?)?.map((k, e) => MapEntry(k as String, e)),
-        ),
-      );
-      return val;
-    });
+_EmbedExternalViewExternal _$EmbedExternalViewExternalFromJson(
+  Map json,
+) => $checkedCreate('_EmbedExternalViewExternal', json, ($checkedConvert) {
+  final val = _EmbedExternalViewExternal(
+    $type: $checkedConvert(
+      r'$type',
+      (v) => v as String? ?? 'app.bsky.embed.external#viewExternal',
+    ),
+    uri: $checkedConvert('uri', (v) => v as String),
+    title: $checkedConvert('title', (v) => v as String),
+    description: $checkedConvert('description', (v) => v as String),
+    thumb: $checkedConvert('thumb', (v) => v as String?),
+    createdAt: $checkedConvert(
+      'createdAt',
+      (v) => v == null ? null : DateTime.parse(v as String),
+    ),
+    updatedAt: $checkedConvert(
+      'updatedAt',
+      (v) => v == null ? null : DateTime.parse(v as String),
+    ),
+    readingTime: $checkedConvert('readingTime', (v) => (v as num?)?.toInt()),
+    labels: $checkedConvert(
+      'labels',
+      (v) => (v as List<dynamic>?)
+          ?.map(
+            (e) => const LabelConverter().fromJson(e as Map<String, dynamic>),
+          )
+          .toList(),
+    ),
+    source: $checkedConvert(
+      'source',
+      (v) =>
+          _$JsonConverterFromJson<
+            Map<String, dynamic>,
+            EmbedExternalViewExternalSource
+          >(v, const EmbedExternalViewExternalSourceConverter().fromJson),
+    ),
+    associatedRefs: $checkedConvert(
+      'associatedRefs',
+      (v) => (v as List<dynamic>?)
+          ?.map(
+            (e) => const RepoStrongRefConverter().fromJson(
+              e as Map<String, dynamic>,
+            ),
+          )
+          .toList(),
+    ),
+    $unknown: $checkedConvert(
+      r'$unknown',
+      (v) => (v as Map?)?.map((k, e) => MapEntry(k as String, e)),
+    ),
+  );
+  return val;
+});
 
 Map<String, dynamic> _$EmbedExternalViewExternalToJson(
   _EmbedExternalViewExternal instance,
@@ -35,5 +71,30 @@ Map<String, dynamic> _$EmbedExternalViewExternalToJson(
   'title': instance.title,
   'description': instance.description,
   'thumb': ?instance.thumb,
+  'createdAt': ?instance.createdAt?.toIso8601String(),
+  'updatedAt': ?instance.updatedAt?.toIso8601String(),
+  'readingTime': ?instance.readingTime,
+  'labels': ?instance.labels?.map(const LabelConverter().toJson).toList(),
+  'source':
+      ?_$JsonConverterToJson<
+        Map<String, dynamic>,
+        EmbedExternalViewExternalSource
+      >(
+        instance.source,
+        const EmbedExternalViewExternalSourceConverter().toJson,
+      ),
+  'associatedRefs': ?instance.associatedRefs
+      ?.map(const RepoStrongRefConverter().toJson)
+      .toList(),
   r'$unknown': ?instance.$unknown,
 };
+
+Value? _$JsonConverterFromJson<Json, Value>(
+  Object? json,
+  Value? Function(Json json) fromJson,
+) => json == null ? null : fromJson(json as Json);
+
+Json? _$JsonConverterToJson<Json, Value>(
+  Value? value,
+  Json? Function(Value value) toJson,
+) => value == null ? null : toJson(value);

--- a/packages/bluesky/lib/src/services/codegen/app/bsky/embed/external/view_external_source.dart
+++ b/packages/bluesky/lib/src/services/codegen/app/bsky/embed/external/view_external_source.dart
@@ -1,0 +1,87 @@
+// Copyright (c) 2023-2026, Shinya Kato.
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+// Package imports:
+import 'package:atproto_core/internals.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+// Project imports:
+import './view_external_source_theme.dart';
+
+part 'view_external_source.freezed.dart';
+part 'view_external_source.g.dart';
+
+// **************************************************************************
+// LexGenerator
+// **************************************************************************
+
+/// The source of an external embed, such as a standard.site publication.
+@freezed
+abstract class EmbedExternalViewExternalSource
+    with _$EmbedExternalViewExternalSource {
+  static const knownProps = <String>[
+    'uri',
+    'icon',
+    'title',
+    'description',
+    'theme',
+  ];
+
+  @JsonSerializable(includeIfNull: false)
+  const factory EmbedExternalViewExternalSource({
+    @Default('app.bsky.embed.external#viewExternalSource') String $type,
+
+    /// URI of the source, if available. Example: the https:// URL of a site.standard.publication record.
+    required String uri,
+
+    /// Fully-qualified URL where an icon representing the source can be fetched. For example, CDN location provided by the App View.
+    String? icon,
+    required String title,
+    String? description,
+    @EmbedExternalViewExternalSourceThemeConverter()
+    EmbedExternalViewExternalSourceTheme? theme,
+
+    Map<String, dynamic>? $unknown,
+  }) = _EmbedExternalViewExternalSource;
+
+  factory EmbedExternalViewExternalSource.fromJson(Map<String, Object?> json) =>
+      _$EmbedExternalViewExternalSourceFromJson(json);
+
+  static bool validate(final Map<String, dynamic> object) {
+    if (!object.containsKey('\$type')) return false;
+    return object['\$type'] == 'app.bsky.embed.external#viewExternalSource';
+  }
+}
+
+extension EmbedExternalViewExternalSourceExtension
+    on EmbedExternalViewExternalSource {
+  bool get hasIcon => icon != null;
+  bool get hasNotIcon => !hasIcon;
+  bool get hasDescription => description != null;
+  bool get hasNotDescription => !hasDescription;
+  bool get hasTheme => theme != null;
+  bool get hasNotTheme => !hasTheme;
+}
+
+final class EmbedExternalViewExternalSourceConverter
+    extends
+        JsonConverter<EmbedExternalViewExternalSource, Map<String, dynamic>> {
+  const EmbedExternalViewExternalSourceConverter();
+
+  @override
+  EmbedExternalViewExternalSource fromJson(Map<String, dynamic> json) {
+    return EmbedExternalViewExternalSource.fromJson(
+      translate(json, EmbedExternalViewExternalSource.knownProps),
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson(EmbedExternalViewExternalSource object) =>
+      untranslate(object.toJson());
+}

--- a/packages/bluesky/lib/src/services/codegen/app/bsky/embed/external/view_external_source.freezed.dart
+++ b/packages/bluesky/lib/src/services/codegen/app/bsky/embed/external/view_external_source.freezed.dart
@@ -1,0 +1,331 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'view_external_source.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$EmbedExternalViewExternalSource {
+
+ String get $type;/// URI of the source, if available. Example: the https:// URL of a site.standard.publication record.
+ String get uri;/// Fully-qualified URL where an icon representing the source can be fetched. For example, CDN location provided by the App View.
+ String? get icon; String get title; String? get description;@EmbedExternalViewExternalSourceThemeConverter() EmbedExternalViewExternalSourceTheme? get theme; Map<String, dynamic>? get $unknown;
+/// Create a copy of EmbedExternalViewExternalSource
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$EmbedExternalViewExternalSourceCopyWith<EmbedExternalViewExternalSource> get copyWith => _$EmbedExternalViewExternalSourceCopyWithImpl<EmbedExternalViewExternalSource>(this as EmbedExternalViewExternalSource, _$identity);
+
+  /// Serializes this EmbedExternalViewExternalSource to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is EmbedExternalViewExternalSource&&(identical(other.$type, $type) || other.$type == $type)&&(identical(other.uri, uri) || other.uri == uri)&&(identical(other.icon, icon) || other.icon == icon)&&(identical(other.title, title) || other.title == title)&&(identical(other.description, description) || other.description == description)&&(identical(other.theme, theme) || other.theme == theme)&&const DeepCollectionEquality().equals(other.$unknown, $unknown));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,$type,uri,icon,title,description,theme,const DeepCollectionEquality().hash($unknown));
+
+@override
+String toString() {
+  return 'EmbedExternalViewExternalSource(\$type: ${$type}, uri: $uri, icon: $icon, title: $title, description: $description, theme: $theme, \$unknown: ${$unknown})';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $EmbedExternalViewExternalSourceCopyWith<$Res>  {
+  factory $EmbedExternalViewExternalSourceCopyWith(EmbedExternalViewExternalSource value, $Res Function(EmbedExternalViewExternalSource) _then) = _$EmbedExternalViewExternalSourceCopyWithImpl;
+@useResult
+$Res call({
+ String $type, String uri, String? icon, String title, String? description,@EmbedExternalViewExternalSourceThemeConverter() EmbedExternalViewExternalSourceTheme? theme, Map<String, dynamic>? $unknown
+});
+
+
+$EmbedExternalViewExternalSourceThemeCopyWith<$Res>? get theme;
+
+}
+/// @nodoc
+class _$EmbedExternalViewExternalSourceCopyWithImpl<$Res>
+    implements $EmbedExternalViewExternalSourceCopyWith<$Res> {
+  _$EmbedExternalViewExternalSourceCopyWithImpl(this._self, this._then);
+
+  final EmbedExternalViewExternalSource _self;
+  final $Res Function(EmbedExternalViewExternalSource) _then;
+
+/// Create a copy of EmbedExternalViewExternalSource
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? $type = null,Object? uri = null,Object? icon = freezed,Object? title = null,Object? description = freezed,Object? theme = freezed,Object? $unknown = freezed,}) {
+  return _then(_self.copyWith(
+$type: null == $type ? _self.$type : $type // ignore: cast_nullable_to_non_nullable
+as String,uri: null == uri ? _self.uri : uri // ignore: cast_nullable_to_non_nullable
+as String,icon: freezed == icon ? _self.icon : icon // ignore: cast_nullable_to_non_nullable
+as String?,title: null == title ? _self.title : title // ignore: cast_nullable_to_non_nullable
+as String,description: freezed == description ? _self.description : description // ignore: cast_nullable_to_non_nullable
+as String?,theme: freezed == theme ? _self.theme : theme // ignore: cast_nullable_to_non_nullable
+as EmbedExternalViewExternalSourceTheme?,$unknown: freezed == $unknown ? _self.$unknown : $unknown // ignore: cast_nullable_to_non_nullable
+as Map<String, dynamic>?,
+  ));
+}
+/// Create a copy of EmbedExternalViewExternalSource
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$EmbedExternalViewExternalSourceThemeCopyWith<$Res>? get theme {
+    if (_self.theme == null) {
+    return null;
+  }
+
+  return $EmbedExternalViewExternalSourceThemeCopyWith<$Res>(_self.theme!, (value) {
+    return _then(_self.copyWith(theme: value));
+  });
+}
+}
+
+
+/// Adds pattern-matching-related methods to [EmbedExternalViewExternalSource].
+extension EmbedExternalViewExternalSourcePatterns on EmbedExternalViewExternalSource {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _EmbedExternalViewExternalSource value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _EmbedExternalViewExternalSource() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _EmbedExternalViewExternalSource value)  $default,){
+final _that = this;
+switch (_that) {
+case _EmbedExternalViewExternalSource():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _EmbedExternalViewExternalSource value)?  $default,){
+final _that = this;
+switch (_that) {
+case _EmbedExternalViewExternalSource() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String $type,  String uri,  String? icon,  String title,  String? description, @EmbedExternalViewExternalSourceThemeConverter()  EmbedExternalViewExternalSourceTheme? theme,  Map<String, dynamic>? $unknown)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _EmbedExternalViewExternalSource() when $default != null:
+return $default(_that.$type,_that.uri,_that.icon,_that.title,_that.description,_that.theme,_that.$unknown);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String $type,  String uri,  String? icon,  String title,  String? description, @EmbedExternalViewExternalSourceThemeConverter()  EmbedExternalViewExternalSourceTheme? theme,  Map<String, dynamic>? $unknown)  $default,) {final _that = this;
+switch (_that) {
+case _EmbedExternalViewExternalSource():
+return $default(_that.$type,_that.uri,_that.icon,_that.title,_that.description,_that.theme,_that.$unknown);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String $type,  String uri,  String? icon,  String title,  String? description, @EmbedExternalViewExternalSourceThemeConverter()  EmbedExternalViewExternalSourceTheme? theme,  Map<String, dynamic>? $unknown)?  $default,) {final _that = this;
+switch (_that) {
+case _EmbedExternalViewExternalSource() when $default != null:
+return $default(_that.$type,_that.uri,_that.icon,_that.title,_that.description,_that.theme,_that.$unknown);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+
+@JsonSerializable(includeIfNull: false)
+class _EmbedExternalViewExternalSource implements EmbedExternalViewExternalSource {
+  const _EmbedExternalViewExternalSource({this.$type = 'app.bsky.embed.external#viewExternalSource', required this.uri, this.icon, required this.title, this.description, @EmbedExternalViewExternalSourceThemeConverter() this.theme, final  Map<String, dynamic>? $unknown}): _$unknown = $unknown;
+  factory _EmbedExternalViewExternalSource.fromJson(Map<String, dynamic> json) => _$EmbedExternalViewExternalSourceFromJson(json);
+
+@override@JsonKey() final  String $type;
+/// URI of the source, if available. Example: the https:// URL of a site.standard.publication record.
+@override final  String uri;
+/// Fully-qualified URL where an icon representing the source can be fetched. For example, CDN location provided by the App View.
+@override final  String? icon;
+@override final  String title;
+@override final  String? description;
+@override@EmbedExternalViewExternalSourceThemeConverter() final  EmbedExternalViewExternalSourceTheme? theme;
+ final  Map<String, dynamic>? _$unknown;
+@override Map<String, dynamic>? get $unknown {
+  final value = _$unknown;
+  if (value == null) return null;
+  if (_$unknown is EqualUnmodifiableMapView) return _$unknown;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableMapView(value);
+}
+
+
+/// Create a copy of EmbedExternalViewExternalSource
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$EmbedExternalViewExternalSourceCopyWith<_EmbedExternalViewExternalSource> get copyWith => __$EmbedExternalViewExternalSourceCopyWithImpl<_EmbedExternalViewExternalSource>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$EmbedExternalViewExternalSourceToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _EmbedExternalViewExternalSource&&(identical(other.$type, $type) || other.$type == $type)&&(identical(other.uri, uri) || other.uri == uri)&&(identical(other.icon, icon) || other.icon == icon)&&(identical(other.title, title) || other.title == title)&&(identical(other.description, description) || other.description == description)&&(identical(other.theme, theme) || other.theme == theme)&&const DeepCollectionEquality().equals(other._$unknown, _$unknown));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,$type,uri,icon,title,description,theme,const DeepCollectionEquality().hash(_$unknown));
+
+@override
+String toString() {
+  return 'EmbedExternalViewExternalSource(\$type: ${$type}, uri: $uri, icon: $icon, title: $title, description: $description, theme: $theme, \$unknown: ${$unknown})';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$EmbedExternalViewExternalSourceCopyWith<$Res> implements $EmbedExternalViewExternalSourceCopyWith<$Res> {
+  factory _$EmbedExternalViewExternalSourceCopyWith(_EmbedExternalViewExternalSource value, $Res Function(_EmbedExternalViewExternalSource) _then) = __$EmbedExternalViewExternalSourceCopyWithImpl;
+@override @useResult
+$Res call({
+ String $type, String uri, String? icon, String title, String? description,@EmbedExternalViewExternalSourceThemeConverter() EmbedExternalViewExternalSourceTheme? theme, Map<String, dynamic>? $unknown
+});
+
+
+@override $EmbedExternalViewExternalSourceThemeCopyWith<$Res>? get theme;
+
+}
+/// @nodoc
+class __$EmbedExternalViewExternalSourceCopyWithImpl<$Res>
+    implements _$EmbedExternalViewExternalSourceCopyWith<$Res> {
+  __$EmbedExternalViewExternalSourceCopyWithImpl(this._self, this._then);
+
+  final _EmbedExternalViewExternalSource _self;
+  final $Res Function(_EmbedExternalViewExternalSource) _then;
+
+/// Create a copy of EmbedExternalViewExternalSource
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? $type = null,Object? uri = null,Object? icon = freezed,Object? title = null,Object? description = freezed,Object? theme = freezed,Object? $unknown = freezed,}) {
+  return _then(_EmbedExternalViewExternalSource(
+$type: null == $type ? _self.$type : $type // ignore: cast_nullable_to_non_nullable
+as String,uri: null == uri ? _self.uri : uri // ignore: cast_nullable_to_non_nullable
+as String,icon: freezed == icon ? _self.icon : icon // ignore: cast_nullable_to_non_nullable
+as String?,title: null == title ? _self.title : title // ignore: cast_nullable_to_non_nullable
+as String,description: freezed == description ? _self.description : description // ignore: cast_nullable_to_non_nullable
+as String?,theme: freezed == theme ? _self.theme : theme // ignore: cast_nullable_to_non_nullable
+as EmbedExternalViewExternalSourceTheme?,$unknown: freezed == $unknown ? _self._$unknown : $unknown // ignore: cast_nullable_to_non_nullable
+as Map<String, dynamic>?,
+  ));
+}
+
+/// Create a copy of EmbedExternalViewExternalSource
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$EmbedExternalViewExternalSourceThemeCopyWith<$Res>? get theme {
+    if (_self.theme == null) {
+    return null;
+  }
+
+  return $EmbedExternalViewExternalSourceThemeCopyWith<$Res>(_self.theme!, (value) {
+    return _then(_self.copyWith(theme: value));
+  });
+}
+}
+
+// dart format on

--- a/packages/bluesky/lib/src/services/codegen/app/bsky/embed/external/view_external_source.g.dart
+++ b/packages/bluesky/lib/src/services/codegen/app/bsky/embed/external/view_external_source.g.dart
@@ -1,0 +1,68 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: non_constant_identifier_names
+
+part of 'view_external_source.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_EmbedExternalViewExternalSource _$EmbedExternalViewExternalSourceFromJson(
+  Map json,
+) => $checkedCreate('_EmbedExternalViewExternalSource', json, (
+  $checkedConvert,
+) {
+  final val = _EmbedExternalViewExternalSource(
+    $type: $checkedConvert(
+      r'$type',
+      (v) => v as String? ?? 'app.bsky.embed.external#viewExternalSource',
+    ),
+    uri: $checkedConvert('uri', (v) => v as String),
+    icon: $checkedConvert('icon', (v) => v as String?),
+    title: $checkedConvert('title', (v) => v as String),
+    description: $checkedConvert('description', (v) => v as String?),
+    theme: $checkedConvert(
+      'theme',
+      (v) =>
+          _$JsonConverterFromJson<
+            Map<String, dynamic>,
+            EmbedExternalViewExternalSourceTheme
+          >(v, const EmbedExternalViewExternalSourceThemeConverter().fromJson),
+    ),
+    $unknown: $checkedConvert(
+      r'$unknown',
+      (v) => (v as Map?)?.map((k, e) => MapEntry(k as String, e)),
+    ),
+  );
+  return val;
+});
+
+Map<String, dynamic> _$EmbedExternalViewExternalSourceToJson(
+  _EmbedExternalViewExternalSource instance,
+) => <String, dynamic>{
+  r'$type': instance.$type,
+  'uri': instance.uri,
+  'icon': ?instance.icon,
+  'title': instance.title,
+  'description': ?instance.description,
+  'theme':
+      ?_$JsonConverterToJson<
+        Map<String, dynamic>,
+        EmbedExternalViewExternalSourceTheme
+      >(
+        instance.theme,
+        const EmbedExternalViewExternalSourceThemeConverter().toJson,
+      ),
+  r'$unknown': ?instance.$unknown,
+};
+
+Value? _$JsonConverterFromJson<Json, Value>(
+  Object? json,
+  Value? Function(Json json) fromJson,
+) => json == null ? null : fromJson(json as Json);
+
+Json? _$JsonConverterToJson<Json, Value>(
+  Value? value,
+  Json? Function(Value value) toJson,
+) => value == null ? null : toJson(value);

--- a/packages/bluesky/lib/src/services/codegen/app/bsky/embed/external/view_external_source_theme.dart
+++ b/packages/bluesky/lib/src/services/codegen/app/bsky/embed/external/view_external_source_theme.dart
@@ -1,0 +1,88 @@
+// Copyright (c) 2023-2026, Shinya Kato.
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+// Package imports:
+import 'package:atproto_core/internals.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+// Project imports:
+import './color_r_g_b.dart';
+
+part 'view_external_source_theme.freezed.dart';
+part 'view_external_source_theme.g.dart';
+
+// **************************************************************************
+// LexGenerator
+// **************************************************************************
+
+/// The theme colors of an external source, such as a site.standard.publication. These colors may be used when rendering an embed from that source.
+@freezed
+abstract class EmbedExternalViewExternalSourceTheme
+    with _$EmbedExternalViewExternalSourceTheme {
+  static const knownProps = <String>[
+    'backgroundRGB',
+    'foregroundRGB',
+    'accentRGB',
+    'accentForegroundRGB',
+  ];
+
+  @JsonSerializable(includeIfNull: false)
+  const factory EmbedExternalViewExternalSourceTheme({
+    @Default('app.bsky.embed.external#viewExternalSourceTheme') String $type,
+    @EmbedExternalColorRGBConverter() EmbedExternalColorRGB? backgroundRGB,
+    @EmbedExternalColorRGBConverter() EmbedExternalColorRGB? foregroundRGB,
+    @EmbedExternalColorRGBConverter() EmbedExternalColorRGB? accentRGB,
+    @EmbedExternalColorRGBConverter()
+    EmbedExternalColorRGB? accentForegroundRGB,
+
+    Map<String, dynamic>? $unknown,
+  }) = _EmbedExternalViewExternalSourceTheme;
+
+  factory EmbedExternalViewExternalSourceTheme.fromJson(
+    Map<String, Object?> json,
+  ) => _$EmbedExternalViewExternalSourceThemeFromJson(json);
+
+  static bool validate(final Map<String, dynamic> object) {
+    if (!object.containsKey('\$type')) return false;
+    return object['\$type'] ==
+        'app.bsky.embed.external#viewExternalSourceTheme';
+  }
+}
+
+extension EmbedExternalViewExternalSourceThemeExtension
+    on EmbedExternalViewExternalSourceTheme {
+  bool get hasBackgroundRGB => backgroundRGB != null;
+  bool get hasNotBackgroundRGB => !hasBackgroundRGB;
+  bool get hasForegroundRGB => foregroundRGB != null;
+  bool get hasNotForegroundRGB => !hasForegroundRGB;
+  bool get hasAccentRGB => accentRGB != null;
+  bool get hasNotAccentRGB => !hasAccentRGB;
+  bool get hasAccentForegroundRGB => accentForegroundRGB != null;
+  bool get hasNotAccentForegroundRGB => !hasAccentForegroundRGB;
+}
+
+final class EmbedExternalViewExternalSourceThemeConverter
+    extends
+        JsonConverter<
+          EmbedExternalViewExternalSourceTheme,
+          Map<String, dynamic>
+        > {
+  const EmbedExternalViewExternalSourceThemeConverter();
+
+  @override
+  EmbedExternalViewExternalSourceTheme fromJson(Map<String, dynamic> json) {
+    return EmbedExternalViewExternalSourceTheme.fromJson(
+      translate(json, EmbedExternalViewExternalSourceTheme.knownProps),
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson(EmbedExternalViewExternalSourceTheme object) =>
+      untranslate(object.toJson());
+}

--- a/packages/bluesky/lib/src/services/codegen/app/bsky/embed/external/view_external_source_theme.freezed.dart
+++ b/packages/bluesky/lib/src/services/codegen/app/bsky/embed/external/view_external_source_theme.freezed.dart
@@ -1,0 +1,396 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'view_external_source_theme.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$EmbedExternalViewExternalSourceTheme {
+
+ String get $type;@EmbedExternalColorRGBConverter() EmbedExternalColorRGB? get backgroundRGB;@EmbedExternalColorRGBConverter() EmbedExternalColorRGB? get foregroundRGB;@EmbedExternalColorRGBConverter() EmbedExternalColorRGB? get accentRGB;@EmbedExternalColorRGBConverter() EmbedExternalColorRGB? get accentForegroundRGB; Map<String, dynamic>? get $unknown;
+/// Create a copy of EmbedExternalViewExternalSourceTheme
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$EmbedExternalViewExternalSourceThemeCopyWith<EmbedExternalViewExternalSourceTheme> get copyWith => _$EmbedExternalViewExternalSourceThemeCopyWithImpl<EmbedExternalViewExternalSourceTheme>(this as EmbedExternalViewExternalSourceTheme, _$identity);
+
+  /// Serializes this EmbedExternalViewExternalSourceTheme to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is EmbedExternalViewExternalSourceTheme&&(identical(other.$type, $type) || other.$type == $type)&&(identical(other.backgroundRGB, backgroundRGB) || other.backgroundRGB == backgroundRGB)&&(identical(other.foregroundRGB, foregroundRGB) || other.foregroundRGB == foregroundRGB)&&(identical(other.accentRGB, accentRGB) || other.accentRGB == accentRGB)&&(identical(other.accentForegroundRGB, accentForegroundRGB) || other.accentForegroundRGB == accentForegroundRGB)&&const DeepCollectionEquality().equals(other.$unknown, $unknown));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,$type,backgroundRGB,foregroundRGB,accentRGB,accentForegroundRGB,const DeepCollectionEquality().hash($unknown));
+
+@override
+String toString() {
+  return 'EmbedExternalViewExternalSourceTheme(\$type: ${$type}, backgroundRGB: $backgroundRGB, foregroundRGB: $foregroundRGB, accentRGB: $accentRGB, accentForegroundRGB: $accentForegroundRGB, \$unknown: ${$unknown})';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $EmbedExternalViewExternalSourceThemeCopyWith<$Res>  {
+  factory $EmbedExternalViewExternalSourceThemeCopyWith(EmbedExternalViewExternalSourceTheme value, $Res Function(EmbedExternalViewExternalSourceTheme) _then) = _$EmbedExternalViewExternalSourceThemeCopyWithImpl;
+@useResult
+$Res call({
+ String $type,@EmbedExternalColorRGBConverter() EmbedExternalColorRGB? backgroundRGB,@EmbedExternalColorRGBConverter() EmbedExternalColorRGB? foregroundRGB,@EmbedExternalColorRGBConverter() EmbedExternalColorRGB? accentRGB,@EmbedExternalColorRGBConverter() EmbedExternalColorRGB? accentForegroundRGB, Map<String, dynamic>? $unknown
+});
+
+
+$EmbedExternalColorRGBCopyWith<$Res>? get backgroundRGB;$EmbedExternalColorRGBCopyWith<$Res>? get foregroundRGB;$EmbedExternalColorRGBCopyWith<$Res>? get accentRGB;$EmbedExternalColorRGBCopyWith<$Res>? get accentForegroundRGB;
+
+}
+/// @nodoc
+class _$EmbedExternalViewExternalSourceThemeCopyWithImpl<$Res>
+    implements $EmbedExternalViewExternalSourceThemeCopyWith<$Res> {
+  _$EmbedExternalViewExternalSourceThemeCopyWithImpl(this._self, this._then);
+
+  final EmbedExternalViewExternalSourceTheme _self;
+  final $Res Function(EmbedExternalViewExternalSourceTheme) _then;
+
+/// Create a copy of EmbedExternalViewExternalSourceTheme
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? $type = null,Object? backgroundRGB = freezed,Object? foregroundRGB = freezed,Object? accentRGB = freezed,Object? accentForegroundRGB = freezed,Object? $unknown = freezed,}) {
+  return _then(_self.copyWith(
+$type: null == $type ? _self.$type : $type // ignore: cast_nullable_to_non_nullable
+as String,backgroundRGB: freezed == backgroundRGB ? _self.backgroundRGB : backgroundRGB // ignore: cast_nullable_to_non_nullable
+as EmbedExternalColorRGB?,foregroundRGB: freezed == foregroundRGB ? _self.foregroundRGB : foregroundRGB // ignore: cast_nullable_to_non_nullable
+as EmbedExternalColorRGB?,accentRGB: freezed == accentRGB ? _self.accentRGB : accentRGB // ignore: cast_nullable_to_non_nullable
+as EmbedExternalColorRGB?,accentForegroundRGB: freezed == accentForegroundRGB ? _self.accentForegroundRGB : accentForegroundRGB // ignore: cast_nullable_to_non_nullable
+as EmbedExternalColorRGB?,$unknown: freezed == $unknown ? _self.$unknown : $unknown // ignore: cast_nullable_to_non_nullable
+as Map<String, dynamic>?,
+  ));
+}
+/// Create a copy of EmbedExternalViewExternalSourceTheme
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$EmbedExternalColorRGBCopyWith<$Res>? get backgroundRGB {
+    if (_self.backgroundRGB == null) {
+    return null;
+  }
+
+  return $EmbedExternalColorRGBCopyWith<$Res>(_self.backgroundRGB!, (value) {
+    return _then(_self.copyWith(backgroundRGB: value));
+  });
+}/// Create a copy of EmbedExternalViewExternalSourceTheme
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$EmbedExternalColorRGBCopyWith<$Res>? get foregroundRGB {
+    if (_self.foregroundRGB == null) {
+    return null;
+  }
+
+  return $EmbedExternalColorRGBCopyWith<$Res>(_self.foregroundRGB!, (value) {
+    return _then(_self.copyWith(foregroundRGB: value));
+  });
+}/// Create a copy of EmbedExternalViewExternalSourceTheme
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$EmbedExternalColorRGBCopyWith<$Res>? get accentRGB {
+    if (_self.accentRGB == null) {
+    return null;
+  }
+
+  return $EmbedExternalColorRGBCopyWith<$Res>(_self.accentRGB!, (value) {
+    return _then(_self.copyWith(accentRGB: value));
+  });
+}/// Create a copy of EmbedExternalViewExternalSourceTheme
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$EmbedExternalColorRGBCopyWith<$Res>? get accentForegroundRGB {
+    if (_self.accentForegroundRGB == null) {
+    return null;
+  }
+
+  return $EmbedExternalColorRGBCopyWith<$Res>(_self.accentForegroundRGB!, (value) {
+    return _then(_self.copyWith(accentForegroundRGB: value));
+  });
+}
+}
+
+
+/// Adds pattern-matching-related methods to [EmbedExternalViewExternalSourceTheme].
+extension EmbedExternalViewExternalSourceThemePatterns on EmbedExternalViewExternalSourceTheme {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _EmbedExternalViewExternalSourceTheme value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _EmbedExternalViewExternalSourceTheme() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _EmbedExternalViewExternalSourceTheme value)  $default,){
+final _that = this;
+switch (_that) {
+case _EmbedExternalViewExternalSourceTheme():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _EmbedExternalViewExternalSourceTheme value)?  $default,){
+final _that = this;
+switch (_that) {
+case _EmbedExternalViewExternalSourceTheme() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String $type, @EmbedExternalColorRGBConverter()  EmbedExternalColorRGB? backgroundRGB, @EmbedExternalColorRGBConverter()  EmbedExternalColorRGB? foregroundRGB, @EmbedExternalColorRGBConverter()  EmbedExternalColorRGB? accentRGB, @EmbedExternalColorRGBConverter()  EmbedExternalColorRGB? accentForegroundRGB,  Map<String, dynamic>? $unknown)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _EmbedExternalViewExternalSourceTheme() when $default != null:
+return $default(_that.$type,_that.backgroundRGB,_that.foregroundRGB,_that.accentRGB,_that.accentForegroundRGB,_that.$unknown);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String $type, @EmbedExternalColorRGBConverter()  EmbedExternalColorRGB? backgroundRGB, @EmbedExternalColorRGBConverter()  EmbedExternalColorRGB? foregroundRGB, @EmbedExternalColorRGBConverter()  EmbedExternalColorRGB? accentRGB, @EmbedExternalColorRGBConverter()  EmbedExternalColorRGB? accentForegroundRGB,  Map<String, dynamic>? $unknown)  $default,) {final _that = this;
+switch (_that) {
+case _EmbedExternalViewExternalSourceTheme():
+return $default(_that.$type,_that.backgroundRGB,_that.foregroundRGB,_that.accentRGB,_that.accentForegroundRGB,_that.$unknown);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String $type, @EmbedExternalColorRGBConverter()  EmbedExternalColorRGB? backgroundRGB, @EmbedExternalColorRGBConverter()  EmbedExternalColorRGB? foregroundRGB, @EmbedExternalColorRGBConverter()  EmbedExternalColorRGB? accentRGB, @EmbedExternalColorRGBConverter()  EmbedExternalColorRGB? accentForegroundRGB,  Map<String, dynamic>? $unknown)?  $default,) {final _that = this;
+switch (_that) {
+case _EmbedExternalViewExternalSourceTheme() when $default != null:
+return $default(_that.$type,_that.backgroundRGB,_that.foregroundRGB,_that.accentRGB,_that.accentForegroundRGB,_that.$unknown);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+
+@JsonSerializable(includeIfNull: false)
+class _EmbedExternalViewExternalSourceTheme implements EmbedExternalViewExternalSourceTheme {
+  const _EmbedExternalViewExternalSourceTheme({this.$type = 'app.bsky.embed.external#viewExternalSourceTheme', @EmbedExternalColorRGBConverter() this.backgroundRGB, @EmbedExternalColorRGBConverter() this.foregroundRGB, @EmbedExternalColorRGBConverter() this.accentRGB, @EmbedExternalColorRGBConverter() this.accentForegroundRGB, final  Map<String, dynamic>? $unknown}): _$unknown = $unknown;
+  factory _EmbedExternalViewExternalSourceTheme.fromJson(Map<String, dynamic> json) => _$EmbedExternalViewExternalSourceThemeFromJson(json);
+
+@override@JsonKey() final  String $type;
+@override@EmbedExternalColorRGBConverter() final  EmbedExternalColorRGB? backgroundRGB;
+@override@EmbedExternalColorRGBConverter() final  EmbedExternalColorRGB? foregroundRGB;
+@override@EmbedExternalColorRGBConverter() final  EmbedExternalColorRGB? accentRGB;
+@override@EmbedExternalColorRGBConverter() final  EmbedExternalColorRGB? accentForegroundRGB;
+ final  Map<String, dynamic>? _$unknown;
+@override Map<String, dynamic>? get $unknown {
+  final value = _$unknown;
+  if (value == null) return null;
+  if (_$unknown is EqualUnmodifiableMapView) return _$unknown;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableMapView(value);
+}
+
+
+/// Create a copy of EmbedExternalViewExternalSourceTheme
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$EmbedExternalViewExternalSourceThemeCopyWith<_EmbedExternalViewExternalSourceTheme> get copyWith => __$EmbedExternalViewExternalSourceThemeCopyWithImpl<_EmbedExternalViewExternalSourceTheme>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$EmbedExternalViewExternalSourceThemeToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _EmbedExternalViewExternalSourceTheme&&(identical(other.$type, $type) || other.$type == $type)&&(identical(other.backgroundRGB, backgroundRGB) || other.backgroundRGB == backgroundRGB)&&(identical(other.foregroundRGB, foregroundRGB) || other.foregroundRGB == foregroundRGB)&&(identical(other.accentRGB, accentRGB) || other.accentRGB == accentRGB)&&(identical(other.accentForegroundRGB, accentForegroundRGB) || other.accentForegroundRGB == accentForegroundRGB)&&const DeepCollectionEquality().equals(other._$unknown, _$unknown));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,$type,backgroundRGB,foregroundRGB,accentRGB,accentForegroundRGB,const DeepCollectionEquality().hash(_$unknown));
+
+@override
+String toString() {
+  return 'EmbedExternalViewExternalSourceTheme(\$type: ${$type}, backgroundRGB: $backgroundRGB, foregroundRGB: $foregroundRGB, accentRGB: $accentRGB, accentForegroundRGB: $accentForegroundRGB, \$unknown: ${$unknown})';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$EmbedExternalViewExternalSourceThemeCopyWith<$Res> implements $EmbedExternalViewExternalSourceThemeCopyWith<$Res> {
+  factory _$EmbedExternalViewExternalSourceThemeCopyWith(_EmbedExternalViewExternalSourceTheme value, $Res Function(_EmbedExternalViewExternalSourceTheme) _then) = __$EmbedExternalViewExternalSourceThemeCopyWithImpl;
+@override @useResult
+$Res call({
+ String $type,@EmbedExternalColorRGBConverter() EmbedExternalColorRGB? backgroundRGB,@EmbedExternalColorRGBConverter() EmbedExternalColorRGB? foregroundRGB,@EmbedExternalColorRGBConverter() EmbedExternalColorRGB? accentRGB,@EmbedExternalColorRGBConverter() EmbedExternalColorRGB? accentForegroundRGB, Map<String, dynamic>? $unknown
+});
+
+
+@override $EmbedExternalColorRGBCopyWith<$Res>? get backgroundRGB;@override $EmbedExternalColorRGBCopyWith<$Res>? get foregroundRGB;@override $EmbedExternalColorRGBCopyWith<$Res>? get accentRGB;@override $EmbedExternalColorRGBCopyWith<$Res>? get accentForegroundRGB;
+
+}
+/// @nodoc
+class __$EmbedExternalViewExternalSourceThemeCopyWithImpl<$Res>
+    implements _$EmbedExternalViewExternalSourceThemeCopyWith<$Res> {
+  __$EmbedExternalViewExternalSourceThemeCopyWithImpl(this._self, this._then);
+
+  final _EmbedExternalViewExternalSourceTheme _self;
+  final $Res Function(_EmbedExternalViewExternalSourceTheme) _then;
+
+/// Create a copy of EmbedExternalViewExternalSourceTheme
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? $type = null,Object? backgroundRGB = freezed,Object? foregroundRGB = freezed,Object? accentRGB = freezed,Object? accentForegroundRGB = freezed,Object? $unknown = freezed,}) {
+  return _then(_EmbedExternalViewExternalSourceTheme(
+$type: null == $type ? _self.$type : $type // ignore: cast_nullable_to_non_nullable
+as String,backgroundRGB: freezed == backgroundRGB ? _self.backgroundRGB : backgroundRGB // ignore: cast_nullable_to_non_nullable
+as EmbedExternalColorRGB?,foregroundRGB: freezed == foregroundRGB ? _self.foregroundRGB : foregroundRGB // ignore: cast_nullable_to_non_nullable
+as EmbedExternalColorRGB?,accentRGB: freezed == accentRGB ? _self.accentRGB : accentRGB // ignore: cast_nullable_to_non_nullable
+as EmbedExternalColorRGB?,accentForegroundRGB: freezed == accentForegroundRGB ? _self.accentForegroundRGB : accentForegroundRGB // ignore: cast_nullable_to_non_nullable
+as EmbedExternalColorRGB?,$unknown: freezed == $unknown ? _self._$unknown : $unknown // ignore: cast_nullable_to_non_nullable
+as Map<String, dynamic>?,
+  ));
+}
+
+/// Create a copy of EmbedExternalViewExternalSourceTheme
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$EmbedExternalColorRGBCopyWith<$Res>? get backgroundRGB {
+    if (_self.backgroundRGB == null) {
+    return null;
+  }
+
+  return $EmbedExternalColorRGBCopyWith<$Res>(_self.backgroundRGB!, (value) {
+    return _then(_self.copyWith(backgroundRGB: value));
+  });
+}/// Create a copy of EmbedExternalViewExternalSourceTheme
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$EmbedExternalColorRGBCopyWith<$Res>? get foregroundRGB {
+    if (_self.foregroundRGB == null) {
+    return null;
+  }
+
+  return $EmbedExternalColorRGBCopyWith<$Res>(_self.foregroundRGB!, (value) {
+    return _then(_self.copyWith(foregroundRGB: value));
+  });
+}/// Create a copy of EmbedExternalViewExternalSourceTheme
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$EmbedExternalColorRGBCopyWith<$Res>? get accentRGB {
+    if (_self.accentRGB == null) {
+    return null;
+  }
+
+  return $EmbedExternalColorRGBCopyWith<$Res>(_self.accentRGB!, (value) {
+    return _then(_self.copyWith(accentRGB: value));
+  });
+}/// Create a copy of EmbedExternalViewExternalSourceTheme
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$EmbedExternalColorRGBCopyWith<$Res>? get accentForegroundRGB {
+    if (_self.accentForegroundRGB == null) {
+    return null;
+  }
+
+  return $EmbedExternalColorRGBCopyWith<$Res>(_self.accentForegroundRGB!, (value) {
+    return _then(_self.copyWith(accentForegroundRGB: value));
+  });
+}
+}
+
+// dart format on

--- a/packages/bluesky/lib/src/services/codegen/app/bsky/embed/external/view_external_source_theme.g.dart
+++ b/packages/bluesky/lib/src/services/codegen/app/bsky/embed/external/view_external_source_theme.g.dart
@@ -1,0 +1,97 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: non_constant_identifier_names
+
+part of 'view_external_source_theme.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_EmbedExternalViewExternalSourceTheme
+_$EmbedExternalViewExternalSourceThemeFromJson(
+  Map json,
+) => $checkedCreate('_EmbedExternalViewExternalSourceTheme', json, (
+  $checkedConvert,
+) {
+  final val = _EmbedExternalViewExternalSourceTheme(
+    $type: $checkedConvert(
+      r'$type',
+      (v) => v as String? ?? 'app.bsky.embed.external#viewExternalSourceTheme',
+    ),
+    backgroundRGB: $checkedConvert(
+      'backgroundRGB',
+      (v) =>
+          _$JsonConverterFromJson<Map<String, dynamic>, EmbedExternalColorRGB>(
+            v,
+            const EmbedExternalColorRGBConverter().fromJson,
+          ),
+    ),
+    foregroundRGB: $checkedConvert(
+      'foregroundRGB',
+      (v) =>
+          _$JsonConverterFromJson<Map<String, dynamic>, EmbedExternalColorRGB>(
+            v,
+            const EmbedExternalColorRGBConverter().fromJson,
+          ),
+    ),
+    accentRGB: $checkedConvert(
+      'accentRGB',
+      (v) =>
+          _$JsonConverterFromJson<Map<String, dynamic>, EmbedExternalColorRGB>(
+            v,
+            const EmbedExternalColorRGBConverter().fromJson,
+          ),
+    ),
+    accentForegroundRGB: $checkedConvert(
+      'accentForegroundRGB',
+      (v) =>
+          _$JsonConverterFromJson<Map<String, dynamic>, EmbedExternalColorRGB>(
+            v,
+            const EmbedExternalColorRGBConverter().fromJson,
+          ),
+    ),
+    $unknown: $checkedConvert(
+      r'$unknown',
+      (v) => (v as Map?)?.map((k, e) => MapEntry(k as String, e)),
+    ),
+  );
+  return val;
+});
+
+Map<String, dynamic> _$EmbedExternalViewExternalSourceThemeToJson(
+  _EmbedExternalViewExternalSourceTheme instance,
+) => <String, dynamic>{
+  r'$type': instance.$type,
+  'backgroundRGB':
+      ?_$JsonConverterToJson<Map<String, dynamic>, EmbedExternalColorRGB>(
+        instance.backgroundRGB,
+        const EmbedExternalColorRGBConverter().toJson,
+      ),
+  'foregroundRGB':
+      ?_$JsonConverterToJson<Map<String, dynamic>, EmbedExternalColorRGB>(
+        instance.foregroundRGB,
+        const EmbedExternalColorRGBConverter().toJson,
+      ),
+  'accentRGB':
+      ?_$JsonConverterToJson<Map<String, dynamic>, EmbedExternalColorRGB>(
+        instance.accentRGB,
+        const EmbedExternalColorRGBConverter().toJson,
+      ),
+  'accentForegroundRGB':
+      ?_$JsonConverterToJson<Map<String, dynamic>, EmbedExternalColorRGB>(
+        instance.accentForegroundRGB,
+        const EmbedExternalColorRGBConverter().toJson,
+      ),
+  r'$unknown': ?instance.$unknown,
+};
+
+Value? _$JsonConverterFromJson<Json, Value>(
+  Object? json,
+  Value? Function(Json json) fromJson,
+) => json == null ? null : fromJson(json as Json);
+
+Json? _$JsonConverterToJson<Json, Value>(
+  Value? value,
+  Json? Function(Value value) toJson,
+) => value == null ? null : toJson(value);

--- a/packages/bluesky/lib/src/services/codegen/app/bsky/embed/getEmbedExternalView/input.dart
+++ b/packages/bluesky/lib/src/services/codegen/app/bsky/embed/getEmbedExternalView/input.dart
@@ -1,0 +1,55 @@
+// Copyright (c) 2023-2026, Shinya Kato.
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+// Package imports:
+import 'package:atproto_core/atproto_core.dart';
+import 'package:atproto_core/internals.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'input.freezed.dart';
+part 'input.g.dart';
+
+// **************************************************************************
+// LexGenerator
+// **************************************************************************
+
+@freezed
+abstract class EmbedGetEmbedExternalViewInput
+    with _$EmbedGetEmbedExternalViewInput {
+  static const knownProps = <String>['url', 'uris'];
+
+  @JsonSerializable(includeIfNull: false)
+  const factory EmbedGetEmbedExternalViewInput({
+    /// The canonical web URL the embed represents (typically the URL the user pasted into the composer). Used as the returned view's `uri`. May be used for validation in the future.
+    required String url,
+    @AtUriConverter() required List<AtUri> uris,
+
+    Map<String, dynamic>? $unknown,
+  }) = _EmbedGetEmbedExternalViewInput;
+
+  factory EmbedGetEmbedExternalViewInput.fromJson(Map<String, Object?> json) =>
+      _$EmbedGetEmbedExternalViewInputFromJson(json);
+}
+
+final class EmbedGetEmbedExternalViewInputConverter
+    extends
+        JsonConverter<EmbedGetEmbedExternalViewInput, Map<String, dynamic>> {
+  const EmbedGetEmbedExternalViewInputConverter();
+
+  @override
+  EmbedGetEmbedExternalViewInput fromJson(Map<String, dynamic> json) {
+    return EmbedGetEmbedExternalViewInput.fromJson(
+      translate(json, EmbedGetEmbedExternalViewInput.knownProps),
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson(EmbedGetEmbedExternalViewInput object) =>
+      untranslate(object.toJson());
+}

--- a/packages/bluesky/lib/src/services/codegen/app/bsky/embed/getEmbedExternalView/input.freezed.dart
+++ b/packages/bluesky/lib/src/services/codegen/app/bsky/embed/getEmbedExternalView/input.freezed.dart
@@ -1,0 +1,299 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'input.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$EmbedGetEmbedExternalViewInput {
+
+/// The canonical web URL the embed represents (typically the URL the user pasted into the composer). Used as the returned view's `uri`. May be used for validation in the future.
+ String get url;@AtUriConverter() List<AtUri> get uris; Map<String, dynamic>? get $unknown;
+/// Create a copy of EmbedGetEmbedExternalViewInput
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$EmbedGetEmbedExternalViewInputCopyWith<EmbedGetEmbedExternalViewInput> get copyWith => _$EmbedGetEmbedExternalViewInputCopyWithImpl<EmbedGetEmbedExternalViewInput>(this as EmbedGetEmbedExternalViewInput, _$identity);
+
+  /// Serializes this EmbedGetEmbedExternalViewInput to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is EmbedGetEmbedExternalViewInput&&(identical(other.url, url) || other.url == url)&&const DeepCollectionEquality().equals(other.uris, uris)&&const DeepCollectionEquality().equals(other.$unknown, $unknown));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,url,const DeepCollectionEquality().hash(uris),const DeepCollectionEquality().hash($unknown));
+
+@override
+String toString() {
+  return 'EmbedGetEmbedExternalViewInput(url: $url, uris: $uris, \$unknown: ${$unknown})';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $EmbedGetEmbedExternalViewInputCopyWith<$Res>  {
+  factory $EmbedGetEmbedExternalViewInputCopyWith(EmbedGetEmbedExternalViewInput value, $Res Function(EmbedGetEmbedExternalViewInput) _then) = _$EmbedGetEmbedExternalViewInputCopyWithImpl;
+@useResult
+$Res call({
+ String url,@AtUriConverter() List<AtUri> uris, Map<String, dynamic>? $unknown
+});
+
+
+
+
+}
+/// @nodoc
+class _$EmbedGetEmbedExternalViewInputCopyWithImpl<$Res>
+    implements $EmbedGetEmbedExternalViewInputCopyWith<$Res> {
+  _$EmbedGetEmbedExternalViewInputCopyWithImpl(this._self, this._then);
+
+  final EmbedGetEmbedExternalViewInput _self;
+  final $Res Function(EmbedGetEmbedExternalViewInput) _then;
+
+/// Create a copy of EmbedGetEmbedExternalViewInput
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? url = null,Object? uris = null,Object? $unknown = freezed,}) {
+  return _then(_self.copyWith(
+url: null == url ? _self.url : url // ignore: cast_nullable_to_non_nullable
+as String,uris: null == uris ? _self.uris : uris // ignore: cast_nullable_to_non_nullable
+as List<AtUri>,$unknown: freezed == $unknown ? _self.$unknown : $unknown // ignore: cast_nullable_to_non_nullable
+as Map<String, dynamic>?,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [EmbedGetEmbedExternalViewInput].
+extension EmbedGetEmbedExternalViewInputPatterns on EmbedGetEmbedExternalViewInput {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _EmbedGetEmbedExternalViewInput value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _EmbedGetEmbedExternalViewInput() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _EmbedGetEmbedExternalViewInput value)  $default,){
+final _that = this;
+switch (_that) {
+case _EmbedGetEmbedExternalViewInput():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _EmbedGetEmbedExternalViewInput value)?  $default,){
+final _that = this;
+switch (_that) {
+case _EmbedGetEmbedExternalViewInput() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String url, @AtUriConverter()  List<AtUri> uris,  Map<String, dynamic>? $unknown)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _EmbedGetEmbedExternalViewInput() when $default != null:
+return $default(_that.url,_that.uris,_that.$unknown);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String url, @AtUriConverter()  List<AtUri> uris,  Map<String, dynamic>? $unknown)  $default,) {final _that = this;
+switch (_that) {
+case _EmbedGetEmbedExternalViewInput():
+return $default(_that.url,_that.uris,_that.$unknown);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String url, @AtUriConverter()  List<AtUri> uris,  Map<String, dynamic>? $unknown)?  $default,) {final _that = this;
+switch (_that) {
+case _EmbedGetEmbedExternalViewInput() when $default != null:
+return $default(_that.url,_that.uris,_that.$unknown);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+
+@JsonSerializable(includeIfNull: false)
+class _EmbedGetEmbedExternalViewInput implements EmbedGetEmbedExternalViewInput {
+  const _EmbedGetEmbedExternalViewInput({required this.url, @AtUriConverter() required final  List<AtUri> uris, final  Map<String, dynamic>? $unknown}): _uris = uris,_$unknown = $unknown;
+  factory _EmbedGetEmbedExternalViewInput.fromJson(Map<String, dynamic> json) => _$EmbedGetEmbedExternalViewInputFromJson(json);
+
+/// The canonical web URL the embed represents (typically the URL the user pasted into the composer). Used as the returned view's `uri`. May be used for validation in the future.
+@override final  String url;
+ final  List<AtUri> _uris;
+@override@AtUriConverter() List<AtUri> get uris {
+  if (_uris is EqualUnmodifiableListView) return _uris;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_uris);
+}
+
+ final  Map<String, dynamic>? _$unknown;
+@override Map<String, dynamic>? get $unknown {
+  final value = _$unknown;
+  if (value == null) return null;
+  if (_$unknown is EqualUnmodifiableMapView) return _$unknown;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableMapView(value);
+}
+
+
+/// Create a copy of EmbedGetEmbedExternalViewInput
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$EmbedGetEmbedExternalViewInputCopyWith<_EmbedGetEmbedExternalViewInput> get copyWith => __$EmbedGetEmbedExternalViewInputCopyWithImpl<_EmbedGetEmbedExternalViewInput>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$EmbedGetEmbedExternalViewInputToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _EmbedGetEmbedExternalViewInput&&(identical(other.url, url) || other.url == url)&&const DeepCollectionEquality().equals(other._uris, _uris)&&const DeepCollectionEquality().equals(other._$unknown, _$unknown));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,url,const DeepCollectionEquality().hash(_uris),const DeepCollectionEquality().hash(_$unknown));
+
+@override
+String toString() {
+  return 'EmbedGetEmbedExternalViewInput(url: $url, uris: $uris, \$unknown: ${$unknown})';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$EmbedGetEmbedExternalViewInputCopyWith<$Res> implements $EmbedGetEmbedExternalViewInputCopyWith<$Res> {
+  factory _$EmbedGetEmbedExternalViewInputCopyWith(_EmbedGetEmbedExternalViewInput value, $Res Function(_EmbedGetEmbedExternalViewInput) _then) = __$EmbedGetEmbedExternalViewInputCopyWithImpl;
+@override @useResult
+$Res call({
+ String url,@AtUriConverter() List<AtUri> uris, Map<String, dynamic>? $unknown
+});
+
+
+
+
+}
+/// @nodoc
+class __$EmbedGetEmbedExternalViewInputCopyWithImpl<$Res>
+    implements _$EmbedGetEmbedExternalViewInputCopyWith<$Res> {
+  __$EmbedGetEmbedExternalViewInputCopyWithImpl(this._self, this._then);
+
+  final _EmbedGetEmbedExternalViewInput _self;
+  final $Res Function(_EmbedGetEmbedExternalViewInput) _then;
+
+/// Create a copy of EmbedGetEmbedExternalViewInput
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? url = null,Object? uris = null,Object? $unknown = freezed,}) {
+  return _then(_EmbedGetEmbedExternalViewInput(
+url: null == url ? _self.url : url // ignore: cast_nullable_to_non_nullable
+as String,uris: null == uris ? _self._uris : uris // ignore: cast_nullable_to_non_nullable
+as List<AtUri>,$unknown: freezed == $unknown ? _self._$unknown : $unknown // ignore: cast_nullable_to_non_nullable
+as Map<String, dynamic>?,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/packages/bluesky/lib/src/services/codegen/app/bsky/embed/getEmbedExternalView/input.g.dart
+++ b/packages/bluesky/lib/src/services/codegen/app/bsky/embed/getEmbedExternalView/input.g.dart
@@ -1,0 +1,36 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: non_constant_identifier_names
+
+part of 'input.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_EmbedGetEmbedExternalViewInput _$EmbedGetEmbedExternalViewInputFromJson(
+  Map json,
+) => $checkedCreate('_EmbedGetEmbedExternalViewInput', json, ($checkedConvert) {
+  final val = _EmbedGetEmbedExternalViewInput(
+    url: $checkedConvert('url', (v) => v as String),
+    uris: $checkedConvert(
+      'uris',
+      (v) => (v as List<dynamic>)
+          .map((e) => const AtUriConverter().fromJson(e as String))
+          .toList(),
+    ),
+    $unknown: $checkedConvert(
+      r'$unknown',
+      (v) => (v as Map?)?.map((k, e) => MapEntry(k as String, e)),
+    ),
+  );
+  return val;
+});
+
+Map<String, dynamic> _$EmbedGetEmbedExternalViewInputToJson(
+  _EmbedGetEmbedExternalViewInput instance,
+) => <String, dynamic>{
+  'url': instance.url,
+  'uris': instance.uris.map(const AtUriConverter().toJson).toList(),
+  r'$unknown': ?instance.$unknown,
+};

--- a/packages/bluesky/lib/src/services/codegen/app/bsky/embed/getEmbedExternalView/output.dart
+++ b/packages/bluesky/lib/src/services/codegen/app/bsky/embed/getEmbedExternalView/output.dart
@@ -1,0 +1,69 @@
+// Copyright (c) 2023-2026, Shinya Kato.
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+// Package imports:
+import 'package:atproto/com_atproto_repo_strongref.dart';
+import 'package:atproto_core/internals.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+// Project imports:
+import '../../../../app/bsky/embed/external/view.dart';
+
+part 'output.freezed.dart';
+part 'output.g.dart';
+
+// **************************************************************************
+// LexGenerator
+// **************************************************************************
+
+@freezed
+abstract class EmbedGetEmbedExternalViewOutput
+    with _$EmbedGetEmbedExternalViewOutput {
+  static const knownProps = <String>[
+    'view',
+    'associatedRefs',
+    'associatedRecords',
+  ];
+
+  @JsonSerializable(includeIfNull: false)
+  const factory EmbedGetEmbedExternalViewOutput({
+    /// Hydrated view of the embed. Present only when the resolved records back the requested URL and supply enough information to populate the required `viewExternal` fields. Omitted alongside the rest of the response when no records resolved or validation failed.
+    @EmbedExternalViewConverter() EmbedExternalView? view,
+    @RepoStrongRefConverter() List<RepoStrongRef>? associatedRefs,
+    List<Map<String, dynamic>>? associatedRecords,
+
+    Map<String, dynamic>? $unknown,
+  }) = _EmbedGetEmbedExternalViewOutput;
+
+  factory EmbedGetEmbedExternalViewOutput.fromJson(Map<String, Object?> json) =>
+      _$EmbedGetEmbedExternalViewOutputFromJson(json);
+}
+
+extension EmbedGetEmbedExternalViewOutputExtension
+    on EmbedGetEmbedExternalViewOutput {
+  bool get hasView => view != null;
+  bool get hasNotView => !hasView;
+}
+
+final class EmbedGetEmbedExternalViewOutputConverter
+    extends
+        JsonConverter<EmbedGetEmbedExternalViewOutput, Map<String, dynamic>> {
+  const EmbedGetEmbedExternalViewOutputConverter();
+
+  @override
+  EmbedGetEmbedExternalViewOutput fromJson(Map<String, dynamic> json) {
+    return EmbedGetEmbedExternalViewOutput.fromJson(
+      translate(json, EmbedGetEmbedExternalViewOutput.knownProps),
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson(EmbedGetEmbedExternalViewOutput object) =>
+      untranslate(object.toJson());
+}

--- a/packages/bluesky/lib/src/services/codegen/app/bsky/embed/getEmbedExternalView/output.freezed.dart
+++ b/packages/bluesky/lib/src/services/codegen/app/bsky/embed/getEmbedExternalView/output.freezed.dart
@@ -1,0 +1,336 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'output.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$EmbedGetEmbedExternalViewOutput {
+
+/// Hydrated view of the embed. Present only when the resolved records back the requested URL and supply enough information to populate the required `viewExternal` fields. Omitted alongside the rest of the response when no records resolved or validation failed.
+@EmbedExternalViewConverter() EmbedExternalView? get view;@RepoStrongRefConverter() List<RepoStrongRef>? get associatedRefs; List<Map<String, dynamic>>? get associatedRecords; Map<String, dynamic>? get $unknown;
+/// Create a copy of EmbedGetEmbedExternalViewOutput
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$EmbedGetEmbedExternalViewOutputCopyWith<EmbedGetEmbedExternalViewOutput> get copyWith => _$EmbedGetEmbedExternalViewOutputCopyWithImpl<EmbedGetEmbedExternalViewOutput>(this as EmbedGetEmbedExternalViewOutput, _$identity);
+
+  /// Serializes this EmbedGetEmbedExternalViewOutput to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is EmbedGetEmbedExternalViewOutput&&(identical(other.view, view) || other.view == view)&&const DeepCollectionEquality().equals(other.associatedRefs, associatedRefs)&&const DeepCollectionEquality().equals(other.associatedRecords, associatedRecords)&&const DeepCollectionEquality().equals(other.$unknown, $unknown));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,view,const DeepCollectionEquality().hash(associatedRefs),const DeepCollectionEquality().hash(associatedRecords),const DeepCollectionEquality().hash($unknown));
+
+@override
+String toString() {
+  return 'EmbedGetEmbedExternalViewOutput(view: $view, associatedRefs: $associatedRefs, associatedRecords: $associatedRecords, \$unknown: ${$unknown})';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $EmbedGetEmbedExternalViewOutputCopyWith<$Res>  {
+  factory $EmbedGetEmbedExternalViewOutputCopyWith(EmbedGetEmbedExternalViewOutput value, $Res Function(EmbedGetEmbedExternalViewOutput) _then) = _$EmbedGetEmbedExternalViewOutputCopyWithImpl;
+@useResult
+$Res call({
+@EmbedExternalViewConverter() EmbedExternalView? view,@RepoStrongRefConverter() List<RepoStrongRef>? associatedRefs, List<Map<String, dynamic>>? associatedRecords, Map<String, dynamic>? $unknown
+});
+
+
+$EmbedExternalViewCopyWith<$Res>? get view;
+
+}
+/// @nodoc
+class _$EmbedGetEmbedExternalViewOutputCopyWithImpl<$Res>
+    implements $EmbedGetEmbedExternalViewOutputCopyWith<$Res> {
+  _$EmbedGetEmbedExternalViewOutputCopyWithImpl(this._self, this._then);
+
+  final EmbedGetEmbedExternalViewOutput _self;
+  final $Res Function(EmbedGetEmbedExternalViewOutput) _then;
+
+/// Create a copy of EmbedGetEmbedExternalViewOutput
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? view = freezed,Object? associatedRefs = freezed,Object? associatedRecords = freezed,Object? $unknown = freezed,}) {
+  return _then(_self.copyWith(
+view: freezed == view ? _self.view : view // ignore: cast_nullable_to_non_nullable
+as EmbedExternalView?,associatedRefs: freezed == associatedRefs ? _self.associatedRefs : associatedRefs // ignore: cast_nullable_to_non_nullable
+as List<RepoStrongRef>?,associatedRecords: freezed == associatedRecords ? _self.associatedRecords : associatedRecords // ignore: cast_nullable_to_non_nullable
+as List<Map<String, dynamic>>?,$unknown: freezed == $unknown ? _self.$unknown : $unknown // ignore: cast_nullable_to_non_nullable
+as Map<String, dynamic>?,
+  ));
+}
+/// Create a copy of EmbedGetEmbedExternalViewOutput
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$EmbedExternalViewCopyWith<$Res>? get view {
+    if (_self.view == null) {
+    return null;
+  }
+
+  return $EmbedExternalViewCopyWith<$Res>(_self.view!, (value) {
+    return _then(_self.copyWith(view: value));
+  });
+}
+}
+
+
+/// Adds pattern-matching-related methods to [EmbedGetEmbedExternalViewOutput].
+extension EmbedGetEmbedExternalViewOutputPatterns on EmbedGetEmbedExternalViewOutput {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _EmbedGetEmbedExternalViewOutput value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _EmbedGetEmbedExternalViewOutput() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _EmbedGetEmbedExternalViewOutput value)  $default,){
+final _that = this;
+switch (_that) {
+case _EmbedGetEmbedExternalViewOutput():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _EmbedGetEmbedExternalViewOutput value)?  $default,){
+final _that = this;
+switch (_that) {
+case _EmbedGetEmbedExternalViewOutput() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function(@EmbedExternalViewConverter()  EmbedExternalView? view, @RepoStrongRefConverter()  List<RepoStrongRef>? associatedRefs,  List<Map<String, dynamic>>? associatedRecords,  Map<String, dynamic>? $unknown)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _EmbedGetEmbedExternalViewOutput() when $default != null:
+return $default(_that.view,_that.associatedRefs,_that.associatedRecords,_that.$unknown);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function(@EmbedExternalViewConverter()  EmbedExternalView? view, @RepoStrongRefConverter()  List<RepoStrongRef>? associatedRefs,  List<Map<String, dynamic>>? associatedRecords,  Map<String, dynamic>? $unknown)  $default,) {final _that = this;
+switch (_that) {
+case _EmbedGetEmbedExternalViewOutput():
+return $default(_that.view,_that.associatedRefs,_that.associatedRecords,_that.$unknown);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function(@EmbedExternalViewConverter()  EmbedExternalView? view, @RepoStrongRefConverter()  List<RepoStrongRef>? associatedRefs,  List<Map<String, dynamic>>? associatedRecords,  Map<String, dynamic>? $unknown)?  $default,) {final _that = this;
+switch (_that) {
+case _EmbedGetEmbedExternalViewOutput() when $default != null:
+return $default(_that.view,_that.associatedRefs,_that.associatedRecords,_that.$unknown);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+
+@JsonSerializable(includeIfNull: false)
+class _EmbedGetEmbedExternalViewOutput implements EmbedGetEmbedExternalViewOutput {
+  const _EmbedGetEmbedExternalViewOutput({@EmbedExternalViewConverter() this.view, @RepoStrongRefConverter() final  List<RepoStrongRef>? associatedRefs, final  List<Map<String, dynamic>>? associatedRecords, final  Map<String, dynamic>? $unknown}): _associatedRefs = associatedRefs,_associatedRecords = associatedRecords,_$unknown = $unknown;
+  factory _EmbedGetEmbedExternalViewOutput.fromJson(Map<String, dynamic> json) => _$EmbedGetEmbedExternalViewOutputFromJson(json);
+
+/// Hydrated view of the embed. Present only when the resolved records back the requested URL and supply enough information to populate the required `viewExternal` fields. Omitted alongside the rest of the response when no records resolved or validation failed.
+@override@EmbedExternalViewConverter() final  EmbedExternalView? view;
+ final  List<RepoStrongRef>? _associatedRefs;
+@override@RepoStrongRefConverter() List<RepoStrongRef>? get associatedRefs {
+  final value = _associatedRefs;
+  if (value == null) return null;
+  if (_associatedRefs is EqualUnmodifiableListView) return _associatedRefs;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(value);
+}
+
+ final  List<Map<String, dynamic>>? _associatedRecords;
+@override List<Map<String, dynamic>>? get associatedRecords {
+  final value = _associatedRecords;
+  if (value == null) return null;
+  if (_associatedRecords is EqualUnmodifiableListView) return _associatedRecords;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(value);
+}
+
+ final  Map<String, dynamic>? _$unknown;
+@override Map<String, dynamic>? get $unknown {
+  final value = _$unknown;
+  if (value == null) return null;
+  if (_$unknown is EqualUnmodifiableMapView) return _$unknown;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableMapView(value);
+}
+
+
+/// Create a copy of EmbedGetEmbedExternalViewOutput
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$EmbedGetEmbedExternalViewOutputCopyWith<_EmbedGetEmbedExternalViewOutput> get copyWith => __$EmbedGetEmbedExternalViewOutputCopyWithImpl<_EmbedGetEmbedExternalViewOutput>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$EmbedGetEmbedExternalViewOutputToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _EmbedGetEmbedExternalViewOutput&&(identical(other.view, view) || other.view == view)&&const DeepCollectionEquality().equals(other._associatedRefs, _associatedRefs)&&const DeepCollectionEquality().equals(other._associatedRecords, _associatedRecords)&&const DeepCollectionEquality().equals(other._$unknown, _$unknown));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,view,const DeepCollectionEquality().hash(_associatedRefs),const DeepCollectionEquality().hash(_associatedRecords),const DeepCollectionEquality().hash(_$unknown));
+
+@override
+String toString() {
+  return 'EmbedGetEmbedExternalViewOutput(view: $view, associatedRefs: $associatedRefs, associatedRecords: $associatedRecords, \$unknown: ${$unknown})';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$EmbedGetEmbedExternalViewOutputCopyWith<$Res> implements $EmbedGetEmbedExternalViewOutputCopyWith<$Res> {
+  factory _$EmbedGetEmbedExternalViewOutputCopyWith(_EmbedGetEmbedExternalViewOutput value, $Res Function(_EmbedGetEmbedExternalViewOutput) _then) = __$EmbedGetEmbedExternalViewOutputCopyWithImpl;
+@override @useResult
+$Res call({
+@EmbedExternalViewConverter() EmbedExternalView? view,@RepoStrongRefConverter() List<RepoStrongRef>? associatedRefs, List<Map<String, dynamic>>? associatedRecords, Map<String, dynamic>? $unknown
+});
+
+
+@override $EmbedExternalViewCopyWith<$Res>? get view;
+
+}
+/// @nodoc
+class __$EmbedGetEmbedExternalViewOutputCopyWithImpl<$Res>
+    implements _$EmbedGetEmbedExternalViewOutputCopyWith<$Res> {
+  __$EmbedGetEmbedExternalViewOutputCopyWithImpl(this._self, this._then);
+
+  final _EmbedGetEmbedExternalViewOutput _self;
+  final $Res Function(_EmbedGetEmbedExternalViewOutput) _then;
+
+/// Create a copy of EmbedGetEmbedExternalViewOutput
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? view = freezed,Object? associatedRefs = freezed,Object? associatedRecords = freezed,Object? $unknown = freezed,}) {
+  return _then(_EmbedGetEmbedExternalViewOutput(
+view: freezed == view ? _self.view : view // ignore: cast_nullable_to_non_nullable
+as EmbedExternalView?,associatedRefs: freezed == associatedRefs ? _self._associatedRefs : associatedRefs // ignore: cast_nullable_to_non_nullable
+as List<RepoStrongRef>?,associatedRecords: freezed == associatedRecords ? _self._associatedRecords : associatedRecords // ignore: cast_nullable_to_non_nullable
+as List<Map<String, dynamic>>?,$unknown: freezed == $unknown ? _self._$unknown : $unknown // ignore: cast_nullable_to_non_nullable
+as Map<String, dynamic>?,
+  ));
+}
+
+/// Create a copy of EmbedGetEmbedExternalViewOutput
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$EmbedExternalViewCopyWith<$Res>? get view {
+    if (_self.view == null) {
+    return null;
+  }
+
+  return $EmbedExternalViewCopyWith<$Res>(_self.view!, (value) {
+    return _then(_self.copyWith(view: value));
+  });
+}
+}
+
+// dart format on

--- a/packages/bluesky/lib/src/services/codegen/app/bsky/embed/getEmbedExternalView/output.g.dart
+++ b/packages/bluesky/lib/src/services/codegen/app/bsky/embed/getEmbedExternalView/output.g.dart
@@ -1,0 +1,70 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: non_constant_identifier_names
+
+part of 'output.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_EmbedGetEmbedExternalViewOutput _$EmbedGetEmbedExternalViewOutputFromJson(
+  Map json,
+) => $checkedCreate('_EmbedGetEmbedExternalViewOutput', json, (
+  $checkedConvert,
+) {
+  final val = _EmbedGetEmbedExternalViewOutput(
+    view: $checkedConvert(
+      'view',
+      (v) => _$JsonConverterFromJson<Map<String, dynamic>, EmbedExternalView>(
+        v,
+        const EmbedExternalViewConverter().fromJson,
+      ),
+    ),
+    associatedRefs: $checkedConvert(
+      'associatedRefs',
+      (v) => (v as List<dynamic>?)
+          ?.map(
+            (e) => const RepoStrongRefConverter().fromJson(
+              e as Map<String, dynamic>,
+            ),
+          )
+          .toList(),
+    ),
+    associatedRecords: $checkedConvert(
+      'associatedRecords',
+      (v) => (v as List<dynamic>?)
+          ?.map((e) => Map<String, dynamic>.from(e as Map))
+          .toList(),
+    ),
+    $unknown: $checkedConvert(
+      r'$unknown',
+      (v) => (v as Map?)?.map((k, e) => MapEntry(k as String, e)),
+    ),
+  );
+  return val;
+});
+
+Map<String, dynamic> _$EmbedGetEmbedExternalViewOutputToJson(
+  _EmbedGetEmbedExternalViewOutput instance,
+) => <String, dynamic>{
+  'view': ?_$JsonConverterToJson<Map<String, dynamic>, EmbedExternalView>(
+    instance.view,
+    const EmbedExternalViewConverter().toJson,
+  ),
+  'associatedRefs': ?instance.associatedRefs
+      ?.map(const RepoStrongRefConverter().toJson)
+      .toList(),
+  'associatedRecords': ?instance.associatedRecords,
+  r'$unknown': ?instance.$unknown,
+};
+
+Value? _$JsonConverterFromJson<Json, Value>(
+  Object? json,
+  Value? Function(Json json) fromJson,
+) => json == null ? null : fromJson(json as Json);
+
+Json? _$JsonConverterToJson<Json, Value>(
+  Value? value,
+  Json? Function(Value value) toJson,
+) => value == null ? null : toJson(value);

--- a/packages/bluesky/lib/src/services/codegen/app/bsky/embed_service.dart
+++ b/packages/bluesky/lib/src/services/codegen/app/bsky/embed_service.dart
@@ -1,0 +1,65 @@
+// Copyright (c) 2023-2026, Shinya Kato.
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+// Package imports:
+import 'package:atproto_core/atproto_core.dart';
+import 'package:atproto_core/internals.dart' show protected;
+
+// Project imports:
+import '../../../../nsids.g.dart' as ns;
+import 'embed/getEmbedExternalView/output.dart';
+
+// **************************************************************************
+// LexGenerator
+// **************************************************************************
+
+/// Resolve one or more AT-URIs into the data needed to render an enhanced external embed. Returns `associatedRefs` (strongRefs to embed into a post's external.associatedRefs), the raw `associatedRecords`, and a hydrated `view`. The response is empty (`{}`) when no records were resolvable, or when validation determined the resolved records don't actually back the requested URL; clients should fall back to their own link-card rendering in that case and skip writing strongRefs to the post.
+Future<XRPCResponse<EmbedGetEmbedExternalViewOutput>>
+appBskyEmbedGetEmbedExternalView({
+  required String url,
+  required List<AtUri> uris,
+  required ServiceContext $ctx,
+  String? $service,
+  Map<String, String>? $headers,
+  Map<String, String>? $unknown,
+}) async => await $ctx.get(
+  ns.appBskyEmbedGetEmbedExternalView,
+  service: $service,
+  headers: $headers,
+  parameters: {
+    ...?$unknown,
+    'url': url,
+    'uris': uris.map((e) => e.toString()).toList(),
+  },
+  to: const EmbedGetEmbedExternalViewOutputConverter().fromJson,
+);
+
+/// `app.bsky.embed.*`
+base class EmbedService {
+  @protected
+  final ServiceContext ctx;
+
+  EmbedService(this.ctx);
+
+  /// Resolve one or more AT-URIs into the data needed to render an enhanced external embed. Returns `associatedRefs` (strongRefs to embed into a post's external.associatedRefs), the raw `associatedRecords`, and a hydrated `view`. The response is empty (`{}`) when no records were resolvable, or when validation determined the resolved records don't actually back the requested URL; clients should fall back to their own link-card rendering in that case and skip writing strongRefs to the post.
+  Future<XRPCResponse<EmbedGetEmbedExternalViewOutput>> getEmbedExternalView({
+    required String url,
+    required List<AtUri> uris,
+    String? $service,
+    Map<String, String>? $headers,
+    Map<String, String>? $unknown,
+  }) async => await appBskyEmbedGetEmbedExternalView(
+    url: url,
+    uris: uris,
+    $ctx: ctx,
+    $service: $service,
+    $headers: $headers,
+    $unknown: $unknown,
+  );
+}

--- a/packages/bluesky/lib/src/services/codegen/chat/bsky/actor/getStatus/output.dart
+++ b/packages/bluesky/lib/src/services/codegen/chat/bsky/actor/getStatus/output.dart
@@ -1,0 +1,61 @@
+// Copyright (c) 2023-2026, Shinya Kato.
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+// Package imports:
+import 'package:atproto_core/internals.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'output.freezed.dart';
+part 'output.g.dart';
+
+// **************************************************************************
+// LexGenerator
+// **************************************************************************
+
+@freezed
+abstract class ActorGetStatusOutput with _$ActorGetStatusOutput {
+  static const knownProps = <String>['chatDisabled', 'canCreateGroups'];
+
+  @JsonSerializable(includeIfNull: false)
+  const factory ActorGetStatusOutput({
+    /// True when the viewer's account is disabled and cannot actively participate in chat.
+    required bool chatDisabled,
+
+    /// Whether the viewer's account is allowed to create group chats. New accounts are restricted from creating groups.
+    required bool canCreateGroups,
+
+    Map<String, dynamic>? $unknown,
+  }) = _ActorGetStatusOutput;
+
+  factory ActorGetStatusOutput.fromJson(Map<String, Object?> json) =>
+      _$ActorGetStatusOutputFromJson(json);
+}
+
+extension ActorGetStatusOutputExtension on ActorGetStatusOutput {
+  bool get isChatDisabled => chatDisabled;
+  bool get isNotChatDisabled => !isChatDisabled;
+  bool get isCanCreateGroups => canCreateGroups;
+  bool get isNotCanCreateGroups => !isCanCreateGroups;
+}
+
+final class ActorGetStatusOutputConverter
+    extends JsonConverter<ActorGetStatusOutput, Map<String, dynamic>> {
+  const ActorGetStatusOutputConverter();
+
+  @override
+  ActorGetStatusOutput fromJson(Map<String, dynamic> json) {
+    return ActorGetStatusOutput.fromJson(
+      translate(json, ActorGetStatusOutput.knownProps),
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson(ActorGetStatusOutput object) =>
+      untranslate(object.toJson());
+}

--- a/packages/bluesky/lib/src/services/codegen/chat/bsky/actor/getStatus/output.freezed.dart
+++ b/packages/bluesky/lib/src/services/codegen/chat/bsky/actor/getStatus/output.freezed.dart
@@ -1,0 +1,295 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'output.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$ActorGetStatusOutput {
+
+/// True when the viewer's account is disabled and cannot actively participate in chat.
+ bool get chatDisabled;/// Whether the viewer's account is allowed to create group chats. New accounts are restricted from creating groups.
+ bool get canCreateGroups; Map<String, dynamic>? get $unknown;
+/// Create a copy of ActorGetStatusOutput
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$ActorGetStatusOutputCopyWith<ActorGetStatusOutput> get copyWith => _$ActorGetStatusOutputCopyWithImpl<ActorGetStatusOutput>(this as ActorGetStatusOutput, _$identity);
+
+  /// Serializes this ActorGetStatusOutput to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is ActorGetStatusOutput&&(identical(other.chatDisabled, chatDisabled) || other.chatDisabled == chatDisabled)&&(identical(other.canCreateGroups, canCreateGroups) || other.canCreateGroups == canCreateGroups)&&const DeepCollectionEquality().equals(other.$unknown, $unknown));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,chatDisabled,canCreateGroups,const DeepCollectionEquality().hash($unknown));
+
+@override
+String toString() {
+  return 'ActorGetStatusOutput(chatDisabled: $chatDisabled, canCreateGroups: $canCreateGroups, \$unknown: ${$unknown})';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $ActorGetStatusOutputCopyWith<$Res>  {
+  factory $ActorGetStatusOutputCopyWith(ActorGetStatusOutput value, $Res Function(ActorGetStatusOutput) _then) = _$ActorGetStatusOutputCopyWithImpl;
+@useResult
+$Res call({
+ bool chatDisabled, bool canCreateGroups, Map<String, dynamic>? $unknown
+});
+
+
+
+
+}
+/// @nodoc
+class _$ActorGetStatusOutputCopyWithImpl<$Res>
+    implements $ActorGetStatusOutputCopyWith<$Res> {
+  _$ActorGetStatusOutputCopyWithImpl(this._self, this._then);
+
+  final ActorGetStatusOutput _self;
+  final $Res Function(ActorGetStatusOutput) _then;
+
+/// Create a copy of ActorGetStatusOutput
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? chatDisabled = null,Object? canCreateGroups = null,Object? $unknown = freezed,}) {
+  return _then(_self.copyWith(
+chatDisabled: null == chatDisabled ? _self.chatDisabled : chatDisabled // ignore: cast_nullable_to_non_nullable
+as bool,canCreateGroups: null == canCreateGroups ? _self.canCreateGroups : canCreateGroups // ignore: cast_nullable_to_non_nullable
+as bool,$unknown: freezed == $unknown ? _self.$unknown : $unknown // ignore: cast_nullable_to_non_nullable
+as Map<String, dynamic>?,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [ActorGetStatusOutput].
+extension ActorGetStatusOutputPatterns on ActorGetStatusOutput {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _ActorGetStatusOutput value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _ActorGetStatusOutput() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _ActorGetStatusOutput value)  $default,){
+final _that = this;
+switch (_that) {
+case _ActorGetStatusOutput():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _ActorGetStatusOutput value)?  $default,){
+final _that = this;
+switch (_that) {
+case _ActorGetStatusOutput() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( bool chatDisabled,  bool canCreateGroups,  Map<String, dynamic>? $unknown)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _ActorGetStatusOutput() when $default != null:
+return $default(_that.chatDisabled,_that.canCreateGroups,_that.$unknown);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( bool chatDisabled,  bool canCreateGroups,  Map<String, dynamic>? $unknown)  $default,) {final _that = this;
+switch (_that) {
+case _ActorGetStatusOutput():
+return $default(_that.chatDisabled,_that.canCreateGroups,_that.$unknown);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( bool chatDisabled,  bool canCreateGroups,  Map<String, dynamic>? $unknown)?  $default,) {final _that = this;
+switch (_that) {
+case _ActorGetStatusOutput() when $default != null:
+return $default(_that.chatDisabled,_that.canCreateGroups,_that.$unknown);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+
+@JsonSerializable(includeIfNull: false)
+class _ActorGetStatusOutput implements ActorGetStatusOutput {
+  const _ActorGetStatusOutput({required this.chatDisabled, required this.canCreateGroups, final  Map<String, dynamic>? $unknown}): _$unknown = $unknown;
+  factory _ActorGetStatusOutput.fromJson(Map<String, dynamic> json) => _$ActorGetStatusOutputFromJson(json);
+
+/// True when the viewer's account is disabled and cannot actively participate in chat.
+@override final  bool chatDisabled;
+/// Whether the viewer's account is allowed to create group chats. New accounts are restricted from creating groups.
+@override final  bool canCreateGroups;
+ final  Map<String, dynamic>? _$unknown;
+@override Map<String, dynamic>? get $unknown {
+  final value = _$unknown;
+  if (value == null) return null;
+  if (_$unknown is EqualUnmodifiableMapView) return _$unknown;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableMapView(value);
+}
+
+
+/// Create a copy of ActorGetStatusOutput
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$ActorGetStatusOutputCopyWith<_ActorGetStatusOutput> get copyWith => __$ActorGetStatusOutputCopyWithImpl<_ActorGetStatusOutput>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$ActorGetStatusOutputToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _ActorGetStatusOutput&&(identical(other.chatDisabled, chatDisabled) || other.chatDisabled == chatDisabled)&&(identical(other.canCreateGroups, canCreateGroups) || other.canCreateGroups == canCreateGroups)&&const DeepCollectionEquality().equals(other._$unknown, _$unknown));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,chatDisabled,canCreateGroups,const DeepCollectionEquality().hash(_$unknown));
+
+@override
+String toString() {
+  return 'ActorGetStatusOutput(chatDisabled: $chatDisabled, canCreateGroups: $canCreateGroups, \$unknown: ${$unknown})';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$ActorGetStatusOutputCopyWith<$Res> implements $ActorGetStatusOutputCopyWith<$Res> {
+  factory _$ActorGetStatusOutputCopyWith(_ActorGetStatusOutput value, $Res Function(_ActorGetStatusOutput) _then) = __$ActorGetStatusOutputCopyWithImpl;
+@override @useResult
+$Res call({
+ bool chatDisabled, bool canCreateGroups, Map<String, dynamic>? $unknown
+});
+
+
+
+
+}
+/// @nodoc
+class __$ActorGetStatusOutputCopyWithImpl<$Res>
+    implements _$ActorGetStatusOutputCopyWith<$Res> {
+  __$ActorGetStatusOutputCopyWithImpl(this._self, this._then);
+
+  final _ActorGetStatusOutput _self;
+  final $Res Function(_ActorGetStatusOutput) _then;
+
+/// Create a copy of ActorGetStatusOutput
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? chatDisabled = null,Object? canCreateGroups = null,Object? $unknown = freezed,}) {
+  return _then(_ActorGetStatusOutput(
+chatDisabled: null == chatDisabled ? _self.chatDisabled : chatDisabled // ignore: cast_nullable_to_non_nullable
+as bool,canCreateGroups: null == canCreateGroups ? _self.canCreateGroups : canCreateGroups // ignore: cast_nullable_to_non_nullable
+as bool,$unknown: freezed == $unknown ? _self._$unknown : $unknown // ignore: cast_nullable_to_non_nullable
+as Map<String, dynamic>?,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/packages/bluesky/lib/src/services/codegen/chat/bsky/actor/getStatus/output.g.dart
+++ b/packages/bluesky/lib/src/services/codegen/chat/bsky/actor/getStatus/output.g.dart
@@ -1,0 +1,30 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: non_constant_identifier_names
+
+part of 'output.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_ActorGetStatusOutput _$ActorGetStatusOutputFromJson(Map json) =>
+    $checkedCreate('_ActorGetStatusOutput', json, ($checkedConvert) {
+      final val = _ActorGetStatusOutput(
+        chatDisabled: $checkedConvert('chatDisabled', (v) => v as bool),
+        canCreateGroups: $checkedConvert('canCreateGroups', (v) => v as bool),
+        $unknown: $checkedConvert(
+          r'$unknown',
+          (v) => (v as Map?)?.map((k, e) => MapEntry(k as String, e)),
+        ),
+      );
+      return val;
+    });
+
+Map<String, dynamic> _$ActorGetStatusOutputToJson(
+  _ActorGetStatusOutput instance,
+) => <String, dynamic>{
+  'chatDisabled': instance.chatDisabled,
+  'canCreateGroups': instance.canCreateGroups,
+  r'$unknown': ?instance.$unknown,
+};

--- a/packages/bluesky/lib/src/services/codegen/chat/bsky/actor_service.dart
+++ b/packages/bluesky/lib/src/services/codegen/chat/bsky/actor_service.dart
@@ -24,6 +24,7 @@ import '../../../../ids.g.dart' as ids;
 import '../../../../nsids.g.dart' as ns;
 import 'actor/declaration/main_allow_group_invites.dart';
 import 'actor/declaration/main_allow_incoming.dart';
+import 'actor/getStatus/output.dart';
 
 import 'package:atproto/com_atproto_services.dart'
     show
@@ -58,6 +59,20 @@ Future<XRPCResponse<Uint8List>> chatBskyActorExportAccountData({
   parameters: {...?$unknown},
 );
 
+/// Get the authenticated viewer's chat status: whether their account is chat-disabled and whether their group-membership additions are restricted to accounts they follow.
+Future<XRPCResponse<ActorGetStatusOutput>> chatBskyActorGetStatus({
+  required ServiceContext $ctx,
+  String? $service,
+  Map<String, String>? $headers,
+  Map<String, String>? $unknown,
+}) async => await $ctx.get(
+  ns.chatBskyActorGetStatus,
+  service: $service,
+  headers: $headers,
+  parameters: {...?$unknown},
+  to: const ActorGetStatusOutputConverter().fromJson,
+);
+
 /// `chat.bsky.actor.*`
 base class ActorService {
   @protected
@@ -82,6 +97,18 @@ base class ActorService {
     Map<String, String>? $headers,
     Map<String, String>? $unknown,
   }) async => await chatBskyActorExportAccountData(
+    $ctx: ctx,
+    $service: $service,
+    $headers: $headers,
+    $unknown: $unknown,
+  );
+
+  /// Get the authenticated viewer's chat status: whether their account is chat-disabled and whether their group-membership additions are restricted to accounts they follow.
+  Future<XRPCResponse<ActorGetStatusOutput>> getStatus({
+    String? $service,
+    Map<String, String>? $headers,
+    Map<String, String>? $unknown,
+  }) async => await chatBskyActorGetStatus(
     $ctx: ctx,
     $service: $service,
     $headers: $headers,

--- a/packages/bluesky/pubspec.yaml
+++ b/packages/bluesky/pubspec.yaml
@@ -1,7 +1,7 @@
 name: bluesky
 resolution: workspace
 description: The most famous and powerful Dart/Flutter library for Bluesky Social.
-version: 1.4.3
+version: 1.4.4
 homepage: https://atprotodart.com
 documentation: https://atprotodart.com/docs/packages/bluesky
 repository: https://github.com/myConsciousness/atproto.dart/tree/main/packages/bluesky

--- a/packages/bluesky_cli/lib/src/commands/codegen/app/bsky/embed.dart
+++ b/packages/bluesky_cli/lib/src/commands/codegen/app/bsky/embed.dart
@@ -11,24 +11,20 @@
 import 'package:args/command_runner.dart';
 
 // Project imports:
-import 'actor/declaration.dart';
-import 'actor/export_account_data.dart';
-import 'actor/get_status.dart';
+import 'embed/get_embed_external_view.dart';
 
 // **************************************************************************
 // LexGenerator
 // **************************************************************************
 
-final class ChatBskyActorCommand extends Command<void> {
-  ChatBskyActorCommand() {
-    addSubcommand(DeclarationCommand());
-    addSubcommand(ExportAccountDataCommand());
-    addSubcommand(GetStatusCommand());
+final class AppBskyEmbedCommand extends Command<void> {
+  AppBskyEmbedCommand() {
+    addSubcommand(GetEmbedExternalViewCommand());
   }
 
   @override
-  String get name => "chat-bsky-actor";
+  String get name => "app-bsky-embed";
 
   @override
-  String get description => "Provides commands for chat.bsky.actor.*";
+  String get description => "Provides commands for app.bsky.embed.*";
 }

--- a/packages/bluesky_cli/lib/src/commands/codegen/app/bsky/embed/get_embed_external_view.dart
+++ b/packages/bluesky_cli/lib/src/commands/codegen/app/bsky/embed/get_embed_external_view.dart
@@ -1,0 +1,52 @@
+// Copyright (c) 2023-2026, Shinya Kato.
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+// Project imports:
+import '../../../../query_command.dart';
+
+// **************************************************************************
+// LexGenerator
+// **************************************************************************
+
+final class GetEmbedExternalViewCommand extends QueryCommand {
+  GetEmbedExternalViewCommand() {
+    argParser
+      ..addOption(
+        "url",
+        help:
+            r"The canonical web URL the embed represents (typically the URL the user pasted into the composer). Used as the returned view's `uri`. May be used for validation in the future.",
+        mandatory: true,
+      )
+      ..addMultiOption(
+        "uris",
+        help:
+            r"AT-URIs of any Atmosphere records that can be resolved and used to construct #externalView views. Example: a site.standard.document and optionally its associated site.standard.publication.",
+      );
+  }
+
+  @override
+  final String name = "get-embed-external-view";
+
+  @override
+  final String description =
+      r"Resolve one or more AT-URIs into the data needed to render an enhanced external embed. Returns `associatedRefs` (strongRefs to embed into a post's external.associatedRefs), the raw `associatedRecords`, and a hydrated `view`. The response is empty (`{}`) when no records were resolvable, or when validation determined the resolved records don't actually back the requested URL; clients should fall back to their own link-card rendering in that case and skip writing strongRefs to the post.";
+
+  @override
+  final String invocation =
+      "bsky app-bsky-embed get-embed-external-view [url] [uris]";
+
+  @override
+  String get methodId => "app.bsky.embed.getEmbedExternalView";
+
+  @override
+  Map<String, dynamic>? get parameters => {
+    "url": argResults!["url"],
+    "uris": argResults!["uris"],
+  };
+}

--- a/packages/bluesky_cli/lib/src/commands/codegen/chat/bsky/actor/get_status.dart
+++ b/packages/bluesky_cli/lib/src/commands/codegen/chat/bsky/actor/get_status.dart
@@ -7,28 +7,29 @@
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
-// Package imports:
-import 'package:args/command_runner.dart';
-
 // Project imports:
-import 'actor/declaration.dart';
-import 'actor/export_account_data.dart';
-import 'actor/get_status.dart';
+import '../../../../query_command.dart';
 
 // **************************************************************************
 // LexGenerator
 // **************************************************************************
 
-final class ChatBskyActorCommand extends Command<void> {
-  ChatBskyActorCommand() {
-    addSubcommand(DeclarationCommand());
-    addSubcommand(ExportAccountDataCommand());
-    addSubcommand(GetStatusCommand());
-  }
+final class GetStatusCommand extends QueryCommand {
+  GetStatusCommand() {}
 
   @override
-  String get name => "chat-bsky-actor";
+  final String name = "get-status";
 
   @override
-  String get description => "Provides commands for chat.bsky.actor.*";
+  final String description =
+      r"Get the authenticated viewer's chat status: whether their account is chat-disabled and whether their group-membership additions are restricted to accounts they follow.";
+
+  @override
+  final String invocation = "bsky chat-bsky-actor get-status";
+
+  @override
+  String get methodId => "chat.bsky.actor.getStatus";
+
+  @override
+  Map<String, dynamic>? get parameters => {};
 }

--- a/packages/bluesky_cli/lib/src/commands/codegen/lex_commands.dart
+++ b/packages/bluesky_cli/lib/src/commands/codegen/lex_commands.dart
@@ -13,6 +13,7 @@ import 'app/bsky/ageassurance.dart';
 import 'app/bsky/bookmark.dart';
 import 'app/bsky/contact.dart';
 import 'app/bsky/draft.dart';
+import 'app/bsky/embed.dart';
 import 'app/bsky/feed.dart';
 import 'app/bsky/graph.dart';
 import 'app/bsky/labeler.dart';
@@ -55,6 +56,7 @@ final lexCommands = [
   AppBskyBookmarkCommand(),
   AppBskyContactCommand(),
   AppBskyDraftCommand(),
+  AppBskyEmbedCommand(),
   AppBskyFeedCommand(),
   AppBskyGraphCommand(),
   AppBskyLabelerCommand(),

--- a/packages/bluesky_cli/pubspec.yaml
+++ b/packages/bluesky_cli/pubspec.yaml
@@ -27,7 +27,7 @@ dependencies:
   args: ^2.7.0
   cli_launcher: ^0.3.1
   cli_util: ^0.4.2
-  bluesky_text: ^1.2.0
+  bluesky_text: ^1.2.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/packages/bluesky_text/CHANGELOG.md
+++ b/packages/bluesky_text/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Note
 
+## v1.2.1
+
+- fix: do not use `.substring` when creating the cashtag entities.
+
 ## v1.2.0
 
 - **FEATURE**: Added support for cashtag detection (e.g. `$AAPL`, `$tsla`).

--- a/packages/bluesky_text/lib/src/extractor/extractor.dart
+++ b/packages/bluesky_text/lib/src/extractor/extractor.dart
@@ -347,7 +347,7 @@ final class _CashtagsExtractor implements Extractor {
       entities.add(
         Entity(
           type: EntityType.cashtag,
-          value: cashtag.substring(1),
+          value: cashtag,
           indices: ByteIndices(
             start: text.value.toUtf8Index(start),
             end: text.value.toUtf8Index(start + cashtag.length),

--- a/packages/bluesky_text/pubspec.yaml
+++ b/packages/bluesky_text/pubspec.yaml
@@ -1,7 +1,7 @@
 name: bluesky_text
 resolution: workspace
 description: Provides the easiest and most powerful way to analyze the text for Bluesky Social.
-version: 1.2.0
+version: 1.2.1
 homepage: https://atprotodart.com
 repository: https://github.com/myConsciousness/atproto.dart/tree/main/packages/bluesky_text
 issue_tracker: https://github.com/myConsciousness/atproto.dart/issues

--- a/packages/bluesky_text/test/src/bluesky_text_test.dart
+++ b/packages/bluesky_text/test/src/bluesky_text_test.dart
@@ -2325,7 +2325,7 @@ becomes
       expect(cashtags.first.isTag, isFalse);
       expect(cashtags.first.isHandle, isFalse);
       expect(cashtags.first.isLink, isFalse);
-      expect(cashtags.first.value, 'AAPL');
+      expect(cashtags.first.value, r'$AAPL');
       expect(cashtags.first.indices.start, 0);
       expect(cashtags.first.indices.end, 5);
 
@@ -2335,7 +2335,7 @@ becomes
         facets.first['features'][0][r'$type'],
         'app.bsky.richtext.facet#tag',
       );
-      expect(facets.first['features'][0]['tag'], 'AAPL');
+      expect(facets.first['features'][0]['tag'], r'$AAPL');
     });
 
     test('case2 multiple cashtags', () {
@@ -2343,10 +2343,10 @@ becomes
       final cashtags = text.cashtags;
 
       expect(cashtags.length, 2);
-      expect(cashtags.first.value, 'AAPL');
+      expect(cashtags.first.value, r'$AAPL');
       expect(cashtags.first.indices.start, 0);
       expect(cashtags.first.indices.end, 5);
-      expect(cashtags[1].value, 'TSLA');
+      expect(cashtags[1].value, r'$TSLA');
       expect(cashtags[1].indices.start, 6);
       expect(cashtags[1].indices.end, 11);
     });
@@ -2356,7 +2356,7 @@ becomes
       final cashtags = text.cashtags;
 
       expect(cashtags.length, 1);
-      expect(cashtags.first.value, 'AAPL');
+      expect(cashtags.first.value, r'$AAPL');
       expect(cashtags.first.indices.start, 9);
       expect(cashtags.first.indices.end, 14);
     });
@@ -2366,7 +2366,7 @@ becomes
       final cashtags = text.cashtags;
 
       expect(cashtags.length, 1);
-      expect(cashtags.first.value, 'AAPL');
+      expect(cashtags.first.value, r'$AAPL');
       expect(cashtags.first.indices.start, 4);
       expect(cashtags.first.indices.end, 9);
     });
@@ -2376,7 +2376,7 @@ becomes
       final cashtags = text.cashtags;
 
       expect(cashtags.length, 1);
-      expect(cashtags.first.value, 'AAPL');
+      expect(cashtags.first.value, r'$AAPL');
       expect(cashtags.first.indices.start, 1);
       expect(cashtags.first.indices.end, 6);
     });
@@ -2386,7 +2386,7 @@ becomes
       final cashtags = text.cashtags;
 
       expect(cashtags.length, 1);
-      expect(cashtags.first.value, 'aapl');
+      expect(cashtags.first.value, r'$aapl');
       expect(cashtags.first.indices.start, 0);
       expect(cashtags.first.indices.end, 5);
     });
@@ -2396,7 +2396,7 @@ becomes
       final cashtags = text.cashtags;
 
       expect(cashtags.length, 1);
-      expect(cashtags.first.value, 'BRK1');
+      expect(cashtags.first.value, r'$BRK1');
     });
 
     test('case8 must start with letter', () {
@@ -2446,7 +2446,7 @@ becomes
       final cashtags = text.cashtags;
 
       expect(cashtags.length, 1);
-      expect(cashtags.first.value, 'AAPL');
+      expect(cashtags.first.value, r'$AAPL');
       expect(cashtags.first.indices.start, 0);
       expect(cashtags.first.indices.end, 5);
     });
@@ -2456,7 +2456,7 @@ becomes
       final cashtags = text.cashtags;
 
       expect(cashtags.length, 1);
-      expect(cashtags.first.value, 'AAPL');
+      expect(cashtags.first.value, r'$AAPL');
     });
 
     test('case16 newline separator', () {
@@ -2464,8 +2464,8 @@ becomes
       final cashtags = text.cashtags;
 
       expect(cashtags.length, 2);
-      expect(cashtags.first.value, 'AAPL');
-      expect(cashtags[1].value, 'TSLA');
+      expect(cashtags.first.value, r'$AAPL');
+      expect(cashtags[1].value, r'$TSLA');
     });
 
     test('case17 cashtag after full-width space', () {
@@ -2473,7 +2473,7 @@ becomes
       final cashtags = text.cashtags;
 
       expect(cashtags.length, 1);
-      expect(cashtags.first.value, 'AAPL');
+      expect(cashtags.first.value, r'$AAPL');
     });
 
     test('case18 length limit of 65 chars after \$', () {
@@ -2481,7 +2481,7 @@ becomes
       final cashtags = text.cashtags;
 
       expect(cashtags.length, 1);
-      expect(cashtags.first.value.length, 65);
+      expect(cashtags.first.value.length, 66);
     });
 
     test('case19 length limit exceeded', () {
@@ -2511,7 +2511,7 @@ becomes
       expect(tags.length, 1);
       expect(tags.first.value, 'tech');
       expect(cashtags.length, 1);
-      expect(cashtags.first.value, 'AAPL');
+      expect(cashtags.first.value, r'$AAPL');
     });
 
     test('case24 cashtag does not collide with handle extraction', () {
@@ -2522,7 +2522,7 @@ becomes
       expect(handles.length, 1);
       expect(handles.first.value, 'alice.dev');
       expect(cashtags.length, 1);
-      expect(cashtags.first.value, 'AAPL');
+      expect(cashtags.first.value, r'$AAPL');
     });
 
     test('case25 cashtag with surrounding emoji', () {
@@ -2530,7 +2530,7 @@ becomes
       final cashtags = text.cashtags;
 
       expect(cashtags.length, 1);
-      expect(cashtags.first.value, 'AAPL');
+      expect(cashtags.first.value, r'$AAPL');
     });
 
     test('case26 facet generation for multiple cashtags', () async {
@@ -2542,8 +2542,8 @@ becomes
         facets.first['features'][0][r'$type'],
         'app.bsky.richtext.facet#tag',
       );
-      expect(facets.first['features'][0]['tag'], 'AAPL');
-      expect(facets[1]['features'][0]['tag'], 'TSLA');
+      expect(facets.first['features'][0]['tag'], r'$AAPL');
+      expect(facets[1]['features'][0]['tag'], r'$TSLA');
     });
 
     test('case27 byte indices for utf-8 multibyte text', () {
@@ -2551,7 +2551,7 @@ becomes
       final cashtags = text.cashtags;
 
       expect(cashtags.length, 1);
-      expect(cashtags.first.value, 'AAPL');
+      expect(cashtags.first.value, r'$AAPL');
       // 日本語 is 9 bytes in UTF-8, plus 1 byte for the space.
       expect(cashtags.first.indices.start, 10);
       expect(cashtags.first.indices.end, 15);
@@ -2568,7 +2568,7 @@ becomes
 
       expect(entities.any((e) => e.isHandle && e.value == 'alice.dev'), isTrue);
       expect(entities.any((e) => e.isTag && e.value == 'tech'), isTrue);
-      expect(entities.any((e) => e.isCashtag && e.value == 'AAPL'), isTrue);
+      expect(entities.any((e) => e.isCashtag && e.value == r'$AAPL'), isTrue);
       expect(
         entities.any((e) => e.isLink && e.value == 'https://x.com'),
         isTrue,
@@ -2581,7 +2581,7 @@ becomes
 
       expect(entities.length, 3);
       expect(entities[0].isCashtag, isTrue);
-      expect(entities[0].value, 'AAPL');
+      expect(entities[0].value, r'$AAPL');
       expect(entities[1].isHandle, isTrue);
       expect(entities[1].value, 'alice.dev');
       expect(entities[2].isTag, isTrue);

--- a/packages/lexicon/lib/src/lexicons.g.dart
+++ b/packages/lexicon/lib/src/lexicons.g.dart
@@ -5320,6 +5320,66 @@ const appBskyEmbedRecord = <String, dynamic>{
   },
 };
 
+/// `app.bsky.embed.getEmbedExternalView`
+const appBskyEmbedGetEmbedExternalView = <String, dynamic>{
+  "lexicon": 1,
+  "id": "app.bsky.embed.getEmbedExternalView",
+  "defs": {
+    "main": {
+      "type": "query",
+      "description":
+          "Resolve one or more AT-URIs into the data needed to render an enhanced external embed. Returns `associatedRefs` (strongRefs to embed into a post's external.associatedRefs), the raw `associatedRecords`, and a hydrated `view`. The response is empty (`{}`) when no records were resolvable, or when validation determined the resolved records don't actually back the requested URL; clients should fall back to their own link-card rendering in that case and skip writing strongRefs to the post.",
+      "parameters": {
+        "type": "params",
+        "required": ["url", "uris"],
+        "properties": {
+          "url": {
+            "type": "string",
+            "format": "uri",
+            "description":
+                "The canonical web URL the embed represents (typically the URL the user pasted into the composer). Used as the returned view's `uri`. May be used for validation in the future.",
+          },
+          "uris": {
+            "type": "array",
+            "description":
+                "AT-URIs of any Atmosphere records that can be resolved and used to construct #externalView views. Example: a site.standard.document and optionally its associated site.standard.publication.",
+            "items": {"type": "string", "format": "at-uri"},
+            "maxLength": 4,
+          },
+        },
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "properties": {
+            "view": {
+              "type": "ref",
+              "description":
+                  "Hydrated view of the embed. Present only when the resolved records back the requested URL and supply enough information to populate the required `viewExternal` fields. Omitted alongside the rest of the response when no records resolved or validation failed.",
+              "ref": "app.bsky.embed.external#view",
+            },
+            "associatedRefs": {
+              "type": "array",
+              "description":
+                  "StrongRefs (URI+CID) of the Atmosphere records that backed this view, suitable for embedding into a post's external.associatedRefs.",
+              "items": {"type": "ref", "ref": "com.atproto.repo.strongRef"},
+            },
+            "associatedRecords": {
+              "type": "array",
+              "items": {
+                "type": "unknown",
+                "description":
+                    "The raw record data of the Atmosphere records that backed this view. This is returned for convenience, to avoid the need for the client to separately fetch the record data for the associatedRefs. Example: the site.standard.document and site.standard.publication records that backed this view.",
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+};
+
 /// `app.bsky.embed.images`
 const appBskyEmbedImages = <String, dynamic>{
   "lexicon": 1,
@@ -5540,10 +5600,10 @@ const appBskyEmbedExternal = <String, dynamic>{
           "accept": ["image/*"],
           "maxSize": 1000000,
         },
-        "associatedRecords": {
+        "associatedRefs": {
           "type": "array",
           "description":
-              "The URI of the Atmosphere record representing this external content, if it exists. Example: a site.standard.document record.",
+              "StrongRefs (uri+cid) of the Atmosphere records that backed this view.",
           "items": {"type": "ref", "ref": "com.atproto.repo.strongRef"},
         },
       },
@@ -5563,6 +5623,78 @@ const appBskyEmbedExternal = <String, dynamic>{
         "title": {"type": "string"},
         "description": {"type": "string"},
         "thumb": {"type": "string", "format": "uri"},
+        "createdAt": {
+          "type": "string",
+          "format": "datetime",
+          "description":
+              "When the external content was created, if available. Example: a publication date, for an article.",
+        },
+        "updatedAt": {
+          "type": "string",
+          "format": "datetime",
+          "description": "When the external content was updated, if available.",
+        },
+        "readingTime": {
+          "type": "integer",
+          "description":
+              "Estimated reading time in minutes, if applicable and available.",
+        },
+        "labels": {
+          "type": "array",
+          "items": {"type": "ref", "ref": "com.atproto.label.defs#label"},
+        },
+        "source": {"type": "ref", "ref": "#viewExternalSource"},
+        "associatedRefs": {
+          "type": "array",
+          "description":
+              "StrongRefs (uri+cid) of the Atmosphere records that backed this view.",
+          "items": {"type": "ref", "ref": "com.atproto.repo.strongRef"},
+        },
+      },
+    },
+    "viewExternalSource": {
+      "type": "object",
+      "description":
+          "The source of an external embed, such as a standard.site publication.",
+      "required": ["uri", "title"],
+      "properties": {
+        "uri": {
+          "type": "string",
+          "format": "uri",
+          "description":
+              "URI of the source, if available. Example: the https:// URL of a site.standard.publication record.",
+        },
+        "icon": {
+          "type": "string",
+          "format": "uri",
+          "description":
+              "Fully-qualified URL where an icon representing the source can be fetched. For example, CDN location provided by the App View.",
+        },
+        "title": {"type": "string"},
+        "description": {"type": "string"},
+        "theme": {"type": "ref", "ref": "#viewExternalSourceTheme"},
+      },
+    },
+    "viewExternalSourceTheme": {
+      "type": "object",
+      "description":
+          "The theme colors of an external source, such as a site.standard.publication. These colors may be used when rendering an embed from that source.",
+      "properties": {
+        "backgroundRGB": {"type": "ref", "ref": "#colorRGB"},
+        "foregroundRGB": {"type": "ref", "ref": "#colorRGB"},
+        "accentRGB": {"type": "ref", "ref": "#colorRGB"},
+        "accentForegroundRGB": {"type": "ref", "ref": "#colorRGB"},
+      },
+    },
+    "colorRGB": {
+      "type": "object",
+      "description":
+          "RGB color definition, inspired by site.standard.theme.color#rgb",
+      "required": ["r", "g", "b"],
+      "properties": {
+        "r": {"type": "integer", "minimum": 0, "maximum": 255},
+        "g": {"type": "integer", "minimum": 0, "maximum": 255},
+        "b": {"type": "integer", "minimum": 0, "maximum": 255},
       },
     },
   },
@@ -14689,13 +14821,13 @@ const chatBskyGroupAddMembers = <String, dynamic>{
       "errors": [
         {"name": "AccountSuspended"},
         {"name": "BlockedActor"},
-        {"name": "UserForbidsGroups"},
         {"name": "ConvoLocked"},
         {"name": "InsufficientRole"},
         {"name": "InvalidConvo"},
         {"name": "MemberLimitReached"},
         {"name": "NotFollowedBySender"},
         {"name": "RecipientNotFound"},
+        {"name": "UserForbidsGroups"},
       ],
     },
   },
@@ -14949,9 +15081,10 @@ const chatBskyGroupCreateGroup = <String, dynamic>{
       "errors": [
         {"name": "AccountSuspended"},
         {"name": "BlockedActor"},
-        {"name": "UserForbidsGroups"},
+        {"name": "NewAccountCannotCreateGroup"},
         {"name": "NotFollowedBySender"},
         {"name": "RecipientNotFound"},
+        {"name": "UserForbidsGroups"},
       ],
     },
   },
@@ -15037,6 +15170,38 @@ const chatBskyActorDefs = <String, dynamic>{
           "[NOTE: This is under active development and should be considered unstable while this note is here]. A past group convo member.",
       "required": [],
       "properties": {},
+    },
+  },
+};
+
+/// `chat.bsky.actor.getStatus`
+const chatBskyActorGetStatus = <String, dynamic>{
+  "lexicon": 1,
+  "id": "chat.bsky.actor.getStatus",
+  "defs": {
+    "main": {
+      "type": "query",
+      "description":
+          "Get the authenticated viewer's chat status: whether their account is chat-disabled and whether their group-membership additions are restricted to accounts they follow.",
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["chatDisabled", "canCreateGroups"],
+          "properties": {
+            "chatDisabled": {
+              "type": "boolean",
+              "description":
+                  "True when the viewer's account is disabled and cannot actively participate in chat.",
+            },
+            "canCreateGroups": {
+              "type": "boolean",
+              "description":
+                  "Whether the viewer's account is allowed to create group chats. New accounts are restricted from creating groups.",
+            },
+          },
+        },
+      },
     },
   },
 };
@@ -22019,6 +22184,7 @@ const lexicons = <Map<String, dynamic>>[
   appBskyBookmarkCreateBookmark,
   appBskyEmbedDefs,
   appBskyEmbedRecord,
+  appBskyEmbedGetEmbedExternalView,
   appBskyEmbedImages,
   appBskyEmbedRecordWithMedia,
   appBskyEmbedVideo,
@@ -22178,6 +22344,7 @@ const lexicons = <Map<String, dynamic>>[
   chatBskyGroupEnableJoinLink,
   chatBskyGroupCreateGroup,
   chatBskyActorDefs,
+  chatBskyActorGetStatus,
   chatBskyActorDeclaration,
   chatBskyActorExportAccountData,
   chatBskyActorDeleteAccount,

--- a/website/docs/lexicons/app/bsky/embed/external.md
+++ b/website/docs/lexicons/app/bsky/embed/external.md
@@ -21,7 +21,7 @@ A representation of some externally linked content (eg, a URL and 'card'), embed
 | **title** | string | - | ✅ | - |
 | **description** | string | - | ✅ | - |
 | **thumb** | [blob](https://atproto.com/specs/data-model#blob-type) | - | ❌ | - |
-| **associatedRecords** | array of [com.atproto.repo.strongRef](../../../../lexicons/com/atproto/repo/strongRef.md#main) | - | ❌ | The URI of the Atmosphere record representing this external content, if it exists. Example: a site.standard.document record. |
+| **associatedRefs** | array of [com.atproto.repo.strongRef](../../../../lexicons/com/atproto/repo/strongRef.md#main) | - | ❌ | StrongRefs (uri+cid) of the Atmosphere records that backed this view. |
 
 ## #view
 
@@ -37,3 +37,42 @@ A representation of some externally linked content (eg, a URL and 'card'), embed
 | **title** | string | - | ✅ | - |
 | **description** | string | - | ✅ | - |
 | **thumb** | string ([uri](https://atproto.com/specs/lexicon#uri)) | - | ❌ | - |
+| **createdAt** | string ([datetime](https://atproto.com/specs/lexicon#datetime)) | - | ❌ | When the external content was created, if available. Example: a publication date, for an article. |
+| **updatedAt** | string ([datetime](https://atproto.com/specs/lexicon#datetime)) | - | ❌ | When the external content was updated, if available. |
+| **readingTime** | integer | - | ❌ | Estimated reading time in minutes, if applicable and available. |
+| **labels** | array of [com.atproto.label.defs#label](../../../../lexicons/com/atproto/label/defs.md#label) | - | ❌ | - |
+| **source** | [#viewExternalSource](#viewexternalsource) | - | ❌ | - |
+| **associatedRefs** | array of [com.atproto.repo.strongRef](../../../../lexicons/com/atproto/repo/strongRef.md#main) | - | ❌ | StrongRefs (uri+cid) of the Atmosphere records that backed this view. |
+
+## #viewExternalSource
+
+The source of an external embed, such as a standard.site publication.
+
+| Property | Type | Known Values | Required | Description |
+| --- | --- | --- | :---: | --- |
+| **uri** | string ([uri](https://atproto.com/specs/lexicon#uri)) | - | ✅ | URI of the source, if available. Example: the https:// URL of a site.standard.publication record. |
+| **icon** | string ([uri](https://atproto.com/specs/lexicon#uri)) | - | ❌ | Fully-qualified URL where an icon representing the source can be fetched. For example, CDN location provided by the App View. |
+| **title** | string | - | ✅ | - |
+| **description** | string | - | ❌ | - |
+| **theme** | [#viewExternalSourceTheme](#viewexternalsourcetheme) | - | ❌ | - |
+
+## #viewExternalSourceTheme
+
+The theme colors of an external source, such as a site.standard.publication. These colors may be used when rendering an embed from that source.
+
+| Property | Type | Known Values | Required | Description |
+| --- | --- | --- | :---: | --- |
+| **backgroundRGB** | [#colorRGB](#colorrgb) | - | ❌ | - |
+| **foregroundRGB** | [#colorRGB](#colorrgb) | - | ❌ | - |
+| **accentRGB** | [#colorRGB](#colorrgb) | - | ❌ | - |
+| **accentForegroundRGB** | [#colorRGB](#colorrgb) | - | ❌ | - |
+
+## #colorRGB
+
+RGB color definition, inspired by site.standard.theme.color#rgb
+
+| Property | Type | Known Values | Required | Description |
+| --- | --- | --- | :---: | --- |
+| **r** | integer | - | ✅ | - |
+| **g** | integer | - | ✅ | - |
+| **b** | integer | - | ✅ | - |

--- a/website/docs/lexicons/app/bsky/embed/getEmbedExternalView.md
+++ b/website/docs/lexicons/app/bsky/embed/getEmbedExternalView.md
@@ -1,0 +1,27 @@
+---
+title: getEmbedExternalView
+description: app.bsky.embed.getEmbedExternalView
+---
+
+# [app.bsky.embed.getEmbedExternalView](https://github.com/myConsciousness/atproto.dart/blob/main/lexicons/app/bsky/embed/getEmbedExternalView.json)
+
+## #main
+
+Resolve one or more AT-URIs into the data needed to render an enhanced external embed. Returns `associatedRefs` (strongRefs to embed into a post's external.associatedRefs), the raw `associatedRecords`, and a hydrated `view`. The response is empty (`{}`) when no records were resolvable, or when validation determined the resolved records don't actually back the requested URL; clients should fall back to their own link-card rendering in that case and skip writing strongRefs to the post.
+
+### Parameters
+
+| Property | Type | Known Values | Required | Description |
+| --- | --- | --- | :---: | --- |
+| **url** | string ([uri](https://atproto.com/specs/lexicon#uri)) | - | ✅ | The canonical web URL the embed represents (typically the URL the user pasted into the composer). Used as the returned view's `uri`. May be used for validation in the future. |
+| **uris** | array of [at-uri](https://atproto.com/specs/at-uri-scheme) | - | ✅ | - |
+
+### Output
+
+- **Encoding**: application/json
+
+| Property | Type | Known Values | Required | Description |
+| --- | --- | --- | :---: | --- |
+| **view** | [app.bsky.embed.external#view](../../../../lexicons/app/bsky/embed/external.md#view) | - | ❌ | - |
+| **associatedRefs** | array of [com.atproto.repo.strongRef](../../../../lexicons/com/atproto/repo/strongRef.md#main) | - | ❌ | StrongRefs (URI+CID) of the Atmosphere records that backed this view, suitable for embedding into a post's external.associatedRefs. |
+| **associatedRecords** | array of unknown | - | ❌ | - |

--- a/website/docs/lexicons/chat/bsky/actor/getStatus.md
+++ b/website/docs/lexicons/chat/bsky/actor/getStatus.md
@@ -1,0 +1,19 @@
+---
+title: getStatus
+description: chat.bsky.actor.getStatus
+---
+
+# [chat.bsky.actor.getStatus](https://github.com/myConsciousness/atproto.dart/blob/main/lexicons/chat/bsky/actor/getStatus.json)
+
+## #main
+
+Get the authenticated viewer's chat status: whether their account is chat-disabled and whether their group-membership additions are restricted to accounts they follow.
+
+### Output
+
+- **Encoding**: application/json
+
+| Property | Type | Known Values | Required | Description |
+| --- | --- | --- | :---: | --- |
+| **chatDisabled** | boolean | - | ✅ | True when the viewer's account is disabled and cannot actively participate in chat. |
+| **canCreateGroups** | boolean | - | ✅ | Whether the viewer's account is allowed to create group chats. New accounts are restricted from creating groups. |

--- a/website/docs/supported_api.md
+++ b/website/docs/supported_api.md
@@ -187,6 +187,12 @@ So all endpoints in the [atproto](#atproto) table are also available from [blues
 | **[app.bsky.bookmark.deleteBookmark](https://pub.dev/documentation/bluesky/latest/app_bsky_services/BookmarkService/deleteBookmark.html)** | [Reference](lexicons/app/bsky/bookmark/deleteBookmark.md) | ❌ |
 | **[app.bsky.bookmark.getBookmarks](https://pub.dev/documentation/bluesky/latest/app_bsky_services/BookmarkService/getBookmarks.html)** | [Reference](lexicons/app/bsky/bookmark/getBookmarks.md) | ✅ |
 
+### app.bsky.embed
+
+| Method | Docs | Paging (cursor) |
+| --- | --- | :---: |
+| **[app.bsky.embed.getEmbedExternalView](https://pub.dev/documentation/bluesky/latest/app_bsky_services/EmbedService/getEmbedExternalView.html)** | [Reference](lexicons/app/bsky/embed/getEmbedExternalView.md) | ❌ |
+
 ### app.bsky.notification
 
 | Method | Docs | Paging (cursor) |
@@ -383,6 +389,7 @@ So all endpoints in the [atproto](#atproto) table are also available from [blues
 | **[chat.bsky.actor.declaration](https://pub.dev/documentation/bluesky/latest/chat_bsky_services/ActorService/declaration.html)** | [Reference](lexicons/chat/bsky/actor/declaration.md) | ❌ |
 | **[chat.bsky.actor.deleteAccount](https://pub.dev/documentation/bluesky/latest/chat_bsky_services/ActorService/deleteAccount.html)** | [Reference](lexicons/chat/bsky/actor/deleteAccount.md) | ❌ |
 | **[chat.bsky.actor.exportAccountData](https://pub.dev/documentation/bluesky/latest/chat_bsky_services/ActorService/exportAccountData.html)** | [Reference](lexicons/chat/bsky/actor/exportAccountData.md) | ❌ |
+| **[chat.bsky.actor.getStatus](https://pub.dev/documentation/bluesky/latest/chat_bsky_services/ActorService/getStatus.html)** | [Reference](lexicons/chat/bsky/actor/getStatus.md) | ❌ |
 
 ### chat.bsky.moderation
 


### PR DESCRIPTION
Generate code for app.bsky.embed.external and chat.actor.getStatus: add colorRGB type, viewExternalSource and theme, and getEmbedExternalView (input/output). Extend view_external with createdAt/updatedAt/readingTime/labels/source and associatedRefs (rename from associatedRecords). Add chat.bsky.actor.getStatus output, update ids/nsids, export new services, add CLI codegen commands and lexicon docs, and bump package metadata and changelog.