### PR TITLE
fix(lex_gen): sort lexicon docs by NSID for deterministic generation

### DIFF
--- a/packages/lex_gen/CHANGELOG.md
+++ b/packages/lex_gen/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Note
 
+## v0.2.1
+
+- fix: sort loaded lexicon docs by NSID instead of file path so that generation results are deterministic across platforms and checkout locations.
+
 ## v0.2.0
 
 - fix: generate `List<...>` for object properties that reference a top-level `array` definition through a local ref (e.g. `#draftEmbedGalleryItems`). Such refs were previously treated as plain object refs and produced code pointing to a non-existent file.

--- a/packages/lex_gen/lib/src/doc_loader.dart
+++ b/packages/lex_gen/lib/src/doc_loader.dart
@@ -13,6 +13,10 @@ import 'package:lexicon/lexicon.dart';
 ///
 /// Supports file paths (must be `.json`) and directory paths.
 /// When a directory is provided, `.json` files are discovered recursively.
+///
+/// The returned docs are sorted by lexicon id (NSID) so that generation
+/// results are deterministic regardless of platform, file system
+/// enumeration order, or where the repository is checked out.
 List<LexiconDoc> loadLexiconDocsFromPaths(
   final List<String> paths, {
   bool recursive = true,
@@ -78,6 +82,10 @@ List<LexiconDoc> loadLexiconDocsFromPaths(
 
     docs.add(doc);
   }
+
+  // Sort by lexicon id instead of file path: ids are content-derived, so
+  // the order never depends on path separators or directory layout.
+  docs.sort((a, b) => a.id.toString().compareTo(b.id.toString()));
 
   return docs;
 }

--- a/packages/lex_gen/pubspec.yaml
+++ b/packages/lex_gen/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lex_gen
 resolution: workspace
 description: Provides a generator that automatically generates source code from the Lexicon in the AT Protocol.
-version: 0.2.0
+version: 0.2.1
 homepage: https://atprotodart.com
 repository: https://github.com/myConsciousness/atproto.dart/tree/main/packages/lex_gen
 issue_tracker: https://github.com/myConsciousness/atproto.dart/issues


### PR DESCRIPTION
## Summary

`lex_gen` loads lexicon docs sorted by file path, which ties the generation order to how the file system represents paths (separators, directory layout, checkout location). This PR sorts the parsed docs by lexicon id (NSID) instead — ids are content-derived, so the order is fully independent of the environment.

Note: `scripts/utils.dart` already received the equivalent id-sort via #2415; this applies the same guarantee to the `lex_gen` package's own loader.

## Verification

- Ran `dart run ./scripts/gen_codes.dart` twice and confirmed all 2,015 generated files are hash-identical run-to-run.
- Confirmed the NSID-sorted order produces byte-for-byte identical output to the previous path-sorted order for the current lexicon set, so this changes no generated code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)