### PR TITLE
ci: fix bugs and modernize .github workflows and configs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -16,6 +16,7 @@ body:
       label: Package
       description: Which package is affected by this bug?
       options:
+        - at_primitives
         - atproto
         - atproto_core
         - atproto_oauth
@@ -92,13 +93,12 @@ body:
           // ...
         }
 
-  - type: dropdown
+  - type: input
     id: dart-version
     attributes:
       label: Dart Version
-      description: What version of Dart are you using?
-      options:
-        - "Please specify in additional context"
+      description: What version of Dart are you using? (`dart --version`)
+      placeholder: "e.g., 3.8.0"
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -16,6 +16,7 @@ body:
       label: Package
       description: Which package should this feature be added to?
       options:
+        - at_primitives
         - atproto
         - atproto_core
         - atproto_oauth

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,15 +3,23 @@
 # REF: https://dependabot.com/docs/config-file/validator/
 version: 2
 
-enable-beta-ecosystems: true
-
 # See: https://docs.github.com/ja/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates
 updates:
-  # See: https://docs.github.com/ja/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/keeping-your-actions-up-to-date-with-dependabot
   - package-ecosystem: "pub"
-    directory: "/"
+    directories:
+      - "/"
+      - "/packages/*"
     schedule:
       interval: "daily"
+      timezone: "Asia/Tokyo"
+      time: "12:00"
+    labels: ["dependabot"]
+
+  # Keep GitHub Actions used in workflows up to date.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
       timezone: "Asia/Tokyo"
       time: "12:00"
     labels: ["GitHub Actions", "dependabot"]

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,63 +1,75 @@
 # Package-specific labels
 at_primitives:
-- packages/at_primitives/**/*
+- changed-files:
+  - any-glob-to-any-file: packages/at_primitives/**
 lexicon:
-- packages/lexicon/**/*
+- changed-files:
+  - any-glob-to-any-file: packages/lexicon/**
 xrpc:
-- packages/xrpc/**/*
+- changed-files:
+  - any-glob-to-any-file: packages/xrpc/**
 multiformats:
-- packages/multiformats/**/*
+- changed-files:
+  - any-glob-to-any-file: packages/multiformats/**
 atproto_test:
-- packages/atproto_test/**/*
+- changed-files:
+  - any-glob-to-any-file: packages/atproto_test/**
 atproto_oauth:
-- packages/atproto_oauth/**/*
+- changed-files:
+  - any-glob-to-any-file: packages/atproto_oauth/**
 atproto_core:
-- packages/atproto_core/**/*
+- changed-files:
+  - any-glob-to-any-file: packages/atproto_core/**
 lex_gen:
-- packages/lex_gen/**/*
+- changed-files:
+  - any-glob-to-any-file: packages/lex_gen/**
 did_plc:
-- packages/did_plc/**/*
+- changed-files:
+  - any-glob-to-any-file: packages/did_plc/**
 atproto:
-- packages/atproto/**/*
+- changed-files:
+  - any-glob-to-any-file: packages/atproto/**
 bluesky_text:
-- packages/bluesky_text/**/*
+- changed-files:
+  - any-glob-to-any-file: packages/bluesky_text/**
 bluesky:
-- packages/bluesky/**/*
+- changed-files:
+  - any-glob-to-any-file: packages/bluesky/**
 bluesky_cli:
-- packages/bluesky_cli/**/*
+- changed-files:
+  - any-glob-to-any-file: packages/bluesky_cli/**
 
-# Test-related changes (only for packages that actually have tests)
+# Test-related changes
 test:
-- packages/at_primitives/test/**/*.dart
-- packages/lexicon/test/**/*.dart
-- packages/xrpc/test/**/*.dart
-- packages/multiformats/test/**/*.dart
-- packages/atproto_core/test/**/*.dart
-- packages/did_plc/test/**/*.dart
-- packages/atproto/test/**/*.dart
-- packages/bluesky_text/test/**/*.dart
-- packages/bluesky/test/**/*.dart
-- packages/bluesky_cli/test/**/*.dart
+- changed-files:
+  - any-glob-to-any-file: packages/*/test/**/*.dart
 
 # Documentation changes
 documentation:
