### PR TITLE
feat(bluesky): align moderation engine with official @atproto/api and add configurable behaviors

### DIFF
--- a/packages/bluesky/CHANGELOG.md
+++ b/packages/bluesky/CHANGELOG.md
@@ -1,8 +1,22 @@
 # Release Note
 
-## v1.5.1
+## v1.6.0
+
+Aligned the client-side moderation engine with the official `@atproto/api` implementation:
 
 - fix: `moderateUserList` now delegates to `decideUserList` instead of recursing into itself (previously caused a `StackOverflowError`).
+- fix: `decideUserList` no longer crashes on `ListView` subjects and now merges the creator's account/profile decisions, matching the official implementation.
+- fix: label causes from subscribed labelers are now attributed to the labeler (`ModerationCauseSource.labeler`) instead of always to the user.
+- fix: `getInterpretedLabelValueDefinitions` now defaults `adultOnly` to `false` (previously `true`), so labeler-defined labels are no longer adult-gated unless declared.
+- fix: `getLabelerHeaders` now appends `;redact` only to app labelers (Bluesky's official labeler), matching the official `atproto-accept-labelers` header behavior. Subscribed labelers are sent without parameters.
+- feat: added the deprecated `gore` alias for `graphic-media` to the known label definitions (`KnownLabelValue.gore`), matching the official label defs.
+- feat: muted words now support `expiresAt` (expired words are ignored) and `actorTarget: exclude-following` (pass the post author via the new `actor` parameter).
+- feat: added `matchMuteWords` and `MuteWordMatch`, mirroring the official API. `ModerationCauseMuteWord` now carries the `matches` that triggered it.
+- fix: muted words with internal slashes now follow the official exclusion rule (`and/or` no longer matches `andor`), and all tag facet features are considered (previously only the first per facet).
+- feat: mute-word matching in `moderatePost` now scans `app.bsky.embed.gallery` alt texts and applies `exclude-following` via the post/quote author.
+- feat: added `moderateStatus` / `decideStatus` for live status (`app.bsky.actor.defs#statusView`) moderation.
+- feat: added `ModerationBehaviors` — a configuration object on `ModerationOpts.behaviors` that lets users customize block/mute/mute-word/hide behaviors and global label definitions without forking the engine. Defaults replicate the official logic.
+- chore: deprecated the string-keyed `kBlockBehavior` / `kMuteBehavior` / `kMuteWordBehavior` / `kHideBehavior` constants in favor of the typed `kDefault*Behaviors` maps.
 - chore: bump `atproto` and `atproto_core`.
 
 ## v1.5.0

--- a/packages/bluesky/lib/moderation.dart
+++ b/packages/bluesky/lib/moderation.dart
@@ -8,7 +8,8 @@ export 'package:bluesky/src/moderation.dart'
         moderateProfile,
         moderateNotification,
         moderateFeedGenerator,
-        moderateUserList;
+        moderateUserList,
+        moderateStatus;
 
 export 'package:bluesky/src/moderation/decision.dart' show ModerationDecision;
 export 'package:bluesky/src/moderation/utils.dart'
@@ -22,8 +23,10 @@ export 'package:bluesky/src/moderation/utils.dart'
 export 'package:bluesky/src/moderation/types/interpreted_label_value_definition.dart';
 export 'package:bluesky/src/moderation/types/moderation_ui.dart';
 export 'package:bluesky/src/moderation/types/moderation_behavior.dart';
+export 'package:bluesky/src/moderation/types/moderation_behaviors.dart';
 export 'package:bluesky/src/moderation/types/labels.dart';
-export 'package:bluesky/src/moderation/types/mute_words.dart' show hasMutedWord;
+export 'package:bluesky/src/moderation/types/mute_words.dart'
+    show hasMutedWord, matchMuteWords, MuteWordMatch;
 
 export 'package:bluesky/src/moderation/types/behaviors/moderation_cause_block_other.dart';
 export 'package:bluesky/src/moderation/types/behaviors/moderation_cause_blocked_by.dart';

--- a/packages/bluesky/lib/src/moderation.dart
+++ b/packages/bluesky/lib/src/moderation.dart
@@ -15,6 +15,7 @@ import 'moderation/types/subjects/moderation_subject_user_list.dart';
 import 'moderation/types/subjects/notification.dart';
 import 'moderation/types/subjects/post.dart';
 import 'moderation/types/subjects/profile.dart';
+import 'moderation/types/subjects/status.dart';
 import 'moderation/types/subjects/user_list.dart';
 
 ModerationDecision moderateProfile(
@@ -44,3 +45,8 @@ ModerationDecision moderateUserList(
   final ModerationSubjectUserList subject,
   final ModerationOpts opts,
 ) => decideUserList(subject, opts);
+
+ModerationDecision moderateStatus(
+  final ModerationSubjectProfile subject,
+  final ModerationOpts opts,
+) => decideStatus(subject, opts);

--- a/packages/bluesky/lib/src/moderation/decision.dart
+++ b/packages/bluesky/lib/src/moderation/decision.dart
@@ -20,20 +20,30 @@ import 'types/behaviors/moderation_cause_source_labeler.dart';
 import 'types/behaviors/moderation_cause_source_list.dart';
 import 'types/behaviors/moderation_cause_source_user.dart';
 import 'types/behaviors/moderation_opts.dart';
-import 'types/const/labels.dart';
 import 'types/interpreted_label_value_definition.dart';
 import 'types/labels.dart';
 import 'types/moderation_behavior.dart';
+import 'types/moderation_behaviors.dart';
 import 'types/moderation_ui.dart';
+import 'types/mute_words.dart';
 import 'types/syntax.dart';
 
 enum ModerationBehaviorSeverity { high, medium, low }
 
 final class ModerationDecision {
-  ModerationDecision._({required this.causes, this.did = '', this.me = false});
+  ModerationDecision._({
+    required this.causes,
+    this.did = '',
+    this.me = false,
+    this.behaviors = const ModerationBehaviors(),
+  });
 
-  factory ModerationDecision.init({String did = '', bool me = false}) =>
-      ModerationDecision._(did: did, me: me, causes: []);
+  factory ModerationDecision.init({
+    String did = '',
+    bool me = false,
+    ModerationBehaviors behaviors = const ModerationBehaviors(),
+  }) =>
+      ModerationDecision._(did: did, me: me, behaviors: behaviors, causes: []);
 
   factory ModerationDecision.merge(final List<ModerationDecision> decisions) {
     if (decisions.isEmpty) return ModerationDecision.init();
@@ -41,6 +51,7 @@ final class ModerationDecision {
     return ModerationDecision._(
       did: decisions.first.did,
       me: decisions.first.me,
+      behaviors: decisions.first.behaviors,
       causes: decisions.expand((e) => e.causes).toList(),
     );
   }
@@ -48,6 +59,9 @@ final class ModerationDecision {
   final String did;
   final bool me;
   final List<ModerationCause> causes;
+
+  /// The behaviors used to interpret the causes in [getUI].
+  final ModerationBehaviors behaviors;
 
   ModerationDecision downgrade() {
     final causes = <ModerationCause>[];
@@ -72,7 +86,12 @@ final class ModerationDecision {
       );
     }
 
-    return ModerationDecision._(did: did, me: me, causes: causes);
+    return ModerationDecision._(
+      did: did,
+      me: me,
+      behaviors: behaviors,
+      causes: causes,
+    );
   }
 
   void addHidden() => causes.add(
@@ -83,13 +102,20 @@ final class ModerationDecision {
     ),
   );
 
-  void addMutedWord() => causes.add(
-    const ModerationCause.muteWord(
-      data: ModerationCauseMuteWord(
-        source: ModerationCauseSource.user(data: ModerationCauseSourceUser()),
+  void addMutedWord([final List<MuteWordMatch>? matches]) {
+    if (matches != null && matches.isEmpty) return;
+
+    causes.add(
+      ModerationCause.muteWord(
+        data: ModerationCauseMuteWord(
+          source: const ModerationCauseSource.user(
+            data: ModerationCauseSourceUser(),
+          ),
+          matches: matches ?? const [],
+        ),
       ),
-    ),
-  );
+    );
+  }
 
   void addBlocking() => causes.add(
     const ModerationCause.blocking(
@@ -136,9 +162,9 @@ final class ModerationDecision {
           opts.labelDefs[label.src]
               ?.where((e) => e.identifier == label.val)
               .firstOrNull ??
-          kLabels[KnownLabelValue.valueOf(label.val)];
+          opts.behaviors.labels[label.val];
     } else {
-      labelDef = kLabels[KnownLabelValue.valueOf(label.val)];
+      labelDef = opts.behaviors.labels[label.val];
     }
 
     if (labelDef == null) {
@@ -209,12 +235,12 @@ final class ModerationDecision {
     causes.add(
       ModerationCause.label(
         data: ModerationCauseLabel(
-          source: isSelf || labeler != null
+          source: isSelf || labeler == null
               ? const ModerationCauseSource.user(
                   data: ModerationCauseSourceUser(),
                 )
               : ModerationCauseSource.labeler(
-                  data: ModerationCauseSourceLabeler(did: labeler!.did),
+                  data: ModerationCauseSourceLabeler(did: labeler.did),
                 ),
           label: label,
           labelDef: labelDef,
@@ -264,13 +290,12 @@ final class ModerationDecision {
         }
 
         if (!cause.downgraded) {
-          if (kBlockBehavior[context.name] == ModerationBehavior.blur) {
+          if (behaviors.block[context] == ModerationBehavior.blur) {
             noOverride = true;
             blurs.add(cause);
-          } else if (kBlockBehavior[context.name] == ModerationBehavior.alert) {
+          } else if (behaviors.block[context] == ModerationBehavior.alert) {
             alerts.add(cause);
-          } else if (kBlockBehavior[context.name] ==
-              ModerationBehavior.inform) {
+          } else if (behaviors.block[context] == ModerationBehavior.inform) {
             informs.add(cause);
           }
         }
@@ -282,11 +307,11 @@ final class ModerationDecision {
         }
 
         if (!cause.downgraded) {
-          if (kMuteBehavior[context.name] == ModerationBehavior.blur) {
+          if (behaviors.mute[context] == ModerationBehavior.blur) {
             blurs.add(cause);
-          } else if (kMuteBehavior[context.name] == ModerationBehavior.alert) {
+          } else if (behaviors.mute[context] == ModerationBehavior.alert) {
             alerts.add(cause);
-          } else if (kMuteBehavior[context.name] == ModerationBehavior.inform) {
+          } else if (behaviors.mute[context] == ModerationBehavior.inform) {
             informs.add(cause);
           }
         }
@@ -298,13 +323,11 @@ final class ModerationDecision {
         }
 
         if (!cause.downgraded) {
-          if (kMuteWordBehavior[context.name] == ModerationBehavior.blur) {
+          if (behaviors.muteWord[context] == ModerationBehavior.blur) {
             blurs.add(cause);
-          } else if (kMuteWordBehavior[context.name] ==
-              ModerationBehavior.alert) {
+          } else if (behaviors.muteWord[context] == ModerationBehavior.alert) {
             alerts.add(cause);
-          } else if (kMuteWordBehavior[context.name] ==
-              ModerationBehavior.inform) {
+          } else if (behaviors.muteWord[context] == ModerationBehavior.inform) {
             informs.add(cause);
           }
         }
@@ -314,11 +337,11 @@ final class ModerationDecision {
         }
 
         if (!cause.downgraded) {
-          if (kHideBehavior[context.name] == ModerationBehavior.blur) {
+          if (behaviors.hide[context] == ModerationBehavior.blur) {
             blurs.add(cause);
-          } else if (kHideBehavior[context.name] == ModerationBehavior.alert) {
+          } else if (behaviors.hide[context] == ModerationBehavior.alert) {
             alerts.add(cause);
-          } else if (kHideBehavior[context.name] == ModerationBehavior.inform) {
+          } else if (behaviors.hide[context] == ModerationBehavior.inform) {
             informs.add(cause);
           }
         }

--- a/packages/bluesky/lib/src/moderation/types/behaviors/moderation_cause_mute_word.dart
+++ b/packages/bluesky/lib/src/moderation/types/behaviors/moderation_cause_mute_word.dart
@@ -6,6 +6,7 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 // Project imports:
+import '../mute_words.dart';
 import 'moderation_cause_source.dart';
 
 part 'moderation_cause_mute_word.freezed.dart';
@@ -16,5 +17,8 @@ abstract class ModerationCauseMuteWord with _$ModerationCauseMuteWord {
     required ModerationCauseSource source,
     @Default(6) int priority,
     @Default(false) bool downgraded,
+
+    /// The muted word matches that caused this moderation.
+    @Default([]) List<MuteWordMatch> matches,
   }) = _ModerationCauseMuteWord;
 }

--- a/packages/bluesky/lib/src/moderation/types/behaviors/moderation_cause_mute_word.freezed.dart
+++ b/packages/bluesky/lib/src/moderation/types/behaviors/moderation_cause_mute_word.freezed.dart
@@ -14,7 +14,8 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$ModerationCauseMuteWord {
 
- ModerationCauseSource get source; int get priority; bool get downgraded;
+ ModerationCauseSource get source; int get priority; bool get downgraded;/// The muted word matches that caused this moderation.
+ List<MuteWordMatch> get matches;
 /// Create a copy of ModerationCauseMuteWord
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -25,16 +26,16 @@ $ModerationCauseMuteWordCopyWith<ModerationCauseMuteWord> get copyWith => _$Mode
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is ModerationCauseMuteWord&&(identical(other.source, source) || other.source == source)&&(identical(other.priority, priority) || other.priority == priority)&&(identical(other.downgraded, downgraded) || other.downgraded == downgraded));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is ModerationCauseMuteWord&&(identical(other.source, source) || other.source == source)&&(identical(other.priority, priority) || other.priority == priority)&&(identical(other.downgraded, downgraded) || other.downgraded == downgraded)&&const DeepCollectionEquality().equals(other.matches, matches));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,source,priority,downgraded);
+int get hashCode => Object.hash(runtimeType,source,priority,downgraded,const DeepCollectionEquality().hash(matches));
 
 @override
 String toString() {
-  return 'ModerationCauseMuteWord(source: $source, priority: $priority, downgraded: $downgraded)';
+  return 'ModerationCauseMuteWord(source: $source, priority: $priority, downgraded: $downgraded, matches: $matches)';
 }
 
 
@@ -45,7 +46,7 @@ abstract mixin class $ModerationCauseMuteWordCopyWith<$Res>  {
   factory $ModerationCauseMuteWordCopyWith(ModerationCauseMuteWord value, $Res Function(ModerationCauseMuteWord) _then) = _$ModerationCauseMuteWordCopyWithImpl;
 @useResult
 $Res call({
- ModerationCauseSource source, int priority, bool downgraded
+ ModerationCauseSource source, int priority, bool downgraded, List<MuteWordMatch> matches
 });
 
 
@@ -62,12 +63,13 @@ class _$ModerationCauseMuteWordCopyWithImpl<$Res>
 
 /// Create a copy of ModerationCauseMuteWord
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? source = null,Object? priority = null,Object? downgraded = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? source = null,Object? priority = null,Object? downgraded = null,Object? matches = null,}) {
   return _then(_self.copyWith(
 source: null == source ? _self.source : source // ignore: cast_nullable_to_non_nullable
 as ModerationCauseSource,priority: null == priority ? _self.priority : priority // ignore: cast_nullable_to_non_nullable
 as int,downgraded: null == downgraded ? _self.downgraded : downgraded // ignore: cast_nullable_to_non_nullable
-as bool,
+as bool,matches: null == matches ? _self.matches : matches // ignore: cast_nullable_to_non_nullable
+as List<MuteWordMatch>,
   ));
 }
 /// Create a copy of ModerationCauseMuteWord
@@ -161,10 +163,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( ModerationCauseSource source,  int priority,  bool downgraded)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( ModerationCauseSource source,  int priority,  bool downgraded,  List<MuteWordMatch> matches)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _ModerationCauseMuteWord() when $default != null:
-return $default(_that.source,_that.priority,_that.downgraded);case _:
+return $default(_that.source,_that.priority,_that.downgraded,_that.matches);case _:
   return orElse();
 
 }
@@ -182,10 +184,10 @@ return $default(_that.source,_that.priority,_that.downgraded);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( ModerationCauseSource source,  int priority,  bool downgraded)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( ModerationCauseSource source,  int priority,  bool downgraded,  List<MuteWordMatch> matches)  $default,) {final _that = this;
 switch (_that) {
 case _ModerationCauseMuteWord():
-return $default(_that.source,_that.priority,_that.downgraded);case _:
+return $default(_that.source,_that.priority,_that.downgraded,_that.matches);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -202,10 +204,10 @@ return $default(_that.source,_that.priority,_that.downgraded);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( ModerationCauseSource source,  int priority,  bool downgraded)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( ModerationCauseSource source,  int priority,  bool downgraded,  List<MuteWordMatch> matches)?  $default,) {final _that = this;
 switch (_that) {
 case _ModerationCauseMuteWord() when $default != null:
-return $default(_that.source,_that.priority,_that.downgraded);case _:
+return $default(_that.source,_that.priority,_that.downgraded,_that.matches);case _:
   return null;
 
 }
@@ -217,12 +219,21 @@ return $default(_that.source,_that.priority,_that.downgraded);case _:
 
 
 class _ModerationCauseMuteWord implements ModerationCauseMuteWord {
-  const _ModerationCauseMuteWord({required this.source, this.priority = 6, this.downgraded = false});
+  const _ModerationCauseMuteWord({required this.source, this.priority = 6, this.downgraded = false, final  List<MuteWordMatch> matches = const []}): _matches = matches;
   
 
 @override final  ModerationCauseSource source;
 @override@JsonKey() final  int priority;
 @override@JsonKey() final  bool downgraded;
+/// The muted word matches that caused this moderation.
+ final  List<MuteWordMatch> _matches;
+/// The muted word matches that caused this moderation.
+@override@JsonKey() List<MuteWordMatch> get matches {
+  if (_matches is EqualUnmodifiableListView) return _matches;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_matches);
+}
+
 
 /// Create a copy of ModerationCauseMuteWord
 /// with the given fields replaced by the non-null parameter values.
@@ -234,16 +245,16 @@ _$ModerationCauseMuteWordCopyWith<_ModerationCauseMuteWord> get copyWith => __$M
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _ModerationCauseMuteWord&&(identical(other.source, source) || other.source == source)&&(identical(other.priority, priority) || other.priority == priority)&&(identical(other.downgraded, downgraded) || other.downgraded == downgraded));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _ModerationCauseMuteWord&&(identical(other.source, source) || other.source == source)&&(identical(other.priority, priority) || other.priority == priority)&&(identical(other.downgraded, downgraded) || other.downgraded == downgraded)&&const DeepCollectionEquality().equals(other._matches, _matches));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,source,priority,downgraded);
+int get hashCode => Object.hash(runtimeType,source,priority,downgraded,const DeepCollectionEquality().hash(_matches));
 
 @override
 String toString() {
-  return 'ModerationCauseMuteWord(source: $source, priority: $priority, downgraded: $downgraded)';
+  return 'ModerationCauseMuteWord(source: $source, priority: $priority, downgraded: $downgraded, matches: $matches)';
 }
 
 
@@ -254,7 +265,7 @@ abstract mixin class _$ModerationCauseMuteWordCopyWith<$Res> implements $Moderat
   factory _$ModerationCauseMuteWordCopyWith(_ModerationCauseMuteWord value, $Res Function(_ModerationCauseMuteWord) _then) = __$ModerationCauseMuteWordCopyWithImpl;
 @override @useResult
 $Res call({
- ModerationCauseSource source, int priority, bool downgraded
+ ModerationCauseSource source, int priority, bool downgraded, List<MuteWordMatch> matches
 });
 
 
@@ -271,12 +282,13 @@ class __$ModerationCauseMuteWordCopyWithImpl<$Res>
 
 /// Create a copy of ModerationCauseMuteWord
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? source = null,Object? priority = null,Object? downgraded = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? source = null,Object? priority = null,Object? downgraded = null,Object? matches = null,}) {
   return _then(_ModerationCauseMuteWord(
 source: null == source ? _self.source : source // ignore: cast_nullable_to_non_nullable
 as ModerationCauseSource,priority: null == priority ? _self.priority : priority // ignore: cast_nullable_to_non_nullable
 as int,downgraded: null == downgraded ? _self.downgraded : downgraded // ignore: cast_nullable_to_non_nullable
-as bool,
+as bool,matches: null == matches ? _self._matches : matches // ignore: cast_nullable_to_non_nullable
+as List<MuteWordMatch>,
   ));
 }
 

--- a/packages/bluesky/lib/src/moderation/types/behaviors/moderation_opts.dart
+++ b/packages/bluesky/lib/src/moderation/types/behaviors/moderation_opts.dart
@@ -7,6 +7,7 @@ import 'package:freezed_annotation/freezed_annotation.dart';
 
 // Project imports:
 import '../interpreted_label_value_definition.dart';
+import '../moderation_behaviors.dart';
 import 'moderation_prefs.dart';
 
 part 'moderation_opts.freezed.dart';
@@ -17,5 +18,9 @@ abstract class ModerationOpts with _$ModerationOpts {
     String? userDid,
     required ModerationPrefs prefs,
     @Default({}) Map<String, List<InterpretedLabelValueDefinition>> labelDefs,
+
+    /// The behaviors used to interpret moderation causes. Defaults to the
+    /// official Bluesky moderation behaviors.
+    @Default(ModerationBehaviors()) ModerationBehaviors behaviors,
   }) = _ModerationOpts;
 }

--- a/packages/bluesky/lib/src/moderation/types/behaviors/moderation_opts.freezed.dart
+++ b/packages/bluesky/lib/src/moderation/types/behaviors/moderation_opts.freezed.dart
@@ -14,7 +14,9 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$ModerationOpts {
 
- String? get userDid; ModerationPrefs get prefs; Map<String, List<InterpretedLabelValueDefinition>> get labelDefs;
+ String? get userDid; ModerationPrefs get prefs; Map<String, List<InterpretedLabelValueDefinition>> get labelDefs;/// The behaviors used to interpret moderation causes. Defaults to the
+/// official Bluesky moderation behaviors.
+ ModerationBehaviors get behaviors;
 /// Create a copy of ModerationOpts
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -25,16 +27,16 @@ $ModerationOptsCopyWith<ModerationOpts> get copyWith => _$ModerationOptsCopyWith
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is ModerationOpts&&(identical(other.userDid, userDid) || other.userDid == userDid)&&(identical(other.prefs, prefs) || other.prefs == prefs)&&const DeepCollectionEquality().equals(other.labelDefs, labelDefs));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is ModerationOpts&&(identical(other.userDid, userDid) || other.userDid == userDid)&&(identical(other.prefs, prefs) || other.prefs == prefs)&&const DeepCollectionEquality().equals(other.labelDefs, labelDefs)&&(identical(other.behaviors, behaviors) || other.behaviors == behaviors));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,userDid,prefs,const DeepCollectionEquality().hash(labelDefs));
+int get hashCode => Object.hash(runtimeType,userDid,prefs,const DeepCollectionEquality().hash(labelDefs),behaviors);
 
 @override
 String toString() {
-  return 'ModerationOpts(userDid: $userDid, prefs: $prefs, labelDefs: $labelDefs)';
+  return 'ModerationOpts(userDid: $userDid, prefs: $prefs, labelDefs: $labelDefs, behaviors: $behaviors)';
 }
 
 
@@ -45,7 +47,7 @@ abstract mixin class $ModerationOptsCopyWith<$Res>  {
   factory $ModerationOptsCopyWith(ModerationOpts value, $Res Function(ModerationOpts) _then) = _$ModerationOptsCopyWithImpl;
 @useResult
 $Res call({
- String? userDid, ModerationPrefs prefs, Map<String, List<InterpretedLabelValueDefinition>> labelDefs
+ String? userDid, ModerationPrefs prefs, Map<String, List<InterpretedLabelValueDefinition>> labelDefs, ModerationBehaviors behaviors
 });
 
 
@@ -62,12 +64,13 @@ class _$ModerationOptsCopyWithImpl<$Res>
 
 /// Create a copy of ModerationOpts
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? userDid = freezed,Object? prefs = null,Object? labelDefs = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? userDid = freezed,Object? prefs = null,Object? labelDefs = null,Object? behaviors = null,}) {
   return _then(_self.copyWith(
 userDid: freezed == userDid ? _self.userDid : userDid // ignore: cast_nullable_to_non_nullable
 as String?,prefs: null == prefs ? _self.prefs : prefs // ignore: cast_nullable_to_non_nullable
 as ModerationPrefs,labelDefs: null == labelDefs ? _self.labelDefs : labelDefs // ignore: cast_nullable_to_non_nullable
-as Map<String, List<InterpretedLabelValueDefinition>>,
+as Map<String, List<InterpretedLabelValueDefinition>>,behaviors: null == behaviors ? _self.behaviors : behaviors // ignore: cast_nullable_to_non_nullable
+as ModerationBehaviors,
   ));
 }
 /// Create a copy of ModerationOpts
@@ -161,10 +164,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String? userDid,  ModerationPrefs prefs,  Map<String, List<InterpretedLabelValueDefinition>> labelDefs)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String? userDid,  ModerationPrefs prefs,  Map<String, List<InterpretedLabelValueDefinition>> labelDefs,  ModerationBehaviors behaviors)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _ModerationOpts() when $default != null:
-return $default(_that.userDid,_that.prefs,_that.labelDefs);case _:
+return $default(_that.userDid,_that.prefs,_that.labelDefs,_that.behaviors);case _:
   return orElse();
 
 }
