### PR TITLE
feat(atproto): add decoded Firehose subscription `subscribeReposAsMessages`

### DIFF
--- a/packages/atproto/CHANGELOG.md
+++ b/packages/atproto/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release Note
 
+## v1.7.0
+
+- feat: added `atproto.sync.subscribeReposAsMessages()`, a Firehose subscription that yields already-decoded, typed `USyncSubscribeReposMessage`s (CBOR/CAR-decoded `blocks`, normalized `ops`/`commit`/`prevData` CID links) instead of raw `Uint8List` frames. The existing `subscribeRepos()` (raw bytes) is unchanged, and a frame that fails to decode surfaces as a stream error without terminating the subscription.
+- feat: `package:atproto/firehose.dart` now re-exports the `com.atproto.sync.subscribeRepos` message types, so a single import provides the adaptors, the typed `USyncSubscribeReposMessage`, and its `isCommit`/`commit` accessors.
+
 ## v1.6.0
 
 - feat: automatic access-token refresh in `ATProto.fromSession` (wired through `com.atproto.server.refreshSession`); `atproto.session` reflects the new credentials. `fromOAuthSession` is untouched, and all new parameters are optional (non-breaking).

--- a/packages/atproto/example/example.dart
+++ b/packages/atproto/example/example.dart
@@ -58,8 +58,21 @@ Future<void> main() async {
     );
 
     //! You can use Stream API easily.