-- packages/*/CHANGELOG.md
-- packages/*/README.md
-- CODE_OF_CONDUCT.md
-- CONTRIBUTING.md
-- README.md
+- changed-files:
+  - any-glob-to-any-file:
+    - packages/*/CHANGELOG.md
+    - packages/*/README.md
+    - CODE_OF_CONDUCT.md
+    - CONTRIBUTING.md
+    - README.md
 
 # CI/CD and tooling
 ci:
-- .github/workflows/**/*
-- .github/labeler.yml
-- melos.yaml
-- pubspec.yaml
-- pubspec_overrides.yaml
-- analysis_options.yaml
+- changed-files:
+  - any-glob-to-any-file:
+    - .github/workflows/**
+    - .github/labeler.yml
+    - .github/dependabot.yml
+    - melos.yaml
+    - pubspec.yaml
+    - pubspec_overrides.yaml
+    - analysis_options.yaml
 
 # Build and development tools
 build:
-- scripts/**/*
-- packages/*/pubspec.yaml
-- packages/*/analysis_options.yaml
+- changed-files:
+  - any-glob-to-any-file:
+    - scripts/**
+    - packages/*/pubspec.yaml
+    - packages/*/analysis_options.yaml

--- a/.github/workflows/generate_codes.yml
+++ b/.github/workflows/generate_codes.yml
@@ -8,44 +8,32 @@ on:
     types:
       - closed
 
+permissions:
+  contents: read
+
 jobs:
   generate-codes:
-    if: github.event.pull_request.base.ref == 'main' &&
-      github.event.pull_request.head.ref == 'chore-sync-lexicons'
+    # Run manually, or only when the sync-lexicons PR is actually merged
+    # (not just closed without merging).
+    if: github.event_name == 'workflow_dispatch' ||
+      (github.event.pull_request.merged == true &&
+      github.event.pull_request.head.ref == 'chore-sync-lexicons')
 
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+        with:
+          ref: main
 
-      - name: Delete Old Branch
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          git fetch origin
-          if git show-ref --quiet refs/remotes/origin/chore-generate-codes; then
-            git push origin --delete chore-generate-codes
-          fi
-
-      - name: Create New Branch
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          git switch -c chore-generate-codes
-          git push -u origin chore-generate-codes
-
-      - uses: dart-lang/setup-dart@v1.3
+      - uses: dart-lang/setup-dart@v1
+        with:
+          sdk: stable
 
       - name: Install dependencies
-        run: |
-          dart pub get
-          cd packages/atproto
-          dart pub get
-          cd ../../packages/bluesky
-          dart pub get
-          cd ../../packages/bluesky_cli
-          dart pub get
-          cd ../../
+        # This repository is a pub workspace, so a single `pub get` at the
+        # root resolves every package.
+        run: dart pub get
 
       - name: Generate
         run: |
@@ -55,42 +43,36 @@ jobs:
           dart run ./scripts/gen_supported_api_matrix.dart
           dart run ./scripts/gen_codes.dart
 
-      - name: Build
-        run: |
-          cd packages/atproto
-          dart run build_runner build --delete-conflicting-outputs
-          cd ../../packages/bluesky
-          dart run build_runner build --delete-conflicting-outputs
-          cd ../../
+      - name: Build (atproto)
+        run: dart run build_runner build --delete-conflicting-outputs
+        working-directory: packages/atproto
+
+      - name: Build (bluesky)
+        run: dart run build_runner build --delete-conflicting-outputs
+        working-directory: packages/bluesky
 
       - name: Format
         run: |
-          cd packages/lexicon
-          dart fix --apply
-          dart run import_sorter:main
-          dart format .
-          cd ../../packages/atproto
-          dart fix --apply
-          dart run import_sorter:main
-          dart format .
-          cd ../../packages/bluesky
-          dart fix --apply
-          dart run import_sorter:main
-          dart format .
-          cd ../../packages/bluesky_cli
-          dart fix --apply
-          dart run import_sorter:main
-          dart format .
-          cd ../../
+          for package in lexicon atproto bluesky bluesky_cli; do
+            (
+              cd "packages/$package"
+              dart fix --apply
+              dart run import_sorter:main
+              dart format .
+            )
+          done
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@v7
         with:
+          # A PAT is required so that CI workflows (Test, Validate
+          # Dependencies) run on the created pull request; PRs created
+          # with the default GITHUB_TOKEN do not trigger workflows.
+          token: ${{ secrets.PAT }}
           commit-message: "chore: Update source files automatically"
           title: "chore: Update source files automatically"
           branch: chore-generate-codes
           base: main
-          labels: Github Actions
+          delete-branch: true
+          labels: GitHub Actions
           assignees: "${{ github.actor }}"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -8,14 +8,13 @@
 name: Labeler
 on: [pull_request]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   label:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
 
     steps:
-      - uses: actions/labeler@v4
-        with:
-          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+      - uses: actions/labeler@v5

--- a/.github/workflows/sync_lexicons.yml
+++ b/.github/workflows/sync_lexicons.yml
@@ -5,30 +5,19 @@ on:
   schedule:
     - cron: "0 18 * * *"
 
+permissions:
+  contents: read
+
 jobs:
   update-lexicons:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - name: Delete Old Branch
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          git fetch origin
-          if git show-ref --quiet refs/remotes/origin/chore-sync-lexicons; then
-            git push origin --delete chore-sync-lexicons
-          fi
-
-      - name: Create New Branch
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          git switch -c chore-sync-lexicons
-          git push -u origin chore-sync-lexicons
-
-      - uses: dart-lang/setup-dart@v1.3
+      - uses: dart-lang/setup-dart@v1
+        with:
+          sdk: stable
 
       - name: Install dependencies
         run: dart pub get
@@ -39,13 +28,18 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.PAT }}
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@v7
         with:
+          # A PAT is required so that CI workflows (Test, Validate
+          # Dependencies) run on the created pull request and so that
+          # the Generate Codes workflow fires when it is merged; PRs
+          # created with the default GITHUB_TOKEN do not trigger
+          # workflows.
+          token: ${{ secrets.PAT }}
           commit-message: "chore: Sync Lexicon Data"
           title: "chore: Sync Lexicon Data"
           branch: chore-sync-lexicons
           base: main
-          labels: Github Actions
+          delete-branch: true
+          labels: GitHub Actions
           assignees: "${{ github.actor }}"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,46 +17,41 @@ jobs:
         working-directory: ${{ matrix.package_path }}
 
     strategy:
+      fail-fast: false
       matrix:
-        channel:
-          - stable
         package_path:
           - packages/at_primitives
           - packages/lexicon
           - packages/xrpc
           - packages/multiformats
           - packages/atproto_core
+          - packages/atproto_oauth
+          - packages/atproto_test
           - packages/did_plc
           - packages/atproto
           - packages/bluesky
           - packages/bluesky_text
+          - packages/bluesky_cli
+          - packages/lex_gen
 
     steps:
-      - uses: actions/checkout@v3.1.0
+      - uses: actions/checkout@v4
+
+      - uses: dart-lang/setup-dart@v1
         with:
-          fetch-depth: 2
-      - uses: subosito/flutter-action@v2.7.1
-        with:
-          channel: ${{ matrix.channel }}
-      - name: Add pub cache bin to PATH
-        run: echo "$HOME/.pub-cache/bin" >> $GITHUB_PATH
-      - name: Add pub cache to PATH
-        run: echo "PUB_CACHE="$HOME/.pub-cache"" >> $GITHUB_ENV
+          sdk: stable
+
       - name: Install dependencies
-        run: flutter pub get
+        run: dart pub get
 
       - name: Check format
         run: dart format --set-exit-if-changed .
 
       - name: Analyze
-        run: flutter analyze
+        run: dart analyze
 
       - name: Run tests
         run: |
           if test -d "test"; then
-            if grep -q flutter "pubspec.yaml"; then
-              flutter test
-            else
-              dart test
-            fi
+            dart test
           fi

--- a/.github/workflows/validate_dependencies.yml
+++ b/.github/workflows/validate_dependencies.yml
@@ -6,12 +6,15 @@ on:
     paths:
       - "packages/*/pubspec.yaml"
 
