### PR TITLE
Bump atproto to v1.4.3 and bluesky to v1.4.6

### DIFF
--- a/packages/atproto/CHANGELOG.md
+++ b/packages/atproto/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Note
 
+## v1.4.3
+
+- core: generated code. ([#2350](https://github.com/myConsciousness/atproto.dart/pull/2350))
+
 ## v1.4.2
 
 - core: generated code. ([#2333](https://github.com/myConsciousness/atproto.dart/pull/2333))

--- a/packages/atproto/pubspec.yaml
+++ b/packages/atproto/pubspec.yaml
@@ -1,7 +1,7 @@
 name: atproto
 resolution: workspace
 description: The most famous and powerful Dart/Flutter library for AT Protocol.
-version: 1.4.2
+version: 1.4.3
 homepage: https://atprotodart.com
 documentation: https://atprotodart.com/docs/packages/atproto
 repository: https://github.com/myConsciousness/atproto.dart/tree/main/packages/atproto

--- a/packages/bluesky/CHANGELOG.md
+++ b/packages/bluesky/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Note
 
+## v1.4.6
+
+- core: generated code. ([#2347](https://github.com/myConsciousness/atproto.dart/pull/2347))
+
 ## v1.4.5
 
 - core: generated code. ([#2343](https://github.com/myConsciousness/atproto.dart/pull/2343))

--- a/packages/bluesky/pubspec.yaml
+++ b/packages/bluesky/pubspec.yaml
@@ -1,7 +1,7 @@
 name: bluesky
 resolution: workspace
 description: The most famous and powerful Dart/Flutter library for Bluesky Social.
-version: 1.4.5
+version: 1.4.6
 homepage: https://atprotodart.com
 documentation: https://atprotodart.com/docs/packages/bluesky
 repository: https://github.com/myConsciousness/atproto.dart/tree/main/packages/bluesky
@@ -19,7 +19,7 @@ topics:
 
 dependencies:
   atproto_core: ^1.2.1
-  atproto: ^1.4.2
+  atproto: ^1.4.3
   freezed_annotation: ^3.1.0
   json_annotation: ^4.9.0
   characters: ^1.4.0


### PR DESCRIPTION
Bump package versions and update changelogs: atproto -> 1.4.3 and bluesky -> 1.4.6. Added release notes for both packages (core: generated code) with PR references. Also updated bluesky's dependency on atproto to ^1.4.3 to match the new release.