@@ -182,10 +185,10 @@ return $default(_that.userDid,_that.prefs,_that.labelDefs);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String? userDid,  ModerationPrefs prefs,  Map<String, List<InterpretedLabelValueDefinition>> labelDefs)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String? userDid,  ModerationPrefs prefs,  Map<String, List<InterpretedLabelValueDefinition>> labelDefs,  ModerationBehaviors behaviors)  $default,) {final _that = this;
 switch (_that) {
 case _ModerationOpts():
-return $default(_that.userDid,_that.prefs,_that.labelDefs);case _:
+return $default(_that.userDid,_that.prefs,_that.labelDefs,_that.behaviors);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -202,10 +205,10 @@ return $default(_that.userDid,_that.prefs,_that.labelDefs);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String? userDid,  ModerationPrefs prefs,  Map<String, List<InterpretedLabelValueDefinition>> labelDefs)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String? userDid,  ModerationPrefs prefs,  Map<String, List<InterpretedLabelValueDefinition>> labelDefs,  ModerationBehaviors behaviors)?  $default,) {final _that = this;
 switch (_that) {
 case _ModerationOpts() when $default != null:
-return $default(_that.userDid,_that.prefs,_that.labelDefs);case _:
+return $default(_that.userDid,_that.prefs,_that.labelDefs,_that.behaviors);case _:
   return null;
 
 }
@@ -217,7 +220,7 @@ return $default(_that.userDid,_that.prefs,_that.labelDefs);case _:
 
 
 class _ModerationOpts implements ModerationOpts {
-  const _ModerationOpts({this.userDid, required this.prefs, final  Map<String, List<InterpretedLabelValueDefinition>> labelDefs = const {}}): _labelDefs = labelDefs;
+  const _ModerationOpts({this.userDid, required this.prefs, final  Map<String, List<InterpretedLabelValueDefinition>> labelDefs = const {}, this.behaviors = const ModerationBehaviors()}): _labelDefs = labelDefs;
   
 
 @override final  String? userDid;
@@ -229,6 +232,9 @@ class _ModerationOpts implements ModerationOpts {
   return EqualUnmodifiableMapView(_labelDefs);
 }
 
+/// The behaviors used to interpret moderation causes. Defaults to the
+/// official Bluesky moderation behaviors.
+@override@JsonKey() final  ModerationBehaviors behaviors;
 
 /// Create a copy of ModerationOpts
 /// with the given fields replaced by the non-null parameter values.
@@ -240,16 +246,16 @@ _$ModerationOptsCopyWith<_ModerationOpts> get copyWith => __$ModerationOptsCopyW
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _ModerationOpts&&(identical(other.userDid, userDid) || other.userDid == userDid)&&(identical(other.prefs, prefs) || other.prefs == prefs)&&const DeepCollectionEquality().equals(other._labelDefs, _labelDefs));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _ModerationOpts&&(identical(other.userDid, userDid) || other.userDid == userDid)&&(identical(other.prefs, prefs) || other.prefs == prefs)&&const DeepCollectionEquality().equals(other._labelDefs, _labelDefs)&&(identical(other.behaviors, behaviors) || other.behaviors == behaviors));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,userDid,prefs,const DeepCollectionEquality().hash(_labelDefs));
+int get hashCode => Object.hash(runtimeType,userDid,prefs,const DeepCollectionEquality().hash(_labelDefs),behaviors);
 
 @override
 String toString() {
-  return 'ModerationOpts(userDid: $userDid, prefs: $prefs, labelDefs: $labelDefs)';
+  return 'ModerationOpts(userDid: $userDid, prefs: $prefs, labelDefs: $labelDefs, behaviors: $behaviors)';
 }
 
 