+permissions:
+  contents: read
+
 jobs:
   validate-dependencies:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Setup Dart
         uses: dart-lang/setup-dart@v1


### PR DESCRIPTION
## Summary

Audit of everything under `.github/` — fixes several real bugs in the CI/automation pipeline and modernizes outdated actions and configs. All workflows pass `actionlint`, and the newly added CI packages were verified locally (format / analyze / test all green).

## Bug fixes

- **4 packages were missing from the test matrix** (`atproto_oauth`, `atproto_test`, `bluesky_cli`, `lex_gen`) — they were never formatted, analyzed, or tested on CI. All four pass locally (56 + 11 + 29 + 60 tests).
- **`generate_codes.yml` ran on unmerged PRs** — the trigger only checked `types: [closed]` with no `merged == true` guard, so rejecting the sync-lexicons PR still kicked off code generation. Also, manual `workflow_dispatch` runs were silently skipped because the `if` condition never matched the dispatch event; both are fixed.
- **Bot PRs never ran CI** — PRs created with the default `GITHUB_TOKEN` don't trigger workflows, so `chore-sync-lexicons` / `chore-generate-codes` PRs landed without Test or Validate Dependencies ever running. They are now created with the existing `PAT` secret.
- **`bug_report.yml` had a required "Dart Version" dropdown with a single placeholder option** ("Please specify in additional context") — converted to a text input.
- **`at_primitives` was missing** from the package dropdown in both the bug report and feature request templates.