-    final subscription = await atproto.sync.subscribeRepos();
-    subscription.data.stream.listen((event) {
+    //!
+    //! `subscribeReposAsMessages` decodes each frame for you (CBOR/CAR, with
+    //! `blocks`, `ops`, and CID links normalized) and yields typed messages.
+    final subscription = await atproto.sync.subscribeReposAsMessages();
+    subscription.data.stream.listen((message) {
+      if (message.isCommit) {
+        final commit = message.commit!;
+        print('${commit.repo}: ${commit.blocks.length} blocks');
+      }
+    });
+
+    //! If you want the raw binary frames instead, use `subscribeRepos()` and
+    //! decode them yourself with `SyncSubscribeReposAdaptor`.
+    final rawSubscription = await atproto.sync.subscribeRepos();
+    rawSubscription.data.stream.listen((event) {
       final repos = const firehose.SyncSubscribeReposAdaptor().execute(event);
 
       print(repos);

--- a/packages/atproto/lib/firehose.dart
+++ b/packages/atproto/lib/firehose.dart
@@ -2,5 +2,6 @@
 // All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+export 'package:atproto/com_atproto_sync_subscriberepos.dart';
 export 'package:atproto/src/firehose/firehose_adaptor.dart';
 export 'package:atproto/src/firehose/sync_subscribe_repos_adaptor.dart';

--- a/packages/atproto/lib/src/atproto.dart
+++ b/packages/atproto/lib/src/atproto.dart
@@ -8,6 +8,7 @@ import 'package:atproto_core/atproto_oauth.dart' as oauth;
 
 // Project imports:
 import '../com_atproto_services.dart';
+import 'services/com/atproto/sync_service.dart';
 import 'services/session.dart' show refreshSession;
 
 /// Provides `com.atproto.*` services.
@@ -140,7 +141,7 @@ sealed class ATProto {
 
   /// Returns the sync service.
   /// This service represents `com.atproto.sync.*`.
-  SyncService get sync;
+  SyncServiceImpl get sync;
 
   /// Returns the labels service.
   /// This service represents `com.atproto.label.*`.
@@ -205,7 +206,7 @@ final class _ATProto implements ATProto {
       identity = IdentityService(ctx),
       repo = RepoService(ctx),
       moderation = ModerationService(ctx),
-      sync = SyncService(ctx),
+      sync = SyncServiceImpl(ctx),
       label = LabelService(ctx),
       lexicon = LexiconService(ctx),
       temp = TempService(ctx),
@@ -242,7 +243,7 @@ final class _ATProto implements ATProto {
   final ModerationService moderation;
 
   @override
-  final SyncService sync;
+  final SyncServiceImpl sync;
 
   @override
   final LabelService label;

--- a/packages/atproto/lib/src/firehose/sync_subscribe_repos_adaptor.dart
+++ b/packages/atproto/lib/src/firehose/sync_subscribe_repos_adaptor.dart
@@ -15,11 +15,23 @@ import 'firehose_adaptor.dart';
 final class SyncSubscribeReposAdaptor {
   const SyncSubscribeReposAdaptor();
 
-  USyncSubscribeReposMessage execute(final dynamic data) {
+  USyncSubscribeReposMessage execute(final dynamic data) =>
+      const USyncSubscribeReposMessageConverter().fromJson(toJson(data));
+
+  /// Decodes a raw firehose frame into the JSON map form of a
+  /// `com.atproto.sync.subscribeRepos` message, with the CAR `blocks`, the
+  /// `ops` CID links, and the top-level `commit`/`prevData` CID links already
+  /// normalized per the atproto data model.
+  ///
+  /// This is the map consumed by [USyncSubscribeReposMessageConverter], and
+  /// [execute] simply wraps it. It is exposed so an XRPC subscription can feed
+  /// the decode straight into its `adaptor`, handing the caller a typed
+  /// `Subscription<USyncSubscribeReposMessage>` instead of raw bytes.
+  Map<String, dynamic> toJson(final dynamic data) {
     final repos = const FirehoseAdaptor().execute(data);
 
     if (_isCommit(repos)) {
-      return const USyncSubscribeReposMessageConverter().fromJson({
+      return {
         ...repos,
         'ops': _getOps(repos),
         'blocks': _getBlocks(repos),
@@ -27,19 +39,16 @@ final class SyncSubscribeReposAdaptor {
         //! `prevData` (sync v1.1) is a CID link the relay adds to every commit.
         //! Without converting it the whole commit degraded to `unknown`.
         'prevData': _getCidLink(repos['prevData']),
-      });
+      };
     }
 
     if (_isSync(repos)) {
       //! `#sync` frames (account migration/recovery) carry the commit as a CAR
       //! in `blocks`; decode it so a typed `Sync` event is produced.
-      return const USyncSubscribeReposMessageConverter().fromJson({
-        ...repos,
-        'blocks': _getBlocks(repos),
-      });
+      return {...repos, 'blocks': _getBlocks(repos)};
     }
 
-    return const USyncSubscribeReposMessageConverter().fromJson(repos);
+    return repos;
   }
 
   List<Map<String, dynamic>> _getOps(final Map<String, dynamic> repos) {

--- a/packages/atproto/lib/src/services/com/atproto/sync_service.dart
+++ b/packages/atproto/lib/src/services/com/atproto/sync_service.dart
@@ -1,0 +1,58 @@
+// Copyright (c) 2023-2025, Shinya Kato.
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// Package imports:
+import 'package:atproto_core/atproto_core.dart';
+
+// Project imports:
+import '../../../firehose/sync_subscribe_repos_adaptor.dart';
+import '../../../nsids.g.dart' as ns;
+import '../../codegen/com/atproto/sync/subscribeRepos/union_main_message.dart';
+import '../../codegen/com/atproto/sync_service.dart';
+
+/// A hand-written extension of the generated [SyncService] that adds a
+/// convenience Firehose subscription which yields already-decoded, typed
+/// messages instead of raw binary frames.
+final class SyncServiceImpl extends SyncService {
+  SyncServiceImpl(super.ctx);
+
+  /// Subscribes to the repository event stream (Firehose) and returns a
+  /// subscription whose events are already decoded into typed
+  /// [USyncSubscribeReposMessage]s.
+  ///
+  /// Unlike [subscribeRepos], which yields the raw [Uint8List] frames and
+  /// leaves decoding to the caller, this method wires
+  /// [SyncSubscribeReposAdaptor] into the XRPC subscription so that every frame
+  /// is CBOR/CAR-decoded before it reaches the stream: `blocks` are expanded
+  /// into a `CID -> record` map, and the `ops`, `commit`, and `prevData` CID
+  /// links are normalized per the atproto data model.
+  ///
+  /// A frame that fails to decode is delivered as a stream error and does not
+  /// terminate the subscription, so a single malformed commit never tears down
+  /// the consumer.
+  ///
+  /// ## Parameters
+  ///
+  /// * [cursor] - The last sequence number the consumer processed; the relay
+  ///   replays events after it (backfill).
+  ///
+  /// ## Example
+  ///
+  /// ```dart
+  /// final subscription = await atproto.sync.subscribeReposAsMessages();
+  /// await for (final message in subscription.data.stream) {
+  ///   if (message.isCommit) {
+  ///     final commit = message.commit!;
+  ///     // commit.blocks: Map<String, dynamic> keyed by CID.
+  ///   }
+  /// }
+  /// ```
+  Future<XRPCResponse<Subscription<USyncSubscribeReposMessage>>>
+  subscribeReposAsMessages({int? cursor}) async => await ctx.stream(
+    ns.comAtprotoSyncSubscribeRepos,
+    parameters: {'cursor': ?cursor},
+    adaptor: const SyncSubscribeReposAdaptor().toJson,
+    to: (json) => const USyncSubscribeReposMessageConverter().fromJson(json),
+  );
+}

--- a/packages/atproto/pubspec.yaml
+++ b/packages/atproto/pubspec.yaml
@@ -1,7 +1,7 @@
 name: atproto
 resolution: workspace
 description: The most famous and powerful Dart/Flutter library for AT Protocol.
-version: 1.6.0
+version: 1.7.0
 homepage: https://atprotodart.com
 documentation: https://atprotodart.com/docs/packages/atproto
 repository: https://github.com/myConsciousness/atproto.dart/tree/main/packages/atproto

--- a/packages/atproto/test/src/firehose/sync_subscribe_repos_adaptor_test.dart
+++ b/packages/atproto/test/src/firehose/sync_subscribe_repos_adaptor_test.dart
@@ -11,7 +11,6 @@ import 'package:cbor/cbor.dart';
 import 'package:test/test.dart';
 
 // Project imports:
-import 'package:atproto/com_atproto_sync_subscriberepos.dart';
 import 'package:atproto/firehose.dart';
 
 /// Encodes [value] as an unsigned LEB128 varint.
@@ -228,6 +227,64 @@ void main() {
       final record = commit.blocks.values.first;
       // Left untouched, not turned into a bogus CID.
       expect(record['ref'], [1, 2, 3]);
+    });
+  });
+
+  group('SyncSubscribeReposAdaptor.toJson', () {
+    final commitFrame = _frame(
+      CborMap({
+        CborString('op'): const CborSmallInt(1),
+        CborString('t'): CborString('#commit'),
+      }),
+      CborMap({
+        CborString('seq'): const CborSmallInt(9),
+        CborString('repo'): CborString('did:plc:alice'),
+        CborString('commit'): _cidLink(0x71, fill: 1),
+        CborString('rev'): CborString('3k'),
+        CborString('since'): CborNull(),
+        CborString('blocks'): CborBytes(recordCar),
+        CborString('ops'): CborList([
+          CborMap({
+            CborString('action'): CborString('create'),
+            CborString('path'): CborString('app.bsky.feed.post/abc'),
+            CborString('cid'): _cidLink(0x71, fill: 3),
+          }),
+        ]),
+        CborString('prevData'): _cidLink(0x71, fill: 2),
+        CborString('time'): CborString('2024-01-01T00:00:00.000Z'),
+      }),
+    );
+
+    test('produces the enriched map with decoded blocks and CID links', () {
+      final json = adaptor.toJson(commitFrame);
+
+      // blocks decoded from the CAR into a `CID -> record` map.
+      expect(json['blocks'], isA<Map<String, dynamic>>());
+      expect(json['blocks'], isNotEmpty);
+
+      // Top-level and op CID links normalized to base32 strings.
+      expect(json['commit'], CID.fromList(_cidBytes(0x71, fill: 1)).toString());
+      expect(
+        json['prevData'],
+        CID.fromList(_cidBytes(0x71, fill: 2)).toString(),
+      );
+      final ops = json['ops'] as List;
+      expect(
+        ops.first['cid'],
+        CID.fromList(_cidBytes(0x71, fill: 3)).toString(),
+      );
+    });
+
+    test('execute() equals converter.fromJson(toJson()) — same result', () {
+      // The typed subscription feeds `toJson` through the XRPC `adaptor` and the
+      // converter through `to`; that pipeline must match the all-in-one
+      // `execute`.
+      final viaExecute = adaptor.execute(commitFrame);
+      final viaPipeline = const USyncSubscribeReposMessageConverter().fromJson(
+        adaptor.toJson(commitFrame),
+      );
+
+      expect(viaPipeline, viaExecute);
     });
   });
 }

--- a/packages/bluesky/CHANGELOG.md
+++ b/packages/bluesky/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Note
 
+## v1.7.1
+
+- chore: bump `atproto` to `^1.7.0`, which exposes `bsky.atproto.sync.subscribeReposAsMessages()` — a Firehose subscription that yields already-decoded, typed messages instead of raw binary frames.
+
 ## v1.7.0
 
 - fix!: rewrote the notification grouper as a typed O(n) implementation; notifications with a missing `labels` field (optional in the lexicon, common in practice) no longer crash `group()`/`_mergeLabels` (B-1/B-2/B-8).

--- a/packages/bluesky/pubspec.yaml
+++ b/packages/bluesky/pubspec.yaml
@@ -1,7 +1,7 @@
 name: bluesky
 resolution: workspace
 description: The most famous and powerful Dart/Flutter library for Bluesky Social.
-version: 1.7.0
+version: 1.7.1
 homepage: https://atprotodart.com
 documentation: https://atprotodart.com/docs/packages/bluesky
 repository: https://github.com/myConsciousness/atproto.dart/tree/main/packages/bluesky
@@ -19,7 +19,7 @@ topics:
 
 dependencies:
   atproto_core: ^1.3.0
-  atproto: ^1.6.0
+  atproto: ^1.7.0
   freezed_annotation: ^3.1.0
   json_annotation: ^4.9.0
   characters: ^1.4.0


### PR DESCRIPTION
## Summary

`atproto.sync.subscribeRepos()` returns a `Subscription<Uint8List>` of **raw binary frames**, leaving every consumer to wire up CBOR/CAR decoding by hand (`SyncSubscribeReposAdaptor().execute(frame)` on each event). This PR adds a convenience method that hands back **already-decoded, typed** events, so the common case is a one-liner.

```dart
import 'package:atproto/firehose.dart'; // adaptors + message types + accessors

final subscription = await atproto.sync.subscribeReposAsMessages();
await for (final message in subscription.data.stream) {
  if (message.isCommit) {
    final commit = message.commit!;
    // commit.blocks: Map<CID, record> — already decoded
  }
}
```

## What changed

- **feat(atproto):** `atproto.sync.subscribeReposAsMessages({int? cursor})` returns a `Subscription<USyncSubscribeReposMessage>`. Each frame is CBOR/CAR-decoded before it reaches the stream — `blocks` are expanded into a `CID -> record` map and the `ops` / `commit` / `prevData` CID links are normalized per the [atproto data model](https://atproto.com/specs/data-model). A frame that fails to decode surfaces as a **stream error** and does **not** terminate the subscription.
- **`subscribeRepos()` (raw bytes) is unchanged** — kept for consumers that want the raw CAR frames.
- **refactor(atproto):** split `SyncSubscribeReposAdaptor.toJson()` out of `execute()` so the decode can be fed straight into the XRPC subscription's `adaptor`/`to`. `execute()` now wraps `toJson()` and is behavior-preserving.
- **feat(atproto):** `package:atproto/firehose.dart` now re-exports the `com.atproto.sync.subscribeRepos` message types, so a single import provides the adaptors, the typed `USyncSubscribeReposMessage`, and its `isCommit`/`commit` accessors.
- **chore(bluesky):** bump `atproto` dependency to `^1.7.0` (the new method is exposed through `bsky.atproto.sync`).

## Design

Follows the hand-written service-impl pattern already used by `VideoServiceImpl`: a `SyncServiceImpl extends SyncService` (the generated base), wired through `atproto.sync`. The typed subscription is produced by passing `SyncSubscribeReposAdaptor.toJson` as the XRPC `adaptor` and the union converter as `to`, so the xrpc layer performs the per-message decode and yields a real `Subscription<USyncSubscribeReposMessage>` (no re-wrapping).

## Versions

| Package | From | To | Reason |
| --- | --- | --- | --- |
| `atproto` | 1.6.0 | **1.7.0** | new feature |
| `bluesky` | 1.7.0 | **1.7.1** | dependency constraint bump to `atproto ^1.7.0` |

## Verification

- `dart analyze` — clean for `atproto` (lib/example/test) and `bluesky` (lib).
- Unit tests — `atproto` (incl. 2 new tests covering `toJson()` and its equivalence with `execute()`) and `bluesky` all pass.
- **Live end-to-end** against `wss://bsky.network/.../subscribeRepos`: frames decode into typed messages with `blocks` populated, and **every** create/update commit op joins to its record in `blocks` (0 missed, 0 decode errors across the sampled stream).

🤖 Generated with [Claude Code](https://claude.com/claude-code)