@@ -260,7 +266,7 @@ abstract mixin class _$ModerationOptsCopyWith<$Res> implements $ModerationOptsCo
   factory _$ModerationOptsCopyWith(_ModerationOpts value, $Res Function(_ModerationOpts) _then) = __$ModerationOptsCopyWithImpl;
 @override @useResult
 $Res call({
- String? userDid, ModerationPrefs prefs, Map<String, List<InterpretedLabelValueDefinition>> labelDefs
+ String? userDid, ModerationPrefs prefs, Map<String, List<InterpretedLabelValueDefinition>> labelDefs, ModerationBehaviors behaviors
 });
 
 
@@ -277,12 +283,13 @@ class __$ModerationOptsCopyWithImpl<$Res>
 
 /// Create a copy of ModerationOpts
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? userDid = freezed,Object? prefs = null,Object? labelDefs = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? userDid = freezed,Object? prefs = null,Object? labelDefs = null,Object? behaviors = null,}) {
   return _then(_ModerationOpts(
 userDid: freezed == userDid ? _self.userDid : userDid // ignore: cast_nullable_to_non_nullable
 as String?,prefs: null == prefs ? _self.prefs : prefs // ignore: cast_nullable_to_non_nullable
 as ModerationPrefs,labelDefs: null == labelDefs ? _self._labelDefs : labelDefs // ignore: cast_nullable_to_non_nullable
-as Map<String, List<InterpretedLabelValueDefinition>>,
+as Map<String, List<InterpretedLabelValueDefinition>>,behaviors: null == behaviors ? _self.behaviors : behaviors // ignore: cast_nullable_to_non_nullable
+as ModerationBehaviors,
   ));
 }
 

