### PR TITLE
chore(bluesky): bump version to 1.4.7

### DIFF
--- a/packages/bluesky/CHANGELOG.md
+++ b/packages/bluesky/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Note
 
+## v1.4.7
+
+- core: generated code. ([#2355](https://github.com/myConsciousness/atproto.dart/pull/2355))
+
 ## v1.4.6
 
 - core: generated code. ([#2347](https://github.com/myConsciousness/atproto.dart/pull/2347))

--- a/packages/bluesky/pubspec.yaml
+++ b/packages/bluesky/pubspec.yaml
@@ -1,7 +1,7 @@
 name: bluesky
 resolution: workspace
 description: The most famous and powerful Dart/Flutter library for Bluesky Social.
-version: 1.4.6
+version: 1.4.7
 homepage: https://atprotodart.com
 documentation: https://atprotodart.com/docs/packages/bluesky
 repository: https://github.com/myConsciousness/atproto.dart/tree/main/packages/bluesky


### PR DESCRIPTION
Update packages/bluesky/pubspec.yaml to version 1.4.7 and add a CHANGELOG entry for v1.4.7. Notes that this release includes generated core code (see PR #2355).