### PR TITLE
chore(atproto): declare http as a dev dependency

### DIFF
--- a/packages/atproto/pubspec.yaml
+++ b/packages/atproto/pubspec.yaml
@@ -25,6 +25,7 @@ dependencies:
 dev_dependencies:
   lints: ^6.0.0
   test: ^1.25.2
+  http: ^1.4.0
   cbor: ^6.3.7
   build_runner: ^2.5.4
   json_serializable: ^6.9.5


### PR DESCRIPTION
## Summary

`packages/atproto/test/src/atproto_test.dart` imports `package:http/http.dart` (using `http.Response` / `http.Request` in the session auto-refresh test), but `http` was not declared in `dependencies` or `dev_dependencies` of `packages/atproto/pubspec.yaml`.

As a result, `dart pub publish --dry-run` reported a validation warning and failed:

```
* line 5, column 1 of test/src/atproto_test.dart: This package does not have http in the `dependencies` or `dev_dependencies` section of `pubspec.yaml`.
```

Because the import is only used in tests, this adds `http` to `dev_dependencies`.

## Verification

- `dart pub publish --dry-run` for `atproto` no longer reports the missing-dependency warning (only the expected "modified file in git" notice remains until merge).
- Ran `melos exec -- dart pub publish --dry-run` across all 13 packages to confirm no other package has the same missing-dependency issue. Only `atproto` was affected; the `atproto_test` warnings are a separate, pre-existing matter (missing `homepage`/`repository` field and version numbering) and are intentionally left out of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)