--- a/packages/bluesky/lib/src/moderation/types/const/labels.dart
+++ b/packages/bluesky/lib/src/moderation/types/const/labels.dart
@@ -14,7 +14,10 @@ enum KnownLabelValue {
   porn('porn'),
   sexual('sexual'),
   nudity('nudity'),
-  graphicMedia('graphic-media');
+  graphicMedia('graphic-media'),
+
+  /// Deprecated alias for [graphicMedia].
+  gore('gore');
 
   final String value;
 
@@ -47,6 +50,19 @@ const kLabels = <KnownLabelValue, InterpretedLabelValueDefinition>{
   KnownLabelValue.sexual: kSexualInterpretedLabelValueDefinition,
   KnownLabelValue.nudity: kNudityInterpretedLabelValueDefinition,
   KnownLabelValue.graphicMedia: kGraphicMediaInterpretedLabelValueDefinition,
+  KnownLabelValue.gore: kGoreInterpretedLabelValueDefinition,
+};
+
+/// The known label definitions keyed by label identifier.
+const kLabelDefinitions = <String, InterpretedLabelValueDefinition>{
+  '!hide': kHideInterpretedLabelValueDefinition,
+  '!warn': kWarnInterpretedLabelValueDefinition,
+  '!no-unauthenticated': kNoUnauthenticatedInterpretedLabelValueDefinition,
+  'porn': kPornInterpretedLabelValueDefinition,
+  'sexual': kSexualInterpretedLabelValueDefinition,
+  'nudity': kNudityInterpretedLabelValueDefinition,
+  'graphic-media': kGraphicMediaInterpretedLabelValueDefinition,
+  'gore': kGoreInterpretedLabelValueDefinition,
 };
 
 const kHideInterpretedLabelValueDefinition = InterpretedLabelValueDefinition(
@@ -184,6 +200,29 @@ const kNudityInterpretedLabelValueDefinition = InterpretedLabelValueDefinition(
   identifier: 'nudity',
   configurable: true,
   defaultSetting: LabelPreference.ignore,
+  severity: 'none',
+  blurs: 'media',
+  behaviors: {
+    LabelTarget.account: {
+      ModerationBehaviorContext.avatar: ModerationBehavior.blur,
+      ModerationBehaviorContext.banner: ModerationBehavior.blur,
+    },
+    LabelTarget.profile: {
+      ModerationBehaviorContext.avatar: ModerationBehavior.blur,
+      ModerationBehaviorContext.banner: ModerationBehavior.blur,
+    },
+    LabelTarget.content: {
+      ModerationBehaviorContext.contentMedia: ModerationBehavior.blur,
+    },
+  },
+);
+
+/// Deprecated alias for [kGraphicMediaInterpretedLabelValueDefinition].
+const kGoreInterpretedLabelValueDefinition = InterpretedLabelValueDefinition(
+  identifier: 'gore',
+  configurable: true,
+  defaultSetting: LabelPreference.warn,
+  flags: [LabelValueDefinitionFlag.adult],
   severity: 'none',
   blurs: 'media',
   behaviors: {

--- a/packages/bluesky/lib/src/moderation/types/moderation_behavior.dart
+++ b/packages/bluesky/lib/src/moderation/types/moderation_behavior.dart
@@ -15,6 +15,7 @@ enum ModerationBehavior {
   bool get isInform => this == ModerationBehavior.inform;
 }
 
+@Deprecated('Use kDefaultBlockBehaviors in moderation_behaviors.dart instead')
 const kBlockBehavior = {
   'profileList': ModerationBehavior.blur,
   'profileView': ModerationBehavior.alert,
@@ -24,6 +25,7 @@ const kBlockBehavior = {
   'contentView': ModerationBehavior.blur,
 };
 
+@Deprecated('Use kDefaultMuteBehaviors in moderation_behaviors.dart instead')
 const kMuteBehavior = {
   'profileList': ModerationBehavior.inform,
   'profileView': ModerationBehavior.alert,
@@ -31,11 +33,15 @@ const kMuteBehavior = {
   'contentView': ModerationBehavior.inform,
 };
 
+@Deprecated(
+  'Use kDefaultMuteWordBehaviors in moderation_behaviors.dart instead',
+)
 const kMuteWordBehavior = {
   'contentList': ModerationBehavior.blur,
   'contentView': ModerationBehavior.blur,
 };
 
+@Deprecated('Use kDefaultHideBehaviors in moderation_behaviors.dart instead')
 const kHideBehavior = {
   'contentList': ModerationBehavior.blur,
   'contentView': ModerationBehavior.blur,

--- a/packages/bluesky/lib/src/moderation/types/moderation_behaviors.dart
+++ b/packages/bluesky/lib/src/moderation/types/moderation_behaviors.dart
@@ -1,0 +1,125 @@
+// Copyright (c) 2023-2025, Shinya Kato.
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// Project imports:
+import 'const/labels.dart';
+import 'interpreted_label_value_definition.dart';
+import 'moderation_behavior.dart';
+
+/// The default behaviors applied when the subject is blocked.
+const kDefaultBlockBehaviors = <ModerationBehaviorContext, ModerationBehavior>{
+  ModerationBehaviorContext.profileList: ModerationBehavior.blur,
+  ModerationBehaviorContext.profileView: ModerationBehavior.alert,
+  ModerationBehaviorContext.avatar: ModerationBehavior.blur,
+  ModerationBehaviorContext.banner: ModerationBehavior.blur,
+  ModerationBehaviorContext.contentList: ModerationBehavior.blur,
+  ModerationBehaviorContext.contentView: ModerationBehavior.blur,
+};
+
+/// The default behaviors applied when the subject is muted.
+const kDefaultMuteBehaviors = <ModerationBehaviorContext, ModerationBehavior>{
+  ModerationBehaviorContext.profileList: ModerationBehavior.inform,
+  ModerationBehaviorContext.profileView: ModerationBehavior.alert,
+  ModerationBehaviorContext.contentList: ModerationBehavior.blur,
+  ModerationBehaviorContext.contentView: ModerationBehavior.inform,
+};
+
+/// The default behaviors applied when the subject matches a muted word.
+const kDefaultMuteWordBehaviors =
+    <ModerationBehaviorContext, ModerationBehavior>{
+      ModerationBehaviorContext.contentList: ModerationBehavior.blur,
+      ModerationBehaviorContext.contentView: ModerationBehavior.blur,
+    };
+
+/// The default behaviors applied when the subject is hidden by the user.
+const kDefaultHideBehaviors = <ModerationBehaviorContext, ModerationBehavior>{
+  ModerationBehaviorContext.contentList: ModerationBehavior.blur,
+  ModerationBehaviorContext.contentView: ModerationBehavior.blur,
+};
+
+/// A configuration object that determines how moderation causes are
+/// interpreted and translated into UI behaviors.
+///
+/// The defaults replicate the official Bluesky moderation logic. Pass a
+/// customized instance via `ModerationOpts.behaviors` to change how blocks,
+/// mutes, muted words, hidden posts and labels are handled, without forking
+/// the moderation engine itself.
+///
+/// ```dart
+/// final opts = ModerationOpts(
+///   userDid: session.did,
+///   prefs: prefs,
+///   behaviors: ModerationBehaviors(
+///     // e.g. show muted content in feeds instead of blurring it.
+///     mute: {
+///       ModerationBehaviorContext.profileView: ModerationBehavior.alert,
+///     },
+///     // e.g. override or add global label definitions.
+///     labels: {
+///       ...kLabelDefinitions,
+///       'my-custom-label': myCustomLabelDefinition,
+///     },
+///   ),
+/// );
+/// ```
+final class ModerationBehaviors {
+  const ModerationBehaviors({
+    this.block = kDefaultBlockBehaviors,
+    this.mute = kDefaultMuteBehaviors,
+    this.muteWord = kDefaultMuteWordBehaviors,
+    this.hide = kDefaultHideBehaviors,
+    this.labels = kLabelDefinitions,
+  });
+
+  /// The behaviors applied when the subject is blocking, blocked by, or
+  /// has another block relationship with the user.
+  final Map<ModerationBehaviorContext, ModerationBehavior> block;
+
+  /// The behaviors applied when the subject is muted by the user.
+  final Map<ModerationBehaviorContext, ModerationBehavior> mute;
+
+  /// The behaviors applied when the subject matches one of the user's
+  /// muted words.
+  final Map<ModerationBehaviorContext, ModerationBehavior> muteWord;
+
+  /// The behaviors applied when the subject was hidden by the user.
+  final Map<ModerationBehaviorContext, ModerationBehavior> hide;
+
+  /// The global label definitions keyed by label identifier.
+  ///
+  /// Labeler-specific definitions are provided separately via
+  /// `ModerationOpts.labelDefs`.
+  final Map<String, InterpretedLabelValueDefinition> labels;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ModerationBehaviors &&
+          _mapEquals(block, other.block) &&
+          _mapEquals(mute, other.mute) &&
+          _mapEquals(muteWord, other.muteWord) &&
+          _mapEquals(hide, other.hide) &&
+          _mapEquals(labels, other.labels);
+
+  @override
+  int get hashCode => Object.hash(
+    block.length,
+    mute.length,
+    muteWord.length,
+    hide.length,
+    labels.length,
+  );
+}
+
+bool _mapEquals<K, V>(final Map<K, V> a, final Map<K, V> b) {
+  if (identical(a, b)) return true;
+  if (a.length != b.length) return false;
+  for (final entry in a.entries) {
+    if (!b.containsKey(entry.key) || b[entry.key] != entry.value) {
+      return false;
+    }
+  }
+
+  return true;
+}

--- a/packages/bluesky/lib/src/moderation/types/mute_words.dart
+++ b/packages/bluesky/lib/src/moderation/types/mute_words.dart
@@ -3,13 +3,13 @@
 // BSD-style license that can be found in the LICENSE file.
 
 // Package imports:
-
-// Package imports:
 import 'package:characters/characters.dart';
 
 // Project imports:
 import '../../services/codegen/app/bsky/actor/defs/muted_word.dart';
+import '../../services/codegen/app/bsky/actor/defs/muted_word_actor_target.dart';
 import '../../services/codegen/app/bsky/actor/defs/muted_word_target.dart';
+import '../../services/codegen/app/bsky/actor/defs/profile_view_basic.dart';
 import '../../services/codegen/app/bsky/richtext/facet/main.dart';
 import '../../services/codegen/app/bsky/richtext/facet/union_main_features.dart';
 
@@ -32,90 +32,161 @@ final _leadingTrailingPunctuationRegex = RegExp(
 final _whitespacePunctuationRegex = RegExp(r'(?:\s|\p{P})+?', unicode: true);
 final _wordBoundaryRegex = RegExp(r'[\s\n\t\r\f\v]+?');
 final _punctuationRegex = RegExp(r'\p{P}+', unicode: true);
+final _slashRegex = RegExp(r'[/]+');
 final _spaceRegex = RegExp(r'\s', unicode: true);
 
-bool hasMutedWord({
+/// A match found by [matchMuteWords].
+final class MuteWordMatch {
+  const MuteWordMatch({required this.word, required this.predicate});
+
+  /// The muted word that matched.
+  final MutedWord word;
+
+  /// The string that matched the muted word.
+  final String predicate;
+}
+
+/// Checks if the given text matches any of the muted words, returning the
+/// list of matches. An empty list means no matches were found.
+List<MuteWordMatch> matchMuteWords({
   required List<MutedWord> mutedWords,
   required String text,
   List<RichtextFacet>? facets,
   List<String>? outlineTags,
   List<String>? languages,
+  ProfileViewBasic? actor,
 }) {
-  final hasExceptionLanguage = _hasExceptionLanguage(languages);
-  final tags = <String>{
+  final exception = _kLanguageExceptions.contains(languages?.firstOrNull ?? '');
+  final tags = <String>[
     if (outlineTags != null) ...outlineTags.map((e) => e.toLowerCase()),
     if (facets != null)
-      ...facets
-          .map(
-            (e) =>
-                e.features.whereType<URichtextFacetFeaturesRichtextFacetTag>(),
-          )
-          .where((e) => e.isNotEmpty)
-          .map((e) => e.first.data.tag.toLowerCase()),
-  }.toList();
+      ...facets.expand(
+        (e) => e.features
+            .whereType<URichtextFacetFeaturesRichtextFacetTag>()
+            .map((tag) => tag.data.tag.toLowerCase()),
+      ),
+  ];
 
+  final matches = <MuteWordMatch>[];
+
+  outer:
   for (final mute in mutedWords) {
     final mutedWord = mute.value.toLowerCase();
     final postText = text.toLowerCase();
 
-    if (tags.contains(mutedWord)) return true;
+    // expired, ignore
+    if (mute.expiresAt != null && mute.expiresAt!.isBefore(DateTime.now())) {
+      continue;
+    }
+
+    if (mute.actorTarget?.knownValue ==
+            KnownMutedWordActorTarget.excludeFollowing &&
+        (actor?.viewer?.following != null)) {
+      continue;
+    }
+
+    // `content` applies to tags as well
+    if (tags.contains(mutedWord)) {
+      matches.add(MuteWordMatch(word: mute, predicate: mute.value));
+      continue;
+    }
+    // rest of the checks are for `content` only
     if (!mute.targets.contains(
       const MutedWordTarget.knownValue(data: KnownMutedWordTarget.content),
     )) {
       continue;
     }
 
-    if ((mutedWord.characters.length == 1 || hasExceptionLanguage) &&
+    // single character or other exception, has to use contains
+    if ((mutedWord.characters.length == 1 || exception) &&
         postText.contains(mutedWord)) {
-      return true;
+      matches.add(MuteWordMatch(word: mute, predicate: mute.value));
+      continue;
     }
+    // too long
     if (mutedWord.length > postText.length) continue;
-    if (mutedWord == postText) return true;
+    // exact match
+    if (mutedWord == postText) {
+      matches.add(MuteWordMatch(word: mute, predicate: mute.value));
+      continue;
+    }
+    // any muted phrase with space or punctuation
     if (_whitespacePunctuationRegex.hasMatch(mutedWord) &&
         postText.contains(mutedWord)) {
-      return true;
+      matches.add(MuteWordMatch(word: mute, predicate: mute.value));
+      continue;
     }
 
+    // check individual character groups
     for (final word in postText.split(_wordBoundaryRegex)) {
-      if (word == mutedWord) return true;
+      if (word == mutedWord) {
+        matches.add(MuteWordMatch(word: mute, predicate: word));
+        continue outer;
+      }
 
+      // compare word without leading/trailing punctuation, but allow internal
+      // punctuation (such as `s@ssy`)
       final wordTrimmedPunctuation = word.replaceAll(
         _leadingTrailingPunctuationRegex,
         '',
       );
 
-      if (mutedWord == wordTrimmedPunctuation) return true;
+      if (mutedWord == wordTrimmedPunctuation) {
+        matches.add(MuteWordMatch(word: mute, predicate: word));
+        continue outer;
+      }
       if (mutedWord.length > wordTrimmedPunctuation.length) continue;
 
       if (_punctuationRegex.hasMatch(wordTrimmedPunctuation)) {
+        // Exit case for any punctuation within the predicate that we _do_
+        // allow e.g. `and/or` should not match `Andor`.
+        if (_slashRegex.hasMatch(wordTrimmedPunctuation)) {
+          continue outer;
+        }
+
         final spacedWord = wordTrimmedPunctuation.replaceAll(
           _punctuationRegex,
           ' ',
         );
-        if (spacedWord == mutedWord) return true;
+        if (spacedWord == mutedWord) {
+          matches.add(MuteWordMatch(word: mute, predicate: word));
+          continue outer;
+        }
 
         final contiguousWord = spacedWord.replaceAll(_spaceRegex, '');
-        if (contiguousWord == mutedWord) return true;
+        if (contiguousWord == mutedWord) {
+          matches.add(MuteWordMatch(word: mute, predicate: word));
+          continue outer;
+        }
 
         final wordParts = wordTrimmedPunctuation.split(_punctuationRegex);
         for (final wordPart in wordParts) {
-          if (wordPart == mutedWord) return true;
+          if (wordPart == mutedWord) {
+            matches.add(MuteWordMatch(word: mute, predicate: word));
+            continue outer;
+          }
         }
       }
     }
   }
 
-  return false;
+  return matches;
 }
 
-bool _hasExceptionLanguage(final List<String>? languages) {
-  if (languages == null) return false;
-
-  for (final language in languages) {
-    if (_kLanguageExceptions.contains(language)) {
-      return true;
-    }
-  }
-
-  return false;
-}
+/// Checks if the given text matches any of the muted words, returning a
+/// boolean if any matches are found.
+bool hasMutedWord({
+  required List<MutedWord> mutedWords,
+  required String text,
+  List<RichtextFacet>? facets,
+  List<String>? outlineTags,
+  List<String>? languages,
+  ProfileViewBasic? actor,
+}) => matchMuteWords(
+  mutedWords: mutedWords,
+  text: text,
+  facets: facets,
+  outlineTags: outlineTags,
+  languages: languages,
+  actor: actor,
+).isNotEmpty;

--- a/packages/bluesky/lib/src/moderation/types/subjects/account.dart
+++ b/packages/bluesky/lib/src/moderation/types/subjects/account.dart
@@ -35,7 +35,11 @@ ModerationDecision decideAccount(
     _ => throw UnimplementedError(),
   };
 
-  final decision = ModerationDecision.init(did: did, me: did == opts.userDid);
+  final decision = ModerationDecision.init(
+    did: did,
+    me: did == opts.userDid,
+    behaviors: opts.behaviors,
+  );
 
   if (viewer != null) {
     if (viewer.isMuted) {

--- a/packages/bluesky/lib/src/moderation/types/subjects/feed_generator.dart
+++ b/packages/bluesky/lib/src/moderation/types/subjects/feed_generator.dart
@@ -27,6 +27,7 @@ ModerationDecision decideFeedGenerator(
   final decision = ModerationDecision.init(
     did: creator.did,
     me: creator.did == opts.userDid,
+    behaviors: opts.behaviors,
   );
 
   for (final label in labels ?? const <Label>[]) {

--- a/packages/bluesky/lib/src/moderation/types/subjects/notification.dart
+++ b/packages/bluesky/lib/src/moderation/types/subjects/notification.dart
@@ -31,6 +31,7 @@ ModerationDecision decideNotification(
   final decision = ModerationDecision.init(
     did: author.did,
     me: author.did == opts.userDid,
+    behaviors: opts.behaviors,
   );
 
   for (final label in labels ?? const <Label>[]) {

--- a/packages/bluesky/lib/src/moderation/types/subjects/post.dart
+++ b/packages/bluesky/lib/src/moderation/types/subjects/post.dart
@@ -7,7 +7,10 @@ import 'package:atproto/com_atproto_label_defs.dart';
 
 // Project imports:
 import '../../../services/codegen/app/bsky/actor/defs/muted_word.dart';
+import '../../../services/codegen/app/bsky/actor/defs/profile_view_basic.dart';
 import '../../../services/codegen/app/bsky/actor/defs/viewer_state.dart';
+import '../../../services/codegen/app/bsky/embed/gallery/union_main_items.dart';
+import '../../../services/codegen/app/bsky/embed/gallery/union_view_items.dart';
 import '../../../services/codegen/app/bsky/embed/record/union_view_record.dart';
 import '../../../services/codegen/app/bsky/embed/record/view_blocked.dart';
 import '../../../services/codegen/app/bsky/embed/record/view_record.dart';
@@ -43,6 +46,7 @@ ModerationDecision decidePost(
   final decision = ModerationDecision.init(
     did: author.did,
     me: author.did == opts.userDid,
+    behaviors: opts.behaviors,
   );
 
   for (final label in labels ?? const <Label>[]) {
@@ -53,13 +57,15 @@ ModerationDecision decidePost(
     decision.addHidden();
   }
 
-  if (!decision.me &&
-      _hasMutedWords(
+  if (!decision.me) {
+    decision.addMutedWord(
+      _matchAllMuteWords(
+        author,
         FeedPostRecord.fromJson(record),
         embed,
         opts.prefs.mutedWords,
-      )) {
-    decision.addMutedWord();
+      ),
+    );
   }
 
   ModerationDecision? embedDecision;
@@ -108,6 +114,7 @@ ModerationDecision decideQuotedPost(
   final decision = ModerationDecision.init(
     did: subject.author.did,
     me: subject.author.did == opts.userDid,
+    behaviors: opts.behaviors,
   );
 
   for (final label in subject.labels ?? const <Label>[]) {
@@ -132,6 +139,7 @@ ModerationDecision decideBlockedQuotedPost(
   final decision = ModerationDecision.init(
     did: subject.author.did,
     me: subject.author.did == opts.userDid,
+    behaviors: opts.behaviors,
   );
 
   if (subject.author.hasViewer) {
@@ -191,110 +199,164 @@ bool _hasHiddenPost(
   return false;
 }
 
-bool _hasMutedWords(
+List<MuteWordMatch> _matchAllMuteWords(
+  final ProfileViewBasic author,
   final FeedPostRecord record,
   final UPostViewEmbed? embed,
   final List<MutedWord> mutedWords,
 ) {
-  if (mutedWords.isEmpty) return false;
+  if (mutedWords.isEmpty) return const [];
 
-  if (hasMutedWord(
+  // post text
+  final matches = matchMuteWords(
     mutedWords: mutedWords,
     text: record.text,
     facets: record.facets,
     outlineTags: record.tags,
     languages: record.langs,
-  )) {
-    return true;
-  }
+    actor: author,
+  );
+  if (matches.isNotEmpty) return matches;
 
-  if (embed == null) return false; // No quote.
-
-  // quote post
-  if (embed.isEmbedImagesView) {
-    for (final image in embed.embedImagesView!.images) {
-      if (hasMutedWord(
-        mutedWords: mutedWords,
-        text: image.alt,
-        languages: record.langs,
-      )) {
-        return true;
-      }
-    }
-  }
-
-  if (embed.isEmbedRecordView) {
-    final embeddedPost = embed.embedRecordView!.record.whenOrNull(
-      embedRecordViewRecord: (data) => data.value,
-    );
-    final embeddedPostRecord = embeddedPost != null
-        ? FeedPostRecord.fromJson(embeddedPost)
-        : null;
-
-    // quoted post text
-    if (embeddedPostRecord != null &&
-        hasMutedWord(
-          mutedWords: mutedWords,
-          text: embeddedPostRecord.text,
-          facets: embeddedPostRecord.facets,
-          outlineTags: embeddedPostRecord.tags,
-          languages: embeddedPostRecord.langs,
-        )) {
-      return true;
-    }
-
-    final embeddedPostEmbed = embeddedPostRecord?.embed;
-
-    // quoted post's images
-    if (embeddedPostEmbed != null && embeddedPostEmbed.isEmbedImages) {
-      for (final image in embeddedPostEmbed.embedImages!.images) {
-        if (hasMutedWord(
+  final recordEmbed = record.embed;
+  if (recordEmbed != null) {
+    // post images
+    if (recordEmbed.isEmbedImages) {
+      for (final image in recordEmbed.embedImages!.images) {
+        final matches = matchMuteWords(
           mutedWords: mutedWords,
           text: image.alt,
-          languages: embeddedPostRecord?.langs,
-        )) {
-          return true;
+          languages: record.langs,
+          actor: author,
+        );
+        if (matches.isNotEmpty) return matches;
+      }
+    }
+
+    // post gallery items
+    if (recordEmbed.isEmbedGallery) {
+      for (final item in recordEmbed.embedGallery!.items) {
+        if (item.isEmbedGalleryImage) {
+          final matches = matchMuteWords(
+            mutedWords: mutedWords,
+            text: item.embedGalleryImage!.alt,
+            languages: record.langs,
+            actor: author,
+          );
+          if (matches.isNotEmpty) return matches;
         }
       }
     }
+  }
 
-    // quoted post's link card
-    if (embeddedPostEmbed != null && embeddedPostEmbed.isEmbedExternal) {
-      final external = embeddedPostEmbed.embedExternal!.external;
-      if (hasMutedWord(
+  if (embed == null) return const [];
+
+  // quote post
+  if (embed.isEmbedRecordView) {
+    final embeddedPostView = embed.embedRecordView!.record.whenOrNull(
+      embedRecordViewRecord: (data) => data,
+    );
+
+    if (embeddedPostView != null &&
+        FeedPostRecord.validate(embeddedPostView.value)) {
+      final embedAuthor = embeddedPostView.author;
+      final embeddedPost = FeedPostRecord.fromJson(embeddedPostView.value);
+
+      // quoted post text
+      final matches = matchMuteWords(
         mutedWords: mutedWords,
-        text: '${external.title} ${external.description}',
-        languages: const [],
-      )) {
-        return true;
+        text: embeddedPost.text,
+        facets: embeddedPost.facets,
+        outlineTags: embeddedPost.tags,
+        languages: embeddedPost.langs,
+        actor: embedAuthor,
+      );
+      if (matches.isNotEmpty) return matches;
+
+      final embeddedPostEmbed = embeddedPost.embed;
+
+      // quoted post's images
+      if (embeddedPostEmbed != null && embeddedPostEmbed.isEmbedImages) {
+        for (final image in embeddedPostEmbed.embedImages!.images) {
+          final matches = matchMuteWords(
+            mutedWords: mutedWords,
+            text: image.alt,
+            languages: embeddedPost.langs,
+            actor: embedAuthor,
+          );
+          if (matches.isNotEmpty) return matches;
+        }
       }
-    }
 
-    if (embeddedPostEmbed != null && embeddedPostEmbed.isEmbedRecordWithMedia) {
-      final embeddedPostEmbedMedia =
-          embeddedPostEmbed.embedRecordWithMedia!.media;
+      // quoted post's gallery
+      if (embeddedPostEmbed != null && embeddedPostEmbed.isEmbedGallery) {
+        for (final item in embeddedPostEmbed.embedGallery!.items) {
+          if (item.isEmbedGalleryImage) {
+            final matches = matchMuteWords(
+              mutedWords: mutedWords,
+              text: item.embedGalleryImage!.alt,
+              languages: embeddedPost.langs,
+              actor: embedAuthor,
+            );
+            if (matches.isNotEmpty) return matches;
+          }
+        }
+      }
 
-      // quoted post's link card when it did a quote + media
-      if (embeddedPostEmbedMedia.isEmbedExternal) {
-        final external = embeddedPostEmbedMedia.embedExternal!.external;
-        if (hasMutedWord(
+      // quoted post's link card
+      if (embeddedPostEmbed != null && embeddedPostEmbed.isEmbedExternal) {
+        final external = embeddedPostEmbed.embedExternal!.external;
+        final matches = matchMuteWords(
           mutedWords: mutedWords,
           text: '${external.title} ${external.description}',
           languages: const [],
-        )) {
-          return true;
-        }
+          actor: embedAuthor,
+        );
+        if (matches.isNotEmpty) return matches;
       }
 
-      // quoted post's images when it did a quote + media
-      if (embeddedPostEmbedMedia.isEmbedImages) {
-        for (final image in embeddedPostEmbedMedia.embedImages!.images) {
-          if (hasMutedWord(
+      if (embeddedPostEmbed != null &&
+          embeddedPostEmbed.isEmbedRecordWithMedia) {
+        final embeddedPostEmbedMedia =
+            embeddedPostEmbed.embedRecordWithMedia!.media;
+
+        // quoted post's link card when it did a quote + media
+        if (embeddedPostEmbedMedia.isEmbedExternal) {
+          final external = embeddedPostEmbedMedia.embedExternal!.external;
+          final matches = matchMuteWords(
             mutedWords: mutedWords,
-            text: image.alt,
-            languages: embeddedPostRecord?.langs,
-          )) {
-            return true;
+            text: '${external.title} ${external.description}',
+            languages: const [],
+            actor: embedAuthor,
+          );
+          if (matches.isNotEmpty) return matches;
+        }
+
+        // quoted post's images when it did a quote + media
+        if (embeddedPostEmbedMedia.isEmbedImages) {
+          for (final image in embeddedPostEmbedMedia.embedImages!.images) {
+            final matches = matchMuteWords(
+              mutedWords: mutedWords,
+              text: image.alt,
+              languages: const [],
+              actor: embedAuthor,
+            );
+            if (matches.isNotEmpty) return matches;
+          }
+        }
+
+        // quoted post's gallery when it did a quote + media
+        if (embeddedPostEmbedMedia.isEmbedGallery) {
+          for (final item in embeddedPostEmbedMedia.embedGallery!.items) {
+            if (item.isEmbedGalleryImage) {
+              final matches = matchMuteWords(
+                mutedWords: mutedWords,
+                text: item.embedGalleryImage!.alt,
+                languages: const [],
+                actor: embedAuthor,
+              );
+              if (matches.isNotEmpty) return matches;
+            }
           }
         }
       }
@@ -303,49 +365,79 @@ bool _hasMutedWords(
   // link card
   else if (embed.isEmbedExternalView) {
     final external = embed.embedExternalView!.external;
-    if (hasMutedWord(
+    final matches = matchMuteWords(
       mutedWords: mutedWords,
       text: '${external.title} ${external.description}',
       languages: const [],
-    )) {
-      return true;
-    }
+      actor: author,
+    );
+    if (matches.isNotEmpty) return matches;
   }
   // quote post with media
   else if (embed.isEmbedRecordWithMediaView) {
-    // quoted post text
     final embeddedPostRecordRecord =
         embed.embedRecordWithMediaView!.record.record;
+
     if (embeddedPostRecordRecord.isEmbedRecordViewRecord) {
-      final post = FeedPostRecord.fromJson(
-        embeddedPostRecordRecord.embedRecordViewRecord!.value,
-      );
+      final embeddedPostView = embeddedPostRecordRecord.embedRecordViewRecord!;
+      final embedAuthor = embeddedPostView.author;
 
-      if (hasMutedWord(
-        mutedWords: mutedWords,
-        text: post.text,
-        facets: post.facets,
-        outlineTags: post.tags,
-        languages: post.langs,
-      )) {
-        return true;
-      }
-    }
-
-    // quoted post images
-    final embeddedPostMedia = embed.embedRecordWithMediaView!.media;
-    if (embeddedPostMedia.isEmbedImagesView) {
-      for (final image in embeddedPostMedia.embedImagesView!.images) {
-        if (hasMutedWord(
+      // quoted post text
+      if (FeedPostRecord.validate(embeddedPostView.value)) {
+        final post = FeedPostRecord.fromJson(embeddedPostView.value);
+        final matches = matchMuteWords(
           mutedWords: mutedWords,
-          text: image.alt,
-          languages: record.langs,
-        )) {
-          return true;
+          text: post.text,
+          facets: post.facets,
+          outlineTags: post.tags,
+          languages: post.langs,
+          actor: embedAuthor,
+        );
+        if (matches.isNotEmpty) return matches;
+      }
+
+      // quoted post images
+      final embeddedPostMedia = embed.embedRecordWithMediaView!.media;
+      if (embeddedPostMedia.isEmbedImagesView) {
+        for (final image in embeddedPostMedia.embedImagesView!.images) {
+          final matches = matchMuteWords(
+            mutedWords: mutedWords,
+            text: image.alt,
+            languages: record.langs,
+            actor: embedAuthor,
+          );
+          if (matches.isNotEmpty) return matches;
         }
+      }
+
+      // quoted post gallery
+      if (embeddedPostMedia.isEmbedGalleryView) {
+        for (final item in embeddedPostMedia.embedGalleryView!.items) {
+          if (item.isEmbedGalleryViewImage) {
+            final matches = matchMuteWords(
+              mutedWords: mutedWords,
+              text: item.embedGalleryViewImage!.alt,
+              languages: record.langs,
+              actor: embedAuthor,
+            );
+            if (matches.isNotEmpty) return matches;
+          }
+        }
+      }
+
+      // quoted post link card
+      if (embeddedPostMedia.isEmbedExternalView) {
+        final external = embeddedPostMedia.embedExternalView!.external;
+        final matches = matchMuteWords(
+          mutedWords: mutedWords,
+          text: '${external.title} ${external.description}',
+          languages: const [],
+          actor: embedAuthor,
+        );
+        if (matches.isNotEmpty) return matches;
       }
     }
   }
 
-  return false;
+  return const [];
 }

--- a/packages/bluesky/lib/src/moderation/types/subjects/status.dart
+++ b/packages/bluesky/lib/src/moderation/types/subjects/status.dart
@@ -3,32 +3,32 @@
 // BSD-style license that can be found in the LICENSE file.
 
 // Package imports:
-
-// Package imports:
 import 'package:atproto/com_atproto_label_defs.dart';
 
 // Project imports:
 import '../../decision.dart';
 import '../behaviors/moderation_opts.dart';
 import '../labels.dart';
+import 'account.dart';
 import 'moderation_subject_profile.dart';
+import 'profile.dart';
 
-ModerationDecision decideProfile(
+ModerationDecision decideStatus(
   final ModerationSubjectProfile subject,
   final ModerationOpts opts,
 ) {
-  final (did, labels) = switch (subject) {
+  final (did, status) = switch (subject) {
     UModerationSubjectProfileProfileViewBasic(data: final data) => (
       data.did,
-      data.labels,
+      data.status,
     ),
     UModerationSubjectProfileProfileView(data: final data) => (
       data.did,
-      data.labels,
+      data.status,
     ),
     UModerationSubjectProfileProfileViewDetailed(data: final data) => (
       data.did,
-      data.labels,
+      data.status,
     ),
     _ => throw UnimplementedError(),
   };
@@ -39,19 +39,13 @@ ModerationDecision decideProfile(
     behaviors: opts.behaviors,
   );
 
-  for (final label in _filterProfileLabels(labels)) {
-    decision.addLabel(target: LabelTarget.profile, label: label, opts: opts);
+  for (final label in status?.labels ?? const <Label>[]) {
+    decision.addLabel(target: LabelTarget.content, label: label, opts: opts);
   }
 
-  return decision;
-}
-
-List<Label> _filterProfileLabels(final List<Label>? labels) {
-  if (labels == null || labels.isEmpty) {
-    return const [];
-  }
-
-  return labels
-      .where((e) => e.uri.toString().endsWith('/app.bsky.actor.profile/self'))
-      .toList();
+  return ModerationDecision.merge([
+    decision,
+    decideAccount(subject, opts),
+    decideProfile(subject, opts),
+  ]);
 }

--- a/packages/bluesky/lib/src/moderation/types/subjects/user_list.dart
+++ b/packages/bluesky/lib/src/moderation/types/subjects/user_list.dart
@@ -10,7 +10,10 @@ import 'package:atproto_core/atproto_core.dart';
 import '../../decision.dart';
 import '../behaviors/moderation_opts.dart';
 import '../labels.dart';
+import 'account.dart';
+import 'moderation_subject_profile.dart';
 import 'moderation_subject_user_list.dart';
+import 'profile.dart';
 
 ModerationDecision decideUserList(
   final ModerationSubjectUserList subject,
@@ -18,24 +21,34 @@ ModerationDecision decideUserList(
 ) {
   final (creator, labels, uri) = subject.when(
     listViewBasic: (data) => (null, data.labels, data.uri.toString()),
-    listView: (data) => (data.creator, data.labels, null),
+    listView: (data) => (data.creator, data.labels, data.uri.toString()),
   );
 
   if (creator != null) {
     final decision = ModerationDecision.init(
       did: creator.did,
       me: creator.did == opts.userDid,
+      behaviors: opts.behaviors,
     );
 
     for (final label in labels ?? const <Label>[]) {
       decision.addLabel(target: LabelTarget.content, label: label, opts: opts);
     }
+
+    final profileSubject = ModerationSubjectProfile.profileView(data: creator);
+
+    return ModerationDecision.merge([
+      decision,
+      decideAccount(profileSubject, opts),
+      decideProfile(profileSubject, opts),
+    ]);
   }
 
-  final creatorDid = AtUri(uri!).hostname;
+  final creatorDid = AtUri(uri).hostname;
   final decision = ModerationDecision.init(
     did: creatorDid,
     me: creatorDid == opts.userDid,
+    behaviors: opts.behaviors,
   );
 
   for (final label in labels ?? const <Label>[]) {

--- a/packages/bluesky/lib/src/moderation/utils.dart
+++ b/packages/bluesky/lib/src/moderation/utils.dart
@@ -120,7 +120,7 @@ List<InterpretedLabelValueDefinition> getInterpretedLabelValueDefinitions(
                   LabelPreference.warn,
               severity: e.severity.toJson(),
               blurs: e.blurs.toJson(),
-              adultOnly: e.adultOnly ?? true,
+              adultOnly: e.adultOnly ?? false,
               definedBy: labelerView.creator.did,
             ),
           )
@@ -250,21 +250,23 @@ extension PreferencesExtension on ActorGetPreferencesOutput {
   }
 }
 
-Map<String, String> getLabelerHeaders(final ModerationPrefs? prefs) {
-  if (prefs == null || prefs.labelers.isEmpty) {
-    return _getLabelerHeaders(const [_kBskyLabelerDid]);
-  }
+Map<String, String> getLabelerHeaders(
+  final ModerationPrefs? prefs, {
+  final List<String> appLabelers = const [_kBskyLabelerDid],
+}) {
+  final subscribedLabelers =
+      prefs?.labelers
+          .map((e) => e.did)
+          .where((e) => e.startsWith('did:'))
+          .where((e) => !appLabelers.contains(e)) ??
+      const <String>[];
 
-  return _getLabelerHeaders([
-    _kBskyLabelerDid,
-    ...prefs.labelers.map((e) => e.did).where((e) => e.startsWith('did:')),
-  ]);
+  // Only app labelers are sent with the `;redact` parameter, following the
+  // official client behavior.
+  return {
+    'atproto-accept-labelers': <String>{
+      ...appLabelers.map((did) => '$did;redact'),
+      ...subscribedLabelers,
+    }.join(', '),
+  };
 }
-
-Map<String, String> _getLabelerHeaders(final List<String> dids) => {
-  'atproto-accept-labelers': dids
-      .toSet()
-      .take(10)
-      .map((str) => '$str;redact')
-      .join(', '),
-};

--- a/packages/bluesky/pubspec.yaml
+++ b/packages/bluesky/pubspec.yaml
@@ -1,7 +1,7 @@
 name: bluesky
 resolution: workspace
 description: The most famous and powerful Dart/Flutter library for Bluesky Social.
-version: 1.5.1
+version: 1.6.0
 homepage: https://atprotodart.com
 documentation: https://atprotodart.com/docs/packages/bluesky
 repository: https://github.com/myConsciousness/atproto.dart/tree/main/packages/bluesky

--- a/packages/bluesky/test/src/moderation/suite/moderation_conformance_test.dart
+++ b/packages/bluesky/test/src/moderation/suite/moderation_conformance_test.dart
@@ -1,0 +1,384 @@
+// Package imports:
+import 'package:atproto/com_atproto_label_defs.dart';
+import 'package:atproto_core/atproto_core.dart';
+import 'package:test/test.dart';
+
+// Project imports:
+import 'package:bluesky/src/moderation.dart';
+import 'package:bluesky/src/moderation/types/behaviors/moderation_cause.dart';
+import 'package:bluesky/src/moderation/types/behaviors/moderation_cause_source.dart';
+import 'package:bluesky/src/moderation/types/behaviors/moderation_opts.dart';
+import 'package:bluesky/src/moderation/types/behaviors/moderation_prefs.dart';
+import 'package:bluesky/src/moderation/types/behaviors/moderation_prefs_labeler.dart';
+import 'package:bluesky/src/moderation/types/const/labels.dart';
+import 'package:bluesky/src/moderation/types/labels.dart';
+import 'package:bluesky/src/moderation/types/moderation_behavior.dart';
+import 'package:bluesky/src/moderation/types/moderation_behaviors.dart';
+import 'package:bluesky/src/moderation/types/moderation_ui.dart';
+import 'package:bluesky/src/moderation/types/mute_words.dart';
+import 'package:bluesky/src/moderation/types/subjects/moderation_subject_profile.dart';
+import 'package:bluesky/src/moderation/types/subjects/moderation_subject_user_list.dart';
+import 'package:bluesky/src/moderation/utils.dart';
+import 'package:bluesky/src/services/codegen/app/bsky/actor/defs/muted_word.dart';
+import 'package:bluesky/src/services/codegen/app/bsky/actor/defs/muted_word_actor_target.dart';
+import 'package:bluesky/src/services/codegen/app/bsky/actor/defs/muted_word_target.dart';
+import 'package:bluesky/src/services/codegen/app/bsky/actor/defs/profile_view.dart';
+import 'package:bluesky/src/services/codegen/app/bsky/actor/defs/status_view.dart';
+import 'package:bluesky/src/services/codegen/app/bsky/actor/defs/status_view_status.dart';
+import 'package:bluesky/src/services/codegen/app/bsky/actor/defs/viewer_state.dart';
+import 'package:bluesky/src/services/codegen/app/bsky/graph/defs/list_purpose.dart';
+import 'package:bluesky/src/services/codegen/app/bsky/graph/defs/list_view.dart';
+import 'utils/mock.dart';
+
+const _kFakeCid = 'bafyreiclp443lavogvhj3d2ob2cxbfuscni2k5jk7bebjzg7khl3esabwq';
+
+ModerationOpts _opts({
+  bool adultContentEnabled = true,
+  Map<String, LabelPreference> labels = const {},
+  List<ModerationPrefsLabeler> labelers = const [],
+  ModerationBehaviors behaviors = const ModerationBehaviors(),
+}) {
+  return ModerationOpts(
+    userDid: 'did:web:alice.test',
+    prefs: ModerationPrefs(
+      adultContentEnabled: adultContentEnabled,
+      labels: labels,
+      labelers: labelers,
+      mutedWords: const [],
+      hiddenPosts: const [],
+    ),
+    behaviors: behaviors,
+  );
+}
+
+const _kLabeler = ModerationPrefsLabeler(
+  did: 'did:web:labeler.test',
+  labels: {},
+);
+
+void main() {
+  group('decideUserList', () {
+    test('handles ListView with creator without crashing and merges account '
+        'causes', () {
+      final decision = moderateUserList(
+        ModerationSubjectUserList.listView(
+          data: ListView(
+            uri: AtUri('at://did:web:bob.test/app.bsky.graph.list/self'),
+            cid: _kFakeCid,
+            name: 'Test List',
+            purpose: const ListPurpose.knownValue(
+              data: KnownListPurpose.appBskyGraphDefsModlist,
+            ),
+            creator: const ProfileView(
+              did: 'did:web:bob.test',
+              handle: 'bob.test',
+              viewer: ViewerState(muted: true),
+            ),
+            indexedAt: DateTime.now().toUtc(),
+          ),
+        ),
+        _opts(),
+      );
+
+      expect(decision.did, 'did:web:bob.test');
+      // The muted cause must come from the merged decideAccount decision.
+      expect(decision.causes.whereType<UModerationCauseMuted>().length, 1);
+      expect(
+        decision.getUI(ModerationBehaviorContext.contentList).filter,
+        isTrue,
+      );
+    });
+  });
+
+  group('addLabel source attribution', () {
+    test('labels from a subscribed labeler are attributed to the labeler', () {
+      final decision = moderateProfile(
+        ModerationSubjectProfile.profileViewBasic(
+          data: profileViewBasic(
+            handle: 'bob.test',
+            displayName: 'Bob',
+            labels: [
+              Label(
+                src: 'did:web:labeler.test',
+                uri: 'did:web:bob.test',
+                val: 'porn',
+                cts: DateTime.now().toUtc(),
+              ),
+            ],
+          ),
+        ),
+        _opts(labels: {'porn': LabelPreference.hide}, labelers: [_kLabeler]),
+      );
+
+      final labelCauses = decision.causes
+          .whereType<UModerationCauseLabel>()
+          .toList();
+
+      expect(labelCauses.length, 1);
+      expect(
+        labelCauses.first.data.source,
+        isA<UModerationCauseSourceLabeler>(),
+      );
+      expect(
+        labelCauses.first.data.source.whenOrNull(labeler: (data) => data.did),
+        'did:web:labeler.test',
+      );
+    });
+
+    test('self labels are attributed to the user', () {
+      final decision = moderateProfile(
+        ModerationSubjectProfile.profileViewBasic(
+          data: profileViewBasic(
+            handle: 'bob.test',
+            displayName: 'Bob',
+            labels: [
+              Label(
+                src: 'did:web:bob.test',
+                uri: 'at://did:web:bob.test/app.bsky.actor.profile/self',
+                val: 'porn',
+                cts: DateTime.now().toUtc(),
+              ),
+            ],
+          ),
+        ),
+        _opts(labels: {'porn': LabelPreference.hide}),
+      );
+
+      final labelCauses = decision.causes
+          .whereType<UModerationCauseLabel>()
+          .toList();
+
+      expect(labelCauses.length, 1);
+      expect(labelCauses.first.data.source, isA<UModerationCauseSourceUser>());
+    });
+  });
+
+  group('gore alias', () {
+    test('labels with the deprecated `gore` value are interpreted as '
+        'graphic-media', () {
+      final decision = moderateProfile(
+        ModerationSubjectProfile.profileViewBasic(
+          data: profileViewBasic(
+            handle: 'bob.test',
+            displayName: 'Bob',
+            labels: [
+              Label(
+                src: 'did:web:labeler.test',
+                uri: 'did:web:bob.test',
+                val: 'gore',
+                cts: DateTime.now().toUtc(),
+              ),
+            ],
+          ),
+        ),
+        _opts(labelers: [_kLabeler]),
+      );
+
+      expect(decision.getUI(ModerationBehaviorContext.avatar).blur, isTrue);
+    });
+  });
+
+  group('mute words conformance', () {
+    const contentTarget = MutedWordTarget.knownValue(
+      data: KnownMutedWordTarget.content,
+    );
+
+    test('expired muted words are ignored', () {
+      expect(
+        hasMutedWord(
+          mutedWords: [
+            MutedWord(
+              value: 'poop',
+              targets: const [contentTarget],
+              expiresAt: DateTime.now().toUtc().subtract(
+                const Duration(days: 1),
+              ),
+            ),
+          ],
+          text: 'This is a poop post',
+        ),
+        isFalse,
+      );
+    });
+
+    test('unexpired muted words still apply', () {
+      expect(
+        hasMutedWord(
+          mutedWords: [
+            MutedWord(
+              value: 'poop',
+              targets: const [contentTarget],
+              expiresAt: DateTime.now().toUtc().add(const Duration(days: 1)),
+            ),
+          ],
+          text: 'This is a poop post',
+        ),
+        isTrue,
+      );
+    });
+
+    test('actorTarget exclude-following skips followed authors', () {
+      final mutedWords = [
+        const MutedWord(
+          value: 'poop',
+          targets: [contentTarget],
+          actorTarget: MutedWordActorTarget.knownValue(
+            data: KnownMutedWordActorTarget.excludeFollowing,
+          ),
+        ),
+      ];
+
+      expect(
+        hasMutedWord(
+          mutedWords: mutedWords,
+          text: 'This is a poop post',
+          actor: profileViewBasic(
+            handle: 'bob.test',
+            viewer: ViewerState(
+              following: AtUri(
+                'at://did:web:alice.test/app.bsky.graph.follow/fake',
+              ),
+            ),
+          ),
+        ),
+        isFalse,
+      );
+
+      expect(
+        hasMutedWord(
+          mutedWords: mutedWords,
+          text: 'This is a poop post',
+          actor: profileViewBasic(handle: 'bob.test'),
+        ),
+        isTrue,
+      );
+    });
+
+    test('matchMuteWords returns the matched word and predicate', () {
+      final matches = matchMuteWords(
+        mutedWords: const [
+          MutedWord(value: 'poop', targets: [contentTarget]),
+        ],
+        text: 'This is a poop! post',
+      );
+
+      expect(matches.length, 1);
+      expect(matches.first.word.value, 'poop');
+      expect(matches.first.predicate, 'poop!');
+    });
+  });
+
+  group('moderateStatus', () {
+    test('applies content labels on the live status', () {
+      final decision = moderateStatus(
+        ModerationSubjectProfile.profileViewBasic(
+          data: profileViewBasic(handle: 'bob.test', displayName: 'Bob')
+              .copyWith(
+                status: StatusView(
+                  status: const StatusViewStatus.knownValue(
+                    data: KnownStatusViewStatus.appBskyActorStatusLive,
+                  ),
+                  record: const {r'$type': 'app.bsky.actor.status'},
+                  labels: [
+                    Label(
+                      src: 'did:web:labeler.test',
+                      uri: 'at://did:web:bob.test/app.bsky.actor.status/self',
+                      val: 'porn',
+                      cts: DateTime.now().toUtc(),
+                    ),
+                  ],
+                ),
+              ),
+        ),
+        _opts(labels: {'porn': LabelPreference.hide}, labelers: [_kLabeler]),
+      );
+
+      expect(
+        decision.getUI(ModerationBehaviorContext.contentMedia).blur,
+        isTrue,
+      );
+    });
+  });
+
+  group('ModerationBehaviors configuration', () {
+    test('custom mute behaviors override the defaults', () {
+      final subject = ModerationSubjectProfile.profileViewBasic(
+        data: profileViewBasic(
+          handle: 'bob.test',
+          displayName: 'Bob',
+          viewer: const ViewerState(muted: true),
+        ),
+      );
+
+      // Default: muting blurs contentList and informs on contentView.
+      final defaultUI = moderateProfile(
+        subject,
+        _opts(),
+      ).getUI(ModerationBehaviorContext.contentView);
+      expect(defaultUI.blur, isFalse);
+      expect(defaultUI.inform, isTrue);
+
+      // Custom: blur muted content everywhere.
+      final customUI = moderateProfile(
+        subject,
+        _opts(
+          behaviors: const ModerationBehaviors(
+            mute: {
+              ModerationBehaviorContext.contentList: ModerationBehavior.blur,
+              ModerationBehaviorContext.contentView: ModerationBehavior.blur,
+            },
+          ),
+        ),
+      ).getUI(ModerationBehaviorContext.contentView);
+      expect(customUI.blur, isTrue);
+      expect(customUI.inform, isFalse);
+    });
+
+    test('custom global label definitions can be added', () {
+      final subject = ModerationSubjectProfile.profileViewBasic(
+        data: profileViewBasic(
+          handle: 'bob.test',
+          displayName: 'Bob',
+          labels: [
+            Label(
+              src: 'did:web:labeler.test',
+              uri: 'did:web:bob.test',
+              val: 'my-custom-label',
+              cts: DateTime.now().toUtc(),
+            ),
+          ],
+        ),
+      );
+
+      // Unknown labels are ignored by default.
+      expect(
+        moderateProfile(subject, _opts(labelers: [_kLabeler])).causes,
+        isEmpty,
+      );
+
+      // With a global definition the label is applied.
+      final decision = moderateProfile(
+        subject,
+        _opts(
+          labelers: [_kLabeler],
+          behaviors: ModerationBehaviors(
+            labels: {
+              ...kLabelDefinitions,
+              'my-custom-label': getInterpretedLabelValueDefinition(
+                identifier: 'my-custom-label',
+                severity: 'alert',
+                blurs: 'content',
+              ),
+            },
+          ),
+        ),
+      );
+
+      expect(decision.causes.whereType<UModerationCauseLabel>(), isNotEmpty);
+      expect(
+        decision.getUI(ModerationBehaviorContext.contentList).blur,
+        isTrue,
+      );
+    });
+  });
+}

--- a/packages/bluesky/test/src/moderation/suite/moderation_mutewords_test.dart
+++ b/packages/bluesky/test/src/moderation/suite/moderation_mutewords_test.dart
@@ -626,7 +626,9 @@ void main() {
       );
     });
 
-    test('match: acc', () async {
+    // Words with internal slashes are ignored to prevent false positives,
+    // e.g. `and/or` should not match `Andor`.
+    test('no match: acc', () async {
       final text = BlueskyText("I'm e/acc pilled");
       final facets = await text.entities.toFacets();
 
@@ -644,7 +646,53 @@ void main() {
           facets: facets.map(RichtextFacet.fromJson).toList(),
           outlineTags: [],
         ),
+        isFalse,
+      );
+    });
+  });
+
+  group('and/or', () {
+    test('match: and/or', () async {
+      final text = BlueskyText('Tomatoes are fruits and/or vegetables');
+      final facets = await text.entities.toFacets();
+
+      expect(
+        hasMutedWord(
+          mutedWords: [
+            MutedWord(
+              value: 'and/or',
+              targets: [
+                MutedWordTarget.knownValue(data: KnownMutedWordTarget.content),
+              ],
+            ),
+          ],
+          text: text.value,
+          facets: facets.map(RichtextFacet.fromJson).toList(),
+          outlineTags: [],
+        ),
         isTrue,
+      );
+    });
+
+    test('no match: andor', () async {
+      final text = BlueskyText('Tomatoes are fruits and/or vegetables');
+      final facets = await text.entities.toFacets();
+
+      expect(
+        hasMutedWord(
+          mutedWords: [
+            MutedWord(
+              value: 'andor',
+              targets: [
+                MutedWordTarget.knownValue(data: KnownMutedWordTarget.content),
+              ],
+            ),
+          ],
+          text: text.value,
+          facets: facets.map(RichtextFacet.fromJson).toList(),
+          outlineTags: [],
+        ),
+        isFalse,
       );
     });
   });

--- a/packages/bluesky/test/src/moderation/utils_test.dart
+++ b/packages/bluesky/test/src/moderation/utils_test.dart
@@ -48,7 +48,7 @@ void main() {
       expect(actual.containsKey('atproto-accept-labelers'), isTrue);
       expect(
         actual['atproto-accept-labelers'],
-        'did:plc:ar7c4by46qjdydhdevvrndac;redact, did:aaaa;redact',
+        'did:plc:ar7c4by46qjdydhdevvrndac;redact, did:aaaa',
       );
     });
 
@@ -68,8 +68,7 @@ void main() {
       expect(actual.containsKey('atproto-accept-labelers'), isTrue);
       expect(
         actual['atproto-accept-labelers'],
-        'did:plc:ar7c4by46qjdydhdevvrndac;redact, did:aaaa;redact, '
-        'did:bbbb;redact',
+        'did:plc:ar7c4by46qjdydhdevvrndac;redact, did:aaaa, did:bbbb',
       );
     });
 
@@ -89,7 +88,7 @@ void main() {
       expect(actual.containsKey('atproto-accept-labelers'), isTrue);
       expect(
         actual['atproto-accept-labelers'],
-        'did:plc:ar7c4by46qjdydhdevvrndac;redact, did:aaaa;redact',
+        'did:plc:ar7c4by46qjdydhdevvrndac;redact, did:aaaa',
       );
     });
   });


### PR DESCRIPTION
## Summary

Audited the client-side moderation engine in `packages/bluesky` against the official implementation ([bluesky-social/atproto `packages/api/src/moderation`](https://github.com/bluesky-social/atproto/tree/main/packages/api/src/moderation)), fixed all behavioral discrepancies, and introduced a configuration structure (`ModerationBehaviors`) so users can customize the moderation logic without forking the engine. Public API signatures are unchanged; all additions are backward compatible.

## Conformance fixes

- **`decideUserList` crashed on `ListView` subjects**: the `listView` branch built a decision, discarded it, then null-asserted a `null` uri. It now returns the creator decision merged with `decideAccount`/`decideProfile`, matching the official implementation.
- **Label source attribution was inverted**: `addLabel` used `isSelf || labeler != null ? user : labeler`, so labels from subscribed labelers were always attributed to the user. Now `ModerationCauseSource.labeler` is used as in the official code.
- **`getInterpretedLabelValueDefinitions` defaulted `adultOnly` to `true`** (official: `false`), which adult-gated every labeler-defined label that didn't declare it.
- **`getLabelerHeaders` appended `;redact` to every labeler**: the official client only redacts app labelers; subscribed labelers are now sent without parameters.

## Newly ported official features

- Mute words: `expiresAt` expiry, `actorTarget: exclude-following` (new optional `actor` parameter), the slash-exclusion rule (`and/or` no longer matches `andor`), and all tag facet features per facet (previously only the first).
- `matchMuteWords` + `MuteWordMatch`; `ModerationCauseMuteWord` now carries `matches`.
- `moderatePost` scans `app.bsky.embed.gallery` alt texts and record-embed media, mirroring the official `matchAllMuteWords` structure.
- `moderateStatus` / `decideStatus` for live status (`app.bsky.actor.defs#statusView`) labels.
- The deprecated `gore` alias for `graphic-media` (`KnownLabelValue.gore`), matching the generated official label defs.

## Configurable moderation logic

New `ModerationBehaviors` object on `ModerationOpts.behaviors` (defaults replicate the official logic):

```dart
final opts = ModerationOpts(
  userDid: session.did,
  prefs: prefs,
  behaviors: ModerationBehaviors(
    mute: {ModerationBehaviorContext.contentView: ModerationBehavior.blur},
    labels: {...kLabelDefinitions, 'my-label': myCustomLabelDefinition},
  ),
);
```

The string-keyed `kBlockBehavior` / `kMuteBehavior` / `kMuteWordBehavior` / `kHideBehavior` constants are deprecated in favor of the typed `kDefault*Behaviors` maps.

## Testing

- `dart analyze`: clean
- `dart test`: 714 tests pass, including a new `moderation_conformance_test.dart` (11 tests) covering each fix and the new configuration structure
- 4 existing test expectations updated to the official spec (redact scope, slash rule)

Note: single-character mute-word detection intentionally keeps grapheme-cluster semantics (`characters`) instead of the official UTF-16 length check — a strict superset that handles emoji mute words correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)