### PR TITLE
Bump bluesky package to v1.4.5

### DIFF
--- a/packages/bluesky/CHANGELOG.md
+++ b/packages/bluesky/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Note
 
+## v1.4.5
+
+- core: generated code. ([#2343](https://github.com/myConsciousness/atproto.dart/pull/2343))
+
 ## v1.4.4
 
 - core: generated code. ([#2340](https://github.com/myConsciousness/atproto.dart/pull/2340))

--- a/packages/bluesky/pubspec.yaml
+++ b/packages/bluesky/pubspec.yaml
@@ -1,7 +1,7 @@
 name: bluesky
 resolution: workspace
 description: The most famous and powerful Dart/Flutter library for Bluesky Social.
-version: 1.4.4
+version: 1.4.5
 homepage: https://atprotodart.com
 documentation: https://atprotodart.com/docs/packages/bluesky
 repository: https://github.com/myConsciousness/atproto.dart/tree/main/packages/bluesky


### PR DESCRIPTION
Update packages/bluesky pubspec version to 1.4.5 and add a corresponding changelog entry. Release notes: "core: generated code" (see PR #2343).