### PR TITLE
chore(atproto_test): add homepage and repository metadata to pubspec

### DIFF
--- a/packages/atproto_test/pubspec.yaml
+++ b/packages/atproto_test/pubspec.yaml
@@ -3,6 +3,12 @@ resolution: workspace
 description: This package provides core reusable and useful functionality for testing atproto based packages.
 version: 1.1.0
 publish_to: none
+homepage: https://atprotodart.com
+documentation: https://atprotodart.com/docs/intro
+repository: https://github.com/myConsciousness/atproto.dart/tree/main/packages/atproto_test
+issue_tracker: https://github.com/myConsciousness/atproto.dart/issues
+funding:
+  - https://github.com/sponsors/myConsciousness
 environment:
   sdk: ">=3.8.0 <4.0.0"
 


### PR DESCRIPTION
## Summary

Running `dart pub publish --dry-run` across the workspace surfaced a validation warning for `atproto_test`:

```
* It's strongly recommended to include a "homepage" or "repository" field in your pubspec.yaml
```

This adds the standard metadata fields (`homepage`, `documentation`, `repository`, `issue_tracker`, `funding`) to `packages/atproto_test/pubspec.yaml`, matching the other packages in this workspace.

## Notes

- `atproto_test` is `publish_to: none`, so these warnings are cosmetic (the package is never published), but aligning its metadata with the rest of the workspace is good hygiene.
- The dry-run also emits a non-incremental version *hint* (previous `0.1.2` → current `1.1.0`). This is intentionally left unchanged: the package is not published and `1.1.0` aligns with the workspace versioning.

## Context

Follow-up to #2428, which addressed the missing `http` dev dependency in `atproto`. This PR handles the remaining, unrelated `atproto_test` dry-run warning surfaced during that sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)