## Improvements

- **`test.yml`**: every package is pure Dart (no pubspec references Flutter), so the Flutter setup is replaced with `dart-lang/setup-dart` — faster runs and removal of the permanently-dead `grep flutter` branch. Also drops unused pub-cache PATH exports, `fetch-depth: 2`, and the single-value `channel` matrix; adds `fail-fast: false` so one package's failure doesn't cancel the rest.
- **`generate_codes.yml` / `sync_lexicons.yml`**: removed the manual delete/create branch steps (`create-pull-request` manages the branch itself), enabled `delete-branch: true`, and collapsed the per-package `pub get` calls into a single root `dart pub get` since the repo is a pub workspace.
- **Action upgrades**: `actions/checkout` v2/v3 → v4, `peter-evans/create-pull-request` v3 → v7, `actions/labeler` v4 → v5 (with `labeler.yml` migrated to the v5 config format), `dart-lang/setup-dart` pinned minor → v1.
- **`dependabot.yml`**: added the `github-actions` ecosystem (workflow actions were never auto-updated), covered workspace packages via `directories: ["/", "/packages/*"]`, and dropped `enable-beta-ecosystems` (pub support is GA).
- Standardized the label spelling to `GitHub Actions` (was inconsistently `Github Actions` in two workflows) and added minimal explicit `permissions` to all workflows.

## Verification

- ✅ `actionlint` clean on all 5 workflows
- ✅ YAML syntax validated for every file under `.github/`
- ✅ `dart format --set-exit-if-changed` / `dart analyze` / `dart test` pass locally for the 4 packages newly added to CI
- ✅ `dart analyze packages` clean across the whole workspace with the Dart (non-Flutter) toolchain
- ✅ `PAT` secret confirmed to exist on the repo


🤖 Generated with [Claude Code](https://claude.com/claude-code)