### PR TITLE
feat(bluesky_text): expose length-overflow range and render segments for Flutter UIs

### DIFF
--- a/packages/bluesky/pubspec.yaml
+++ b/packages/bluesky/pubspec.yaml
@@ -34,7 +34,7 @@ dev_dependencies:
     git:
       url: https://github.com/myConsciousness/import_sorter.git
       ref: fix/monorepo-pub-workspaces
-  bluesky_text: ^1.4.1
+  bluesky_text: ^1.5.0
 
   atproto_test:
     path: ../atproto_test

--- a/packages/bluesky_cli/pubspec.yaml
+++ b/packages/bluesky_cli/pubspec.yaml
@@ -27,7 +27,7 @@ dependencies:
   args: ^2.7.0
   cli_launcher: ^0.3.1
   cli_util: ^0.5.1
-  bluesky_text: ^1.4.1
+  bluesky_text: ^1.5.0
 
 dev_dependencies:
   http: ^1.4.0

--- a/packages/bluesky_text/CHANGELOG.md
+++ b/packages/bluesky_text/CHANGELOG.md
@@ -45,6 +45,13 @@
   graphemes and 3000 UTF-8 bytes). Previously it budgeted graphemes only, so a
   byte-heavy chunk — e.g. many multi-byte ZWJ emoji — could stay under 300
   graphemes yet exceed 3000 bytes and still be rejected by the server.
+- **FIX**: `split()` on a `format()`ted instance now splits the original text
+  instead of the lossy formatted value, so `format().split()` behaves exactly
+  like `split()` on the original. Splitting formatted text and re-extracting
+  previously corrupted facets — a shortened link's `uri` became its truncated
+  display text and a markdown link's facet vanished — because the chunks dropped
+  the position-bound replacements. Each chunk is a raw, independently-formattable
+  piece; format each one *after* splitting (e.g. via `chunk.toPostData()`).
 - **PERF**: `BlueskyText` now lazily memoizes every derived value (`length`,
   `handles`, `entities`, `overflow`, `segments`, `format()`…), so touching
   several properties of one instance in a Flutter `build` costs one analysis

--- a/packages/bluesky_text/CHANGELOG.md
+++ b/packages/bluesky_text/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release Note
 
-## v1.4.1
+## v1.5.0
 
 - **FEAT**: Added `BlueskyText.overflow`, which returns a `TextLengthOverflow`
   describing the range of the text that exceeds the post-length limit (more than
@@ -66,6 +66,9 @@
   bytes without allocating an intermediate byte list. For over-limit text this
   cuts `isLengthLimitExceeded` ~18x and `segments` ~2x; a 300-grapheme post
   segments in well under 0.1 ms.
+
+## v1.4.1
+
 - **FIX**: Markdown links whose destination contains surrounding whitespace are
   now detected and formatted correctly. Previously the link's end offset was
   reconstructed from `label length + URL length + 4`, which ignored any

--- a/packages/bluesky_text/CHANGELOG.md
+++ b/packages/bluesky_text/CHANGELOG.md
@@ -24,6 +24,33 @@
   single pass — without merging the byte-based entity indices and the overflow
   range by hand. Concatenating every `TextSegment.text` reproduces the value,
   and no segment is ever split across an entity boundary.
+- **FEAT**: Added `renderFacets(text, facets)` and `PostFacet` for displaying a
+  **fetched** post: it partitions the text into `TextSegment`s using the
+  server-provided facets (authoritative mentions/links/tags, mentions already
+  carrying their DID) instead of re-detecting entities. Each segment exposes a
+  `FacetFeature` with the resolved DID / URI / tag, so a Flutter client can
+  style received posts with one `TextSpan` builder shared with the compose path.
+  `PostFacet.fromJson` parses the `app.bsky.richtext.facet` API shape, and the
+  byte→UTF-16 `Utf16IndexConverter` is now public.
+- **FEAT**: `Entities.toFacets` / the new `Entities.toFacetsResult` accept a
+  `HandleResolver`, so mention DID resolution can be served from a cache or
+  batched instead of the built-in per-handle network call. `toFacetsResult`
+  additionally returns the handles that failed to resolve, so a client can warn
+  the user rather than silently posting a mention-less message.
+- **FEAT**: Added `BlueskyText.formatted` (the memoized, posting-ready form) and
+  `BlueskyText.toPostData(...)`, which formats and resolves facets in one call —
+  the only correct order, since markdown links become link facets only after
+  formatting — returning `(text, facets, unresolvedHandles)`.
+- **FIX**: `split()` now budgets each chunk against **both** post limits (300
+  graphemes and 3000 UTF-8 bytes). Previously it budgeted graphemes only, so a
+  byte-heavy chunk — e.g. many multi-byte ZWJ emoji — could stay under 300
+  graphemes yet exceed 3000 bytes and still be rejected by the server.
+- **PERF**: `BlueskyText` now lazily memoizes every derived value (`length`,
+  `handles`, `entities`, `overflow`, `segments`, `format()`…), so touching
+  several properties of one instance in a Flutter `build` costs one analysis
+  instead of one per property (~1.6x faster when touching seven). Note: as a
+  result `BlueskyText` is **no longer `const`** — `const BlueskyText(...)` must
+  become `BlueskyText(...)`.
 - **PERF**: The length-limit hot paths (polled on every keystroke in a Flutter
   editor) avoid the regex-based entity extraction entirely unless it is needed.
   `isLengthLimitExceeded` and `overflow` fall back to a cheap grapheme scan when

--- a/packages/bluesky_text/CHANGELOG.md
+++ b/packages/bluesky_text/CHANGELOG.md
@@ -52,7 +52,14 @@
   display text and a markdown link's facet vanished — because the chunks dropped
   the position-bound replacements. Each chunk is a raw, independently-formattable
   piece; format each one *after* splitting (e.g. via `chunk.toPostData()`).
-- **PERF**: `BlueskyText` now lazily memoizes every derived value (`length`,
+- **FIX**: `split()` now breaks on **any** Unicode whitespace — newlines, tabs
+  and the ideographic (full-width) space `U+3000` — not just the ASCII space.
+  Previously a multi-line or CJK post with no ASCII spaces was treated as one
+  giant word and hard-split mid-word (e.g. `word44` became `wo` | `rd44`). The
+  author's newlines and spacing are now preserved within each chunk, and no
+  chunk starts or ends with whitespace. A markdown link is also kept atomic, so
+  one straddling a chunk boundary is no longer torn open (which would drop its
+  facet).
   `handles`, `entities`, `overflow`, `segments`, `format()`…), so touching
   several properties of one instance in a Flutter `build` costs one analysis
   instead of one per property (~1.6x faster when touching seven). Note: as a

--- a/packages/bluesky_text/CHANGELOG.md
+++ b/packages/bluesky_text/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 ## v1.4.1
 
+- **FEAT**: Added `BlueskyText.overflow`, which returns a `TextLengthOverflow`
+  describing the range of the text that exceeds the post-length limit (more than
+  300 graphemes or 3000 UTF-8 bytes), or `null` when it is within both. The
+  boundary is reported in UTF-16, UTF-8 byte and grapheme coordinates so a UI
+  can, for example, split the value with `TextLengthOverflow.utf16Start` and
+  render the overflowing tail in red via a Flutter `TextSpan`.
+  - The boundary always lands on a grapheme cluster boundary, so emoji and other
+    multi-code-unit characters are never split.
+  - When the boundary would fall inside an entity (handle, link, tag, cashtag or
+    markdown link) it is snapped back to that entity's start, so the entity is
+    treated atomically — wholly within the limit or wholly in the overflow.
+  - Because the range is derived from the value, calling `.format().overflow`
+    reports the overflow of the formatted text (markdown expanded, links
+    shortened), which is what is displayed and posted.
+- **FEAT**: Added `BlueskyText.segments`, which partitions the value into
+  non-overlapping, gap-free `TextSegment`s in document order. Each segment
+  carries UTF-16 offsets, the entity it belongs to (if any) and whether it lies
+  in the overflow region, so a Flutter `TextEditingController` can color links,
+  handles and tags together with the over-limit tail (for example in red) in a
+  single pass — without merging the byte-based entity indices and the overflow
+  range by hand. Concatenating every `TextSegment.text` reproduces the value,
+  and no segment is ever split across an entity boundary.
+- **PERF**: The length-limit hot paths (polled on every keystroke in a Flutter
+  editor) avoid the regex-based entity extraction entirely unless it is needed.
+  `isLengthLimitExceeded` and `overflow` fall back to a cheap grapheme scan when
+  within the limit, `segments` resolves the entities only once (instead of
+  extracting them again via `overflow`), and the grapheme scan counts UTF-8
+  bytes without allocating an intermediate byte list. For over-limit text this
+  cuts `isLengthLimitExceeded` ~18x and `segments` ~2x; a 300-grapheme post
+  segments in well under 0.1 ms.
 - **FIX**: Markdown links whose destination contains surrounding whitespace are
   now detected and formatted correctly. Previously the link's end offset was
   reconstructed from `label length + URL length + 4`, which ignored any

--- a/packages/bluesky_text/benchmark/segments_benchmark.dart
+++ b/packages/bluesky_text/benchmark/segments_benchmark.dart
@@ -1,0 +1,119 @@
+// Copyright (c) 2023-2025, Shinya Kato.
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// A micro-benchmark for the hot paths a Flutter `TextEditingController` hits on
+// every keystroke: `isLengthLimitExceeded`, `overflow`, `entities`, `segments`.
+//
+// Run with: dart run benchmark/segments_benchmark.dart
+
+// Dart imports:
+import 'dart:math';
+
+// Package imports:
+import 'package:characters/characters.dart';
+
+// Project imports:
+import 'package:bluesky_text/bluesky_text.dart';
+
+const _iterations = 2000;
+const _warmup = 500;
+
+/// A realistic ~300-grapheme post: prose, handles, links, tags, emoji.
+final _realistic = () {
+  final buffer = StringBuffer();
+  const sentence =
+      'Shipping a new build today 🚀 big thanks to @shinyakato.dev and '
+      'the team, notes at https://example.com/blog/release-notes-v2 '
+      '#bluesky #dart こんにちは世界 ';
+  while (buffer.length < 900) {
+    buffer.write(sentence);
+  }
+  //* Trim to a value that is around the 300-grapheme limit.
+  return BlueskyText(buffer.toString()).split().first.value;
+}();
+
+/// A pathological value: many short entities packed together.
+final _entityDense = () {
+  final buffer = StringBuffer();
+  for (var i = 0; i < 30; i++) {
+    buffer.write('@user$i.bsky.social #tag$i https://ex$i.com/p ');
+  }
+  return buffer.toString();
+}();
+
+/// Well over the limit — a long paste the user then trims.
+final _oversized = 'a' * 1500;
+
+double _bench(final String label, final void Function() body) {
+  for (var i = 0; i < _warmup; i++) {
+    body();
+  }
+
+  final stopwatch = Stopwatch()..start();
+  for (var i = 0; i < _iterations; i++) {
+    body();
+  }
+  stopwatch.stop();
+
+  final perCallUs = stopwatch.elapsedMicroseconds / _iterations;
+  print('${label.padRight(46)} ${perCallUs.toStringAsFixed(2)} µs/call');
+  return perCallUs;
+}
+
+void _suite(final String name, final String value) {
+  print(
+    '\n=== $name (${BlueskyText(value).length} graphemes, '
+    '${value.length} UTF-16 units) ===',
+  );
+
+  _bench('$name  isLengthLimitExceeded', () {
+    BlueskyText(value).isLengthLimitExceeded;
+  });
+  _bench('$name  overflow', () {
+    BlueskyText(value).overflow;
+  });
+  _bench('$name  entities', () {
+    BlueskyText(value).entities;
+  });
+  _bench('$name  segments', () {
+    BlueskyText(value).segments;
+  });
+  _bench('$name  format().segments', () {
+    BlueskyText(value).format().segments;
+  });
+}
+
+/// Simulates typing the value one grapheme at a time, calling `segments` on
+/// each keystroke like a live `TextEditingController` would.
+void _typingSimulation(final String value) {
+  final graphemes = value.characters.toList();
+
+  final stopwatch = Stopwatch()..start();
+  final buffer = StringBuffer();
+  for (final g in graphemes) {
+    buffer.write(g);
+    BlueskyText(buffer.toString()).segments;
+  }
+  stopwatch.stop();
+
+  final total = stopwatch.elapsedMicroseconds / 1000;
+  final perKey = stopwatch.elapsedMicroseconds / graphemes.length;
+  print('\n=== typing simulation (${graphemes.length} keystrokes) ===');
+  print(
+    'total ${total.toStringAsFixed(1)} ms, '
+    '${perKey.toStringAsFixed(2)} µs/keystroke '
+    '(60fps frame budget = 16000 µs)',
+  );
+}
+
+void main() {
+  // Touch Random so the import is meaningful if the value builders evolve.
+  final _ = Random(1);
+
+  _suite('realistic', _realistic);
+  _suite('entity-dense', _entityDense);
+  _suite('oversized', _oversized);
+
+  _typingSimulation(_realistic);
+}

--- a/packages/bluesky_text/benchmark/segments_benchmark.dart
+++ b/packages/bluesky_text/benchmark/segments_benchmark.dart
@@ -107,6 +107,38 @@ void _typingSimulation(final String value) {
   );
 }
 
+/// Touching several properties of one text — as a Flutter `build` does — costs
+/// one analysis when the instance is reused (memoized), versus one per property
+/// when a fresh instance is built each time.
+void _memoizationComparison(final String value) {
+  void touchAll(final BlueskyText text) {
+    text.length;
+    text.handles;
+    text.links;
+    text.tags;
+    text.entities;
+    text.overflow;
+    text.segments;
+  }
+
+  final reused = _bench('reused instance (memoized)', () {
+    touchAll(BlueskyText(value));
+  });
+  final fresh = _bench('fresh instance per property', () {
+    BlueskyText(value).length;
+    BlueskyText(value).handles;
+    BlueskyText(value).links;
+    BlueskyText(value).tags;
+    BlueskyText(value).entities;
+    BlueskyText(value).overflow;
+    BlueskyText(value).segments;
+  });
+  print(
+    'memoization saves ${(fresh - reused).toStringAsFixed(1)} µs/build '
+    '(${(fresh / reused).toStringAsFixed(1)}x)',
+  );
+}
+
 void main() {
   // Touch Random so the import is meaningful if the value builders evolve.
   final _ = Random(1);
@@ -116,4 +148,7 @@ void main() {
   _suite('oversized', _oversized);
 
   _typingSimulation(_realistic);
+
+  print('\n=== memoization (touching 7 properties of one text) ===');
+  _memoizationComparison(_realistic);
 }

--- a/packages/bluesky_text/example/example.dart
+++ b/packages/bluesky_text/example/example.dart
@@ -7,21 +7,35 @@ import 'package:bluesky/core.dart';
 import 'package:bluesky_text/bluesky_text.dart';
 
 Future<void> main() async {
-  //! You just need to pass text to parse.
+  //! --------------------------------------------------------------------
+  //! 1. Analyze: just pass text — handles, links and tags are detected.
+  //! --------------------------------------------------------------------
   final text = BlueskyText(
     'I speak 日本語 and English 🚀 @shinyakato.dev and @shinyakato.bsky.social. '
     'Visit 🚀 https://shinyakato.dev.',
   );
 
-  //! Rendering for Flutter: color entities and the over-limit tail together.
-  //!
-  //! `segments` partitions the (formatted) text into non-overlapping slices,
-  //! each tagged with its entity (if any) and whether it lies past the
-  //! 300-grapheme / 3000-byte limit. Map each slice straight to a `TextSpan`
-  //! style — links/handles in blue, the overflowing tail in red — in a single
-  //! pass, with no manual index math. This is the natural body of a Flutter
-  //! `TextEditingController.buildTextSpan`, called on every keystroke.
-  for (final segment in text.format().segments) {
+  print(text.handles); //! @shinyakato.dev, @shinyakato.bsky.social
+  print(text.links); //! https://shinyakato.dev
+  print(text.entities); //! all of the above, in document order
+
+  //! Derived values (length, entities, segments, …) are lazily memoized, so
+  //! touching several of them on one instance — as a Flutter `build` does —
+  //! costs one analysis, not one per property.
+
+  //! --------------------------------------------------------------------
+  //! 2. Render while composing (Flutter).
+  //! --------------------------------------------------------------------
+  //! `formatted` is the posting-ready form (markdown expanded, links
+  //! shortened) — measure and render what will actually be posted.
+  final post = text.formatted;
+
+  //! `segments` partitions the text into non-overlapping slices, each tagged
+  //! with its entity (if any) and whether it lies past the 300-grapheme /
+  //! 3000-byte limit. Map each slice straight to a `TextSpan` style — this is
+  //! the body of a `TextEditingController.buildTextSpan`, called on every
+  //! keystroke. Offsets are UTF-16, directly usable with `substring`.
+  for (final segment in post.segments) {
     final style = segment.isOverflow
         ? 'red'
         : segment.isEntity
@@ -30,79 +44,85 @@ Future<void> main() async {
     print('[$style] ${segment.text}');
   }
 
-  //! Need just the boundary (e.g. to show a live "-N over" counter)? `overflow`
-  //! returns it in UTF-16, UTF-8 byte and grapheme coordinates, or null when
-  //! within the limit.
-  final overflow = text.format().overflow;
+  //! --------------------------------------------------------------------
+  //! 3. The length limit and the overflowing tail.
+  //! --------------------------------------------------------------------
+  final tooLong = BlueskyText('${'とても長い投稿です。' * 40} #bluesky').formatted;
+
+  //! `overflow` locates where the text first exceeds the limit — in UTF-16
+  //! (for `substring` / `TextSpan`), UTF-8 bytes (the facet axis) and
+  //! graphemes — or null when within it. The boundary never splits an emoji
+  //! or an entity: a straddling entity moves wholly into the overflow.
+  final overflow = tooLong.overflow;
   if (overflow != null) {
-    final displayed = text.format().value;
-    print('within:   ${displayed.substring(0, overflow.utf16Start)}');
-    print('exceeded: ${displayed.substring(overflow.utf16Start)}');
-  }
-
-  if (text.isLengthLimitExceeded) {
-    //! Let's split.
-    final texts = text.split();
-
-    for (final text in texts) {
-      print(text.handles);
-      print(text.links);
-      print(text.entities);
-    }
-  } else {
-    // [{type: handle, value: @shinyakato.dev, indices: {start: 35, end: 50}},
-    // {type: handle, value: @shinyakato.bsky.social, indices: {start: 55, end: 78}}]
-    print(text.handles);
-
-    // [{type: link, value: https://shinyakato.dev, indices: {start: 91, end: 113}}]
-    print(text.links);
-
-    // [{type: handle, value: @shinyakato.dev, indices: {start: 35, end: 50}},
-    // {type: handle, value: @shinyakato.bsky.social, indices: {start: 55, end: 78}},
-    // {type: link, value: https://shinyakato.dev, indices: {start: 91, end: 113}}]
-    print(text.entities);
-
-    //! And you can easily integrate with bluesky package! `toPostData` formats
-    //! (markdown expanded, links shortened) AND resolves facets in one call —
-    //! the only correct order, since markdown links become facets only after
-    //! formatting.
-    final bluesky = bsky.Bluesky.fromSession(await _session);
-    final post = await text.toPostData();
-
-    //! Unresolved mentions are surfaced instead of silently dropped, so you can
-    //! warn the user before posting.
-    if (post.unresolvedHandles.isNotEmpty) {
-      print('Could not resolve: ${post.unresolvedHandles}');
-    }
-
-    await bluesky.feed.post.create(
-      text: post.text,
-      facets: post.facets.map(RichtextFacet.fromJson).toList(),
+    print(
+      'exceeds at grapheme ${overflow.graphemeStart}: '
+      '"…${tooLong.value.substring(overflow.utf16Start)}"',
     );
   }
 
-  //! Displaying a FETCHED post: render the server's facets (authoritative —
-  //! mentions already carry their DID) rather than re-detecting entities.
-  //! `renderFacets` gives the same `TextSegment` partition, so one `TextSpan`
-  //! builder styles both the composer and the timeline.
+  //! Or split it into postable chunks for a thread — every chunk respects
+  //! BOTH limits (300 graphemes AND 3000 UTF-8 bytes).
+  for (final chunk in tooLong.split()) {
+    print('chunk: ${chunk.length} graphemes');
+  }
+
+  //! --------------------------------------------------------------------
+  //! 4. Post it: format + facets in one call.
+  //! --------------------------------------------------------------------
+  //! `toPostData` formats and resolves facets in the correct order (markdown
+  //! links become facets only after formatting). Inject a resolver to serve
+  //! mention DIDs from your own cache instead of a per-handle network call.
+  final data = await text.toPostData(
+    resolver: (handle) async => _didCache[handle],
+  );
+
+  //! Handles that failed to resolve are surfaced — warn the user instead of
+  //! silently posting without those mentions.
+  if (data.unresolvedHandles.isNotEmpty) {
+    print('Could not resolve: ${data.unresolvedHandles}');
+  }
+
+  final bluesky = bsky.Bluesky.fromSession(await _session);
+  await bluesky.feed.post.create(
+    text: data.text,
+    facets: data.facets.map(RichtextFacet.fromJson).toList(),
+  );
+
+  //! --------------------------------------------------------------------
+  //! 5. Display a FETCHED post (timeline).
+  //! --------------------------------------------------------------------
+  //! Render the server's facets — authoritative, mentions already carry
+  //! their DID — instead of re-detecting entities. `renderFacets` returns
+  //! the same `TextSegment` partition as step 2, so ONE `TextSpan` builder
+  //! styles both the composer and the timeline.
   const fetchedText = 'hello @shinyakato.dev 🦋';
-  final fetchedFacets = [
+  const fetchedFacets = [
     {
       'index': {'byteStart': 6, 'byteEnd': 21},
       'features': [
-        {'\$type': 'app.bsky.richtext.facet#mention', 'did': 'did:plc:1234'},
+        {r'$type': 'app.bsky.richtext.facet#mention', 'did': 'did:plc:xxxx'},
       ],
     },
   ];
+
   for (final segment in renderFacets(
     fetchedText,
     fetchedFacets.map(PostFacet.fromJson).toList(),
   )) {
-    print(
-      '[${segment.type ?? 'text'}] ${segment.text} ${segment.feature?.value ?? ''}',
-    );
+    //! `segment.feature` carries the resolved DID / URI / tag — exactly what
+    //! a tap handler needs.
+    final target = segment.isFeature ? ' -> ${segment.feature!.value}' : '';
+    print('[${segment.type ?? 'text'}] ${segment.text}$target');
   }
 }
+
+//! Your app usually already knows the DIDs of the handles the user mentions
+//! (from search results, follows, etc.) — serve them from a cache.
+const _didCache = {
+  'shinyakato.dev': 'did:plc:xxxx',
+  'shinyakato.bsky.social': 'did:plc:xxxx',
+};
 
 Future<Session> get _session async {
   final session = await createSession(

--- a/packages/bluesky_text/example/example.dart
+++ b/packages/bluesky_text/example/example.dart
@@ -13,6 +13,33 @@ Future<void> main() async {
     'Visit 🚀 https://shinyakato.dev.',
   );
 
+  //! Rendering for Flutter: color entities and the over-limit tail together.
+  //!
+  //! `segments` partitions the (formatted) text into non-overlapping slices,
+  //! each tagged with its entity (if any) and whether it lies past the
+  //! 300-grapheme / 3000-byte limit. Map each slice straight to a `TextSpan`
+  //! style — links/handles in blue, the overflowing tail in red — in a single
+  //! pass, with no manual index math. This is the natural body of a Flutter
+  //! `TextEditingController.buildTextSpan`, called on every keystroke.
+  for (final segment in text.format().segments) {
+    final style = segment.isOverflow
+        ? 'red'
+        : segment.isEntity
+        ? 'blue (${segment.type})'
+        : 'default';
+    print('[$style] ${segment.text}');
+  }
+
+  //! Need just the boundary (e.g. to show a live "-N over" counter)? `overflow`
+  //! returns it in UTF-16, UTF-8 byte and grapheme coordinates, or null when
+  //! within the limit.
+  final overflow = text.format().overflow;
+  if (overflow != null) {
+    final displayed = text.format().value;
+    print('within:   ${displayed.substring(0, overflow.utf16Start)}');
+    print('exceeded: ${displayed.substring(overflow.utf16Start)}');
+  }
+
   if (text.isLengthLimitExceeded) {
     //! Let's split.
     final texts = text.split();

--- a/packages/bluesky_text/example/example.dart
+++ b/packages/bluesky_text/example/example.dart
@@ -62,13 +62,44 @@ Future<void> main() async {
     // {type: link, value: https://shinyakato.dev, indices: {start: 91, end: 113}}]
     print(text.entities);
 
-    //! And you can easily integrate with bluesky package!
+    //! And you can easily integrate with bluesky package! `toPostData` formats
+    //! (markdown expanded, links shortened) AND resolves facets in one call —
+    //! the only correct order, since markdown links become facets only after
+    //! formatting.
     final bluesky = bsky.Bluesky.fromSession(await _session);
-    final facets = await text.entities.toFacets();
+    final post = await text.toPostData();
+
+    //! Unresolved mentions are surfaced instead of silently dropped, so you can
+    //! warn the user before posting.
+    if (post.unresolvedHandles.isNotEmpty) {
+      print('Could not resolve: ${post.unresolvedHandles}');
+    }
 
     await bluesky.feed.post.create(
-      text: text.value,
-      facets: facets.map(RichtextFacet.fromJson).toList(),
+      text: post.text,
+      facets: post.facets.map(RichtextFacet.fromJson).toList(),
+    );
+  }
+
+  //! Displaying a FETCHED post: render the server's facets (authoritative —
+  //! mentions already carry their DID) rather than re-detecting entities.
+  //! `renderFacets` gives the same `TextSegment` partition, so one `TextSpan`
+  //! builder styles both the composer and the timeline.
+  const fetchedText = 'hello @shinyakato.dev 🦋';
+  final fetchedFacets = [
+    {
+      'index': {'byteStart': 6, 'byteEnd': 21},
+      'features': [
+        {'\$type': 'app.bsky.richtext.facet#mention', 'did': 'did:plc:1234'},
+      ],
+    },
+  ];
+  for (final segment in renderFacets(
+    fetchedText,
+    fetchedFacets.map(PostFacet.fromJson).toList(),
+  )) {
+    print(
+      '[${segment.type ?? 'text'}] ${segment.text} ${segment.feature?.value ?? ''}',
     );
   }
 }

--- a/packages/bluesky_text/lib/bluesky_text.dart
+++ b/packages/bluesky_text/lib/bluesky_text.dart
@@ -7,7 +7,11 @@ export 'package:bluesky_text/src/config/link_config.dart';
 export 'package:bluesky_text/src/entities/byte_indices.dart';
 export 'package:bluesky_text/src/entities/entities.dart';
 export 'package:bluesky_text/src/entities/entity.dart';
+export 'package:bluesky_text/src/facet.dart';
+export 'package:bluesky_text/src/facet_segmenter.dart' show renderFacets;
 export 'package:bluesky_text/src/text_length_overflow.dart';
 export 'package:bluesky_text/src/text_segment.dart';
+export 'package:bluesky_text/src/unicode_string.dart'
+    show Utf16IndexConverter, utf8ByteLength;
 export 'package:bluesky_text/src/utils.dart'
     show isEmojiOnly, getGraphemeLength;

--- a/packages/bluesky_text/lib/bluesky_text.dart
+++ b/packages/bluesky_text/lib/bluesky_text.dart
@@ -7,5 +7,7 @@ export 'package:bluesky_text/src/config/link_config.dart';
 export 'package:bluesky_text/src/entities/byte_indices.dart';
 export 'package:bluesky_text/src/entities/entities.dart';
 export 'package:bluesky_text/src/entities/entity.dart';
+export 'package:bluesky_text/src/text_length_overflow.dart';
+export 'package:bluesky_text/src/text_segment.dart';
 export 'package:bluesky_text/src/utils.dart'
     show isEmojiOnly, getGraphemeLength;

--- a/packages/bluesky_text/lib/src/bluesky_text.dart
+++ b/packages/bluesky_text/lib/src/bluesky_text.dart
@@ -142,7 +142,24 @@ sealed class BlueskyText {
   /// means that even if you specify a maximum number of characters for
   /// splitting, if some tokens exceed the maximum number of characters in t
   /// he middle, you do not have to worry about them being split at the halfway
-  /// point.
+  /// point. Each chunk respects **both** post limits (300 graphemes and 3000
+  /// UTF-8 bytes).
+  ///
+  /// Each chunk is a **raw**, independently-formattable piece, so format each
+  /// one *after* splitting — do not split an already-[format]ted instance and
+  /// post its chunks directly. (Calling [split] on a formatted instance is
+  /// safe: it transparently splits the original text, so `format().split()` is
+  /// equivalent to `split()` on the original.) The canonical thread flow is:
+  ///
+  /// ```dart
+  /// for (final chunk in text.split()) {
+  ///   final data = await chunk.toPostData();
+  ///   await bluesky.feed.post.create(
+  ///     text: data.text,
+  ///     facets: data.facets.map(RichtextFacet.fromJson).toList(),
+  ///   );
+  /// }
+  /// ```
   List<BlueskyText> split();
 
   /// Returns a new formatted [BlueskyText] based on configs.
@@ -372,11 +389,29 @@ final class _BlueskyText implements BlueskyText {
   //* must not silently corrupt every later access.
   late final List<BlueskyText> _chunks = List.unmodifiable(
     splitter.execute(
-      this,
+      _splitSource,
       enableMarkdown: _enableMarkdown,
       linkConfig: _linkConfig,
     ),
   );
+
+  /// The text to actually split. For a formatted instance, [value] is lossy
+  /// display text (shortened URLs, expanded markdown) whose entities can no
+  /// longer be re-derived correctly, so splitting it and re-extracting would
+  /// corrupt facets (a shortened URL would become the mention/link `uri`, and a
+  /// markdown link would vanish). Split the ORIGINAL text instead, so each chunk
+  /// is a raw, independently-formattable piece — this makes `format().split()`
+  /// behave exactly like `split()` on the original text.
+  BlueskyText get _splitSource {
+    final replacements = _replacements;
+    if (replacements == null) return this;
+
+    return BlueskyText(
+      replacements.base,
+      enableMarkdown: _enableMarkdown,
+      linkConfig: _linkConfig,
+    );
+  }
 
   @override
   List<BlueskyText> split() => _chunks;

--- a/packages/bluesky_text/lib/src/bluesky_text.dart
+++ b/packages/bluesky_text/lib/src/bluesky_text.dart
@@ -2,17 +2,17 @@
 // All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// Dart imports:
-import 'dart:convert';
-
 // Project imports:
 import 'config/link_config.dart';
-import 'const.dart';
 import 'entities/entities.dart';
+import 'entities/entity.dart';
 import 'entities/replacements.dart';
 import 'extractor/extractor.dart';
 import 'formatter.dart';
+import 'segmenter.dart';
 import 'splitter.dart';
+import 'text_length_overflow.dart';
+import 'text_segment.dart';
 import 'utils.dart' as utils;
 
 /// This class provides high-performance analysis of [Bluesky Social](https://blueskyweb.xyz)'s text
@@ -150,6 +150,66 @@ sealed class BlueskyText {
   /// graphemes ([length]) and at most 3000 UTF-8 bytes — otherwise false.
   bool get isNotLengthLimitExceeded;
 
+  /// Returns the range of [value] that exceeds the post-length limit, or `null`
+  /// when the text is within both limits ([isNotLengthLimitExceeded]).
+  ///
+  /// The overflow spans from a boundary offset to the end of [value] and is
+  /// reported in UTF-16, UTF-8 byte and grapheme coordinates (see
+  /// [TextLengthOverflow]). Use [TextLengthOverflow.utf16Start] to split the
+  /// value for a Flutter `TextSpan` — for example to render the overflowing
+  /// tail in red:
+  ///
+  /// ```dart
+  /// final overflow = text.format().overflow;
+  /// if (overflow != null) {
+  ///   final within = text.value.substring(0, overflow.utf16Start);
+  ///   final exceeded = text.value.substring(overflow.utf16Start);
+  ///   // render `within` normally and `exceeded` in red.
+  /// }
+  /// ```
+  ///
+  /// The boundary always lands on a grapheme cluster boundary, and when it
+  /// would otherwise fall inside an entity (a handle, link, tag, cashtag or
+  /// markdown link) it is snapped back to that entity's start so the entity is
+  /// treated atomically — either wholly within the limit or wholly in the
+  /// overflow. Because the boundary is derived from [value], calling this after
+  /// [format] reports the overflow of the formatted text (markdown expanded,
+  /// links shortened), which is what is displayed and posted.
+  TextLengthOverflow? get overflow;
+
+  /// Returns [value] partitioned into non-overlapping, gap-free [TextSegment]s
+  /// in document order, each tagged with the [entities] it belongs to (if any)
+  /// and whether it lies in the [overflow] region.
+  ///
+  /// This is a ready-to-render partition for a Flutter `TextSpan` tree: on each
+  /// keystroke you can color entities (links, handles, tags) and the
+  /// over-limit tail (for example in red) in a single pass, without merging the
+  /// byte-based [entities] and the [overflow] range yourself. Concatenating
+  /// every [TextSegment.text] reproduces [value].
+  ///
+  /// ```dart
+  /// TextSpan(
+  ///   children: [
+  ///     for (final s in text.segments)
+  ///       TextSpan(
+  ///         text: s.text,
+  ///         style: TextStyle(
+  ///           color: s.isOverflow
+  ///               ? Colors.red
+  ///               : s.isEntity
+  ///                   ? Colors.blue
+  ///                   : null,
+  ///         ),
+  ///       ),
+  ///   ],
+  /// )
+  /// ```
+  ///
+  /// Like [overflow], the segmentation is measured against [value], so call it
+  /// on the instance whose text is displayed — typically the raw input while
+  /// editing, or `format()` for a preview of the posted text.
+  List<TextSegment> get segments;
+
   /// Returns true if this [value] is empty, otherwise false.
   bool get isEmpty;
 
@@ -230,10 +290,59 @@ final class _BlueskyText implements BlueskyText {
 
   @override
   bool get isLengthLimitExceeded =>
-      maxLength < length || maxByteLength < utf8.encode(value).length;
+      //* Existence of an overflow never depends on entity snapping (snapping
+      //* only moves the boundary, never creates or removes it), so this stays
+      //* on the cheap raw scan and never triggers the regex-based extraction —
+      //* it is polled on every keystroke to toggle a post button.
+      utils.computeLengthOverflow(value) != null;
 
   @override
   bool get isNotLengthLimitExceeded => !isLengthLimitExceeded;
+
+  @override
+  TextLengthOverflow? get overflow {
+    final raw = utils.computeLengthOverflow(value);
+    if (raw == null) return null;
+
+    //* `entities` (the regex extraction) is only resolved once the limit is
+    //* actually exceeded.
+    return _snapOverflow(raw, entities);
+  }
+
+  @override
+  List<TextSegment> get segments {
+    //* Resolve the entities exactly once and reuse them for both the overflow
+    //* snapping and the partition, instead of letting `overflow` re-extract.
+    final resolved = entities;
+    final raw = utils.computeLengthOverflow(value);
+    final overflow = raw == null ? null : _snapOverflow(raw, resolved);
+
+    return segmenter.execute(value, resolved, overflow);
+  }
+
+  /// Snaps [raw]'s boundary back to the start of any entity that strictly
+  /// contains it, so a straddling entity is pushed wholly into the overflow.
+  /// Entities carry UTF-8 byte indices, matching [TextLengthOverflow.byteStart],
+  /// and never overlap, so at most one strictly contains the boundary point.
+  TextLengthOverflow _snapOverflow(
+    final TextLengthOverflow raw,
+    final List<Entity> entities,
+  ) {
+    for (final entity in entities) {
+      if (entity.indices.start < raw.byteStart &&
+          raw.byteStart < entity.indices.end) {
+        return utils.snapLengthOverflowToByte(
+          value,
+          byteStart: entity.indices.start,
+          limit: raw.limit,
+          utf16End: raw.utf16End,
+          byteEnd: raw.byteEnd,
+        );
+      }
+    }
+
+    return raw;
+  }
 
   @override
   bool get isEmpty => value.trim().isEmpty;

--- a/packages/bluesky_text/lib/src/bluesky_text.dart
+++ b/packages/bluesky_text/lib/src/bluesky_text.dart
@@ -77,7 +77,13 @@ import 'utils.dart' as utils;
 /// ```
 sealed class BlueskyText {
   /// Returns the new instance of [BlueskyText].
-  const factory BlueskyText(
+  ///
+  /// The instance lazily memoizes every derived value ([length], [handles],
+  /// [entities], [overflow], [segments], [format]…) the first time it is read,
+  /// so touching several of them in a Flutter `build` costs one analysis, not
+  /// one per property. Construct once per text and reuse the instance; a new
+  /// instance re-analyzes from scratch.
+  factory BlueskyText(
     final String text, {
     final bool enableMarkdown,
     final LinkConfig? linkConfig,
@@ -141,6 +147,52 @@ sealed class BlueskyText {
 
   /// Returns a new formatted [BlueskyText] based on configs.
   BlueskyText format();
+
+  /// The formatted, posting-ready form of this text — the same instance
+  /// [format] returns, memoized (markdown expanded, links shortened).
+  ///
+  /// Post-length and facet concerns should be measured against **this**, not
+  /// the raw instance: the raw [value] may contain markdown syntax and full
+  /// URLs that shrink when posted (or a markdown label that is longer than the
+  /// text actually posted). The canonical flow is:
+  ///
+  /// ```dart
+  /// final post = text.formatted;
+  /// if (post.isNotLengthLimitExceeded) {
+  ///   await bluesky.feed.post.create(
+  ///     text: post.value,
+  ///     facets: (await post.entities.toFacets()).map(RichtextFacet.fromJson).toList(),
+  ///   );
+  /// }
+  /// ```
+  ///
+  /// See [toPostData] for a one-call shortcut.
+  BlueskyText get formatted;
+
+  /// Builds everything needed to create a post in a single call: the formatted
+  /// [value], its facets, and any handles that failed to resolve.
+  ///
+  /// This formats first and resolves facets on the formatted entities — the
+  /// only correct order, since markdown links become link facets only after
+  /// [format]. Pass a [resolver] to control mention DID resolution (e.g. a
+  /// cache); inspect `unresolvedHandles` to warn the user rather than silently
+  /// posting without those mentions.
+  ///
+  /// ```dart
+  /// final post = await text.toPostData();
+  /// await bluesky.feed.post.create(
+  ///   text: post.text,
+  ///   facets: post.facets.map(RichtextFacet.fromJson).toList(),
+  /// );
+  /// ```
+  Future<
+    ({
+      String text,
+      List<Map<String, dynamic>> facets,
+      List<String> unresolvedHandles,
+    })
+  >
+  toPostData({String? service, HandleResolver? resolver});
 
   /// Returns true if this text exceeds either post limit — more than 300
   /// graphemes ([length]) or more than 3000 UTF-8 bytes — otherwise false.
@@ -225,7 +277,7 @@ sealed class BlueskyText {
 
 final class _BlueskyText implements BlueskyText {
   /// Returns the new instance of [_BlueskyText].
-  const _BlueskyText(
+  _BlueskyText(
     this.value, {
     bool enableMarkdown = true,
     LinkConfig? linkConfig,
@@ -242,13 +294,13 @@ final class _BlueskyText implements BlueskyText {
   final String value;
 
   @override
-  int get length => utils.getGraphemeLength(value);
+  late final int length = utils.getGraphemeLength(value);
 
   @override
-  Entities get handles => Entities(handlesExtractor.execute(this));
+  late final Entities handles = Entities(handlesExtractor.execute(this));
 
   @override
-  Entities get links => Entities(
+  late final Entities links = Entities(
     linksExtractor.execute(
       this,
       ExtractorConfig(
@@ -259,16 +311,17 @@ final class _BlueskyText implements BlueskyText {
   );
 
   @override
-  Entities get tags => Entities(tagsExtractor.execute(this));
+  late final Entities tags = Entities(tagsExtractor.execute(this));
 
   @override
-  Entities get cashtags => Entities(cashtagsExtractor.execute(this));
+  late final Entities cashtags = Entities(cashtagsExtractor.execute(this));
 
   @override
-  Entities get entities => Entities(
+  late final Entities entities = Entities(
     allExtractor.execute(
       this,
       ExtractorConfig(
+        //* Reuses the memoized [handles] instead of re-extracting them.
         handles: handles,
         replacements: _replacements,
         enableMarkdown: _enableMarkdown,
@@ -276,49 +329,77 @@ final class _BlueskyText implements BlueskyText {
     ),
   );
 
-  @override
-  BlueskyText format() => _replacements != null
-      ? this //* is already formatted.
+  /// The formatted (markdown-expanded, link-shortened) instance — what is
+  /// actually displayed and posted. An already-formatted instance (one carrying
+  /// `replacements`) is its own formatted form.
+  late final BlueskyText _formatted = _replacements != null
+      ? this
       : formatter.execute(this, _enableMarkdown, _linkConfig).$1;
 
   @override
-  List<BlueskyText> split() => splitter.execute(
+  BlueskyText format() => _formatted;
+
+  @override
+  BlueskyText get formatted => _formatted;
+
+  @override
+  Future<
+    ({
+      String text,
+      List<Map<String, dynamic>> facets,
+      List<String> unresolvedHandles,
+    })
+  >
+  toPostData({String? service, HandleResolver? resolver}) async {
+    final post = _formatted;
+    final result = await post.entities.toFacetsResult(
+      service: service,
+      resolver: resolver,
+    );
+
+    return (
+      text: post.value,
+      facets: result.facets,
+      unresolvedHandles: result.unresolvedHandles,
+    );
+  }
+
+  late final List<BlueskyText> _chunks = splitter.execute(
     this,
     enableMarkdown: _enableMarkdown,
     linkConfig: _linkConfig,
   );
 
   @override
-  bool get isLengthLimitExceeded =>
-      //* Existence of an overflow never depends on entity snapping (snapping
-      //* only moves the boundary, never creates or removes it), so this stays
-      //* on the cheap raw scan and never triggers the regex-based extraction —
-      //* it is polled on every keystroke to toggle a post button.
-      utils.computeLengthOverflow(value) != null;
+  List<BlueskyText> split() => _chunks;
+
+  /// The raw (pre-snapping) overflow. Kept separate from [overflow] so
+  /// [isLengthLimitExceeded] can answer from this cheap grapheme scan alone,
+  /// without ever triggering the regex-based entity extraction — it is polled
+  /// on every keystroke to toggle a post button.
+  late final TextLengthOverflow? _rawOverflow = utils.computeLengthOverflow(
+    value,
+  );
+
+  @override
+  bool get isLengthLimitExceeded => _rawOverflow != null;
 
   @override
   bool get isNotLengthLimitExceeded => !isLengthLimitExceeded;
 
   @override
-  TextLengthOverflow? get overflow {
-    final raw = utils.computeLengthOverflow(value);
-    if (raw == null) return null;
-
-    //* `entities` (the regex extraction) is only resolved once the limit is
-    //* actually exceeded.
-    return _snapOverflow(raw, entities);
-  }
+  late final TextLengthOverflow? overflow = _rawOverflow == null
+      ? null
+      //* `entities` (the regex extraction) is only resolved once the limit is
+      //* actually exceeded.
+      : _snapOverflow(_rawOverflow, entities);
 
   @override
-  List<TextSegment> get segments {
-    //* Resolve the entities exactly once and reuse them for both the overflow
-    //* snapping and the partition, instead of letting `overflow` re-extract.
-    final resolved = entities;
-    final raw = utils.computeLengthOverflow(value);
-    final overflow = raw == null ? null : _snapOverflow(raw, resolved);
-
-    return segmenter.execute(value, resolved, overflow);
-  }
+  late final List<TextSegment> segments = segmenter.execute(
+    value,
+    entities,
+    overflow,
+  );
 
   /// Snaps [raw]'s boundary back to the start of any entity that strictly
   /// contains it, so a straddling entity is pushed wholly into the overflow.
@@ -351,7 +432,7 @@ final class _BlueskyText implements BlueskyText {
   bool get isNotEmpty => !isEmpty;
 
   @override
-  bool get isEmojiOnly => utils.isEmojiOnly(value);
+  late final bool isEmojiOnly = utils.isEmojiOnly(value);
 
   @override
   bool get isNotEmojiOnly => !isEmojiOnly;

--- a/packages/bluesky_text/lib/src/bluesky_text.dart
+++ b/packages/bluesky_text/lib/src/bluesky_text.dart
@@ -212,10 +212,13 @@ sealed class BlueskyText {
   /// tail in red:
   ///
   /// ```dart
-  /// final overflow = text.format().overflow;
+  /// final post = text.formatted;
+  /// final overflow = post.overflow;
   /// if (overflow != null) {
-  ///   final within = text.value.substring(0, overflow.utf16Start);
-  ///   final exceeded = text.value.substring(overflow.utf16Start);
+  ///   //! The offsets index into the *formatted* value, so substring that —
+  ///   //! not the raw `text.value`, whose offsets differ after formatting.
+  ///   final within = post.value.substring(0, overflow.utf16Start);
+  ///   final exceeded = post.value.substring(overflow.utf16Start);
   ///   // render `within` normally and `exceeded` in red.
   /// }
   /// ```
@@ -364,10 +367,15 @@ final class _BlueskyText implements BlueskyText {
     );
   }
 
-  late final List<BlueskyText> _chunks = splitter.execute(
-    this,
-    enableMarkdown: _enableMarkdown,
-    linkConfig: _linkConfig,
+  //* Memoized results are shared across calls, so they are wrapped
+  //* unmodifiable: a caller mutating the returned list (`..sort()`, `clear()`)
+  //* must not silently corrupt every later access.
+  late final List<BlueskyText> _chunks = List.unmodifiable(
+    splitter.execute(
+      this,
+      enableMarkdown: _enableMarkdown,
+      linkConfig: _linkConfig,
+    ),
   );
 
   @override
@@ -395,10 +403,8 @@ final class _BlueskyText implements BlueskyText {
       : _snapOverflow(_rawOverflow, entities);
 
   @override
-  late final List<TextSegment> segments = segmenter.execute(
-    value,
-    entities,
-    overflow,
+  late final List<TextSegment> segments = List.unmodifiable(
+    segmenter.execute(value, entities, overflow),
   );
 
   /// Snaps [raw]'s boundary back to the start of any entity that strictly

--- a/packages/bluesky_text/lib/src/entities/entities.dart
+++ b/packages/bluesky_text/lib/src/entities/entities.dart
@@ -26,7 +26,8 @@ class Entities extends UnmodifiableListView<Entity> {
     );
 
     final facets = <Map<String, dynamic>>[];
-    final unresolvedHandles = <String>[];
+    //* A set so a handle mentioned multiple times is reported once.
+    final unresolvedHandles = <String>{};
     for (var i = 0; i < length; i++) {
       final facet = results[i];
       if (facet.isEmpty) {
@@ -39,7 +40,7 @@ class Entities extends UnmodifiableListView<Entity> {
       facets.add(facet);
     }
 
-    return (facets: facets, unresolvedHandles: unresolvedHandles);
+    return (facets: facets, unresolvedHandles: unresolvedHandles.toList());
   }
 
   /// Returns the collection of facet.

--- a/packages/bluesky_text/lib/src/entities/entities.dart
+++ b/packages/bluesky_text/lib/src/entities/entities.dart
@@ -12,12 +12,43 @@ class Entities extends UnmodifiableListView<Entity> {
   /// Returns the new instance of [Entities].
   Entities(super.source);
 
-  /// Returns the collection of facet.
-  Future<List<Map<String, dynamic>>> toFacets({String? service}) async {
-    final facets = await Future.wait(
-      map((entity) => entity.toFacet(service: service)),
+  /// Returns the facets for these entities, together with the handles that
+  /// failed to resolve to a DID (and were therefore dropped from `facets`).
+  ///
+  /// Pass a [resolver] to control mention resolution — e.g. to serve cached
+  /// DIDs or batch lookups — instead of the built-in per-handle network call.
+  /// `unresolvedHandles` lets the caller warn the user (or retry) rather than
+  /// silently posting a mention-less message.
+  Future<({List<Map<String, dynamic>> facets, List<String> unresolvedHandles})>
+  toFacetsResult({String? service, HandleResolver? resolver}) async {
+    final results = await Future.wait(
+      map((entity) => entity.toFacet(service: service, resolver: resolver)),
     );
 
-    return facets..removeWhere((e) => e.isEmpty);
+    final facets = <Map<String, dynamic>>[];
+    final unresolvedHandles = <String>[];
+    for (var i = 0; i < length; i++) {
+      final facet = results[i];
+      if (facet.isEmpty) {
+        //* Only a handle produces an empty facet by *failing to resolve*; the
+        //* other empty case is a raw markdown link, which is not a resolution
+        //* failure and must not be reported.
+        if (this[i].isHandle) unresolvedHandles.add(this[i].value);
+        continue;
+      }
+      facets.add(facet);
+    }
+
+    return (facets: facets, unresolvedHandles: unresolvedHandles);
   }
+
+  /// Returns the collection of facet.
+  ///
+  /// A thin wrapper over [toFacetsResult] that keeps only the facets; use
+  /// [toFacetsResult] when you also need the unresolved handles.
+  Future<List<Map<String, dynamic>>> toFacets({
+    String? service,
+    HandleResolver? resolver,
+  }) async =>
+      (await toFacetsResult(service: service, resolver: resolver)).facets;
 }

--- a/packages/bluesky_text/lib/src/entities/entity.dart
+++ b/packages/bluesky_text/lib/src/entities/entity.dart
@@ -10,6 +10,14 @@ import '../api/find_did.dart' as api;
 import 'byte_indices.dart';
 import 'facetable.dart';
 
+/// Resolves a Bluesky `handle` (e.g. `shinyakato.dev`) to its DID, or returns
+/// `null` when the handle does not resolve.
+///
+/// Supply one to [Entity.toFacet] / `Entities.toFacets` to control mention
+/// resolution — for example to serve already-known DIDs from a cache or to
+/// batch lookups — instead of the built-in per-handle network call.
+typedef HandleResolver = Future<String?> Function(String handle);
+
 final class Entity implements Facetable {
   final EntityType type;
   final String value;
@@ -24,7 +32,16 @@ final class Entity implements Facetable {
   });
 
   /// Returns the facet representation of this entity as JSON.
-  Future<Map<String, dynamic>> toFacet({String? service}) async {
+  ///
+  /// For a handle, [resolver] (when given) is used to look up the DID instead of
+  /// the built-in network call, so callers can inject a cache of known DIDs.
+  /// When the handle does not resolve, an empty map is returned; use
+  /// `Entities.toFacetsResult` to learn which handles were dropped rather than
+  /// silently posting without their mentions.
+  Future<Map<String, dynamic>> toFacet({
+    String? service,
+    HandleResolver? resolver,
+  }) async {
     final facet = <String, dynamic>{
       'index': {'byteStart': indices.start, 'byteEnd': indices.end},
       'features': [],
@@ -32,21 +49,33 @@ final class Entity implements Facetable {
 
     switch (type) {
       case EntityType.handle:
-        try {
-          final did = await api.findDID(handle: value, service: service);
-
-          facet['features'].add({
-            '\$type': 'app.bsky.richtext.facet#mention',
-            'did': did.data['did'],
-          });
-        } on xrpc.InvalidRequestException {
-          //* The handle could not be resolved to a DID (e.g. it does not
-          //* exist), so there is legitimately no mention facet to emit. Only
-          //* this specific case is swallowed; network failures and other
-          //* unexpected errors are intentionally rethrown so a transient outage
-          //* does not silently drop mentions without the caller noticing.
-          return {};
+        final String? did;
+        if (resolver != null) {
+          did = await resolver(value);
+        } else {
+          try {
+            did =
+                (await api.findDID(handle: value, service: service)).data['did']
+                    as String?;
+          } on xrpc.InvalidRequestException {
+            //* The handle could not be resolved to a DID (e.g. it does not
+            //* exist), so there is legitimately no mention facet to emit. Only
+            //* this specific case is swallowed; network failures and other
+            //* unexpected errors are intentionally rethrown so a transient
+            //* outage does not silently drop mentions without the caller
+            //* noticing.
+            return {};
+          }
         }
+
+        //* A resolver that returns null (unknown handle) is treated the same as
+        //* the `InvalidRequestException` above: no mention facet.
+        if (did == null) return {};
+
+        facet['features'].add({
+          '\$type': 'app.bsky.richtext.facet#mention',
+          'did': did,
+        });
 
         break;
       case EntityType.link:

--- a/packages/bluesky_text/lib/src/facet.dart
+++ b/packages/bluesky_text/lib/src/facet.dart
@@ -1,0 +1,76 @@
+// Copyright (c) 2023-2025, Shinya Kato.
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// Project imports:
+import 'entities/entity.dart';
+import 'text_segment.dart';
+
+/// A server-provided rich-text facet from a fetched post: a UTF-8 byte range
+/// plus the resolved features that apply to it.
+///
+/// This is the *authoritative* rich-text of a post as its author committed it
+/// (mentions already carry their DID), unlike re-detecting entities from the
+/// raw text. Pass a post's `text` and its facets to `renderFacets` to build a
+/// styled partition for display.
+///
+/// Kept dependency-free: construct directly, or use [PostFacet.fromJson] to
+/// parse the `app.bsky.richtext.facet` JSON returned by the API.
+class PostFacet {
+  const PostFacet({
+    required this.byteStart,
+    required this.byteEnd,
+    required this.features,
+  });
+
+  /// Parses one `app.bsky.richtext.facet` JSON object (with an `index` and a
+  /// `features` list). Unknown feature `$type`s are skipped.
+  factory PostFacet.fromJson(final Map<String, dynamic> json) {
+    final index = (json['index'] as Map).cast<String, dynamic>();
+    final features = <FacetFeature>[];
+
+    for (final raw in (json['features'] as List? ?? const [])) {
+      final feature = _featureFromJson((raw as Map).cast<String, dynamic>());
+      if (feature != null) features.add(feature);
+    }
+
+    return PostFacet(
+      byteStart: index['byteStart'] as int,
+      byteEnd: index['byteEnd'] as int,
+      features: features,
+    );
+  }
+
+  /// The UTF-8 byte offset where the facet starts (inclusive).
+  final int byteStart;
+
+  /// The UTF-8 byte offset where the facet ends (exclusive).
+  final int byteEnd;
+
+  /// The features applied to the range (usually one).
+  final List<FacetFeature> features;
+}
+
+FacetFeature? _featureFromJson(final Map<String, dynamic> feature) {
+  switch (feature['\$type']) {
+    case 'app.bsky.richtext.facet#mention':
+      final did = feature['did'];
+      return did is String
+          ? FacetFeature(type: EntityType.handle, value: did)
+          : null;
+    case 'app.bsky.richtext.facet#link':
+      final uri = feature['uri'];
+      return uri is String
+          ? FacetFeature(type: EntityType.link, value: uri)
+          : null;
+    case 'app.bsky.richtext.facet#tag':
+      final tag = feature['tag'];
+      return tag is String
+          ? FacetFeature(type: EntityType.tag, value: tag)
+          : null;
+    default:
+      //* Unknown / unsupported feature type (the range is rendered as plain
+      //* text rather than dropped).
+      return null;
+  }
+}

--- a/packages/bluesky_text/lib/src/facet_segmenter.dart
+++ b/packages/bluesky_text/lib/src/facet_segmenter.dart
@@ -20,8 +20,10 @@ import 'text_segment.dart';
 ///
 /// The facet byte offsets are expected to align with grapheme boundaries (as
 /// the API guarantees). Facets are sorted by start, and any facet overlapping a
-/// previously kept one — or with no recognized feature, or an empty range — is
-/// dropped, so the output is always a clean partition.
+/// previously kept one — or with no recognized feature, an empty range, or a
+/// range entirely beyond the text — is dropped, so the output is always a
+/// clean partition. A range extending past the end of the text is clamped to
+/// it. When a facet carries multiple features, the first is used.
 List<TextSegment> renderFacets(
   final String text,
   final List<PostFacet> facets,

--- a/packages/bluesky_text/lib/src/facet_segmenter.dart
+++ b/packages/bluesky_text/lib/src/facet_segmenter.dart
@@ -1,0 +1,54 @@
+// Copyright (c) 2023-2025, Shinya Kato.
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// Project imports:
+import 'facet.dart';
+import 'segmenter.dart';
+import 'text_segment.dart';
+
+/// Partitions a fetched post's [text] into non-overlapping, gap-free
+/// [TextSegment]s using its server-provided [facets] — the display counterpart
+/// of `BlueskyText.segments`.
+///
+/// Each facet range becomes a segment carrying its [TextSegment.feature] (the
+/// resolved DID / URI / tag), and the gaps between them become plain segments,
+/// so a Flutter `TextSpan` tree can style mentions, links and tags of a
+/// received post with authoritative data — no re-detection, no manual
+/// byte→UTF-16 math. Concatenating every [TextSegment.text] reproduces [text],
+/// and `isOverflow` is always `false` (display has no post-length limit).
+///
+/// The facet byte offsets are expected to align with grapheme boundaries (as
+/// the API guarantees). Facets are sorted by start, and any facet overlapping a
+/// previously kept one — or with no recognized feature, or an empty range — is
+/// dropped, so the output is always a clean partition.
+List<TextSegment> renderFacets(
+  final String text,
+  final List<PostFacet> facets,
+) {
+  if (text.isEmpty) return const [];
+
+  final ordered = [...facets]
+    ..sort((a, b) => a.byteStart.compareTo(b.byteStart));
+
+  final spans = <SegmentSpan>[];
+  int lastEnd = 0;
+  for (final facet in ordered) {
+    if (facet.features.isEmpty) continue;
+    if (facet.byteStart >= facet.byteEnd) continue;
+    //* Skip a facet that overlaps one already kept; the partition builder
+    //* assumes non-overlapping spans.
+    if (facet.byteStart < lastEnd) continue;
+
+    spans.add(
+      SegmentSpan(
+        startByte: facet.byteStart,
+        endByte: facet.byteEnd,
+        feature: facet.features.first,
+      ),
+    );
+    lastEnd = facet.byteEnd;
+  }
+
+  return buildTextSegments(text, spans, null);
+}

--- a/packages/bluesky_text/lib/src/segmenter.dart
+++ b/packages/bluesky_text/lib/src/segmenter.dart
@@ -1,0 +1,135 @@
+// Copyright (c) 2023-2025, Shinya Kato.
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// Project imports:
+import 'entities/entity.dart';
+import 'text_length_overflow.dart';
+import 'text_segment.dart';
+import 'unicode_string.dart';
+
+const segmenter = Segmenter();
+
+sealed class Segmenter {
+  const factory Segmenter() = _Segmenter;
+
+  /// Partitions [value] using the already-resolved [entities] and [overflow] so
+  /// the caller controls extraction (and can reuse it), keeping this off the
+  /// regex path entirely.
+  List<TextSegment> execute(
+    final String value,
+    final List<Entity> entities,
+    final TextLengthOverflow? overflow,
+  );
+}
+
+final class _Segmenter implements Segmenter {
+  const _Segmenter();
+
+  @override
+  List<TextSegment> execute(
+    final String value,
+    final List<Entity> entities,
+    final TextLengthOverflow? overflow,
+  ) {
+    if (value.isEmpty) return const [];
+
+    //* Entities are non-overlapping (the extractor dedups) but not necessarily
+    //* sorted; order them so the partition is built left-to-right and the
+    //* byte→UTF-16 converter can stay monotonic.
+    final sorted = [...entities]
+      ..sort((a, b) => a.indices.start.compareTo(b.indices.start));
+
+    //* The overflow boundary in UTF-8 bytes, or null when within the limit.
+    //* Snapping guarantees it never falls strictly inside an entity, so it only
+    //* ever splits a plain-text slice.
+    final overflowByteStart = overflow?.byteStart;
+
+    final converter = Utf16IndexConverter(value);
+    final segments = <TextSegment>[];
+
+    void addSlice(
+      final int startByte,
+      final int endByte,
+      final Entity? entity,
+    ) {
+      if (startByte >= endByte) return;
+
+      //* Split a slice that straddles the overflow boundary into a within-limit
+      //* part and an overflowing part.
+      if (overflowByteStart != null &&
+          startByte < overflowByteStart &&
+          overflowByteStart < endByte) {
+        addSlice(startByte, overflowByteStart, entity);
+        addSlice(overflowByteStart, endByte, entity);
+        return;
+      }
+
+      final utf16Start = converter.convert(startByte);
+      final utf16End = converter.convert(endByte);
+
+      segments.add(
+        TextSegment(
+          text: value.substring(utf16Start, utf16End),
+          utf16Start: utf16Start,
+          utf16End: utf16End,
+          entity: entity,
+          isOverflow:
+              overflowByteStart != null && startByte >= overflowByteStart,
+        ),
+      );
+    }
+
+    int cursorByte = 0;
+    for (final entity in sorted) {
+      if (entity.indices.start > cursorByte) {
+        addSlice(cursorByte, entity.indices.start, null);
+      }
+
+      addSlice(entity.indices.start, entity.indices.end, entity);
+      cursorByte = entity.indices.end;
+    }
+
+    //* Trailing plain text after the last entity. Its UTF-16 end is simply the
+    //* value length, so the total byte length is never needed.
+    final trailingStart = converter.convert(cursorByte);
+    if (trailingStart < value.length) {
+      if (overflowByteStart != null && cursorByte < overflowByteStart) {
+        //* The boundary lies in the trailing text (it cannot be inside an
+        //* entity), so break the tail into within-limit and overflow parts.
+        final boundary = converter.convert(overflowByteStart);
+        if (trailingStart < boundary) {
+          segments.add(
+            _plain(value, trailingStart, boundary, isOverflow: false),
+          );
+        }
+        segments.add(_plain(value, boundary, value.length, isOverflow: true));
+      } else {
+        segments.add(
+          _plain(
+            value,
+            trailingStart,
+            value.length,
+            isOverflow:
+                overflowByteStart != null && cursorByte >= overflowByteStart,
+          ),
+        );
+      }
+    }
+
+    return segments;
+  }
+
+  TextSegment _plain(
+    final String value,
+    final int utf16Start,
+    final int utf16End, {
+    required final bool isOverflow,
+  }) => TextSegment(
+    text: value.substring(utf16Start, utf16End),
+    utf16Start: utf16Start,
+    utf16End: utf16End,
+    entity: null,
+    isOverflow: isOverflow,
+  );
+}

--- a/packages/bluesky_text/lib/src/segmenter.dart
+++ b/packages/bluesky_text/lib/src/segmenter.dart
@@ -70,6 +70,12 @@ List<TextSegment> buildTextSegments(
     final utf16Start = converter.convert(startByte);
     final utf16End = converter.convert(endByte);
 
+    //* A byte range at or beyond the end of [value] (possible with malformed
+    //* facets from a third-party PDS) converts to an empty UTF-16 range; drop
+    //* it rather than emit an empty segment that would break the "every
+    //* segment is non-empty" partition invariant.
+    if (utf16Start >= utf16End) return;
+
     segments.add(
       TextSegment(
         text: value.substring(utf16Start, utf16End),

--- a/packages/bluesky_text/lib/src/segmenter.dart
+++ b/packages/bluesky_text/lib/src/segmenter.dart
@@ -10,6 +10,128 @@ import 'unicode_string.dart';
 
 const segmenter = Segmenter();
 
+/// One styled range on the UTF-8 byte axis, carrying either a re-detected
+/// [entity] (compose path) or a server [feature] (display path). Consumed by
+/// [buildTextSegments], which fills the plain-text gaps between spans.
+class SegmentSpan {
+  const SegmentSpan({
+    required this.startByte,
+    required this.endByte,
+    this.entity,
+    this.feature,
+  });
+
+  final int startByte;
+  final int endByte;
+  final Entity? entity;
+  final FacetFeature? feature;
+}
+
+/// Partitions [value] into non-overlapping, gap-free [TextSegment]s from the
+/// styled [spans] (entity/facet ranges on the UTF-8 byte axis) and an optional
+/// [overflowByteStart].
+///
+/// Shared by the compose path ([Segmenter.execute], entities + overflow) and
+/// the display path (`renderFacets`, facets with `overflowByteStart == null`).
+/// The [spans] must be non-overlapping; they are sorted here so the byte→UTF-16
+/// converter stays monotonic. [overflowByteStart] is assumed never to fall
+/// strictly inside a span (entity boundaries are snapped; facets have no
+/// overflow), so it only ever splits a plain-text slice.
+List<TextSegment> buildTextSegments(
+  final String value,
+  final List<SegmentSpan> spans,
+  final int? overflowByteStart,
+) {
+  if (value.isEmpty) return const [];
+
+  final sorted = [...spans]..sort((a, b) => a.startByte.compareTo(b.startByte));
+
+  final converter = Utf16IndexConverter(value);
+  final segments = <TextSegment>[];
+
+  void addSlice(
+    final int startByte,
+    final int endByte,
+    final Entity? entity,
+    final FacetFeature? feature,
+  ) {
+    if (startByte >= endByte) return;
+
+    //* Split a slice that straddles the overflow boundary into a within-limit
+    //* part and an overflowing part.
+    if (overflowByteStart != null &&
+        startByte < overflowByteStart &&
+        overflowByteStart < endByte) {
+      addSlice(startByte, overflowByteStart, entity, feature);
+      addSlice(overflowByteStart, endByte, entity, feature);
+      return;
+    }
+
+    final utf16Start = converter.convert(startByte);
+    final utf16End = converter.convert(endByte);
+
+    segments.add(
+      TextSegment(
+        text: value.substring(utf16Start, utf16End),
+        utf16Start: utf16Start,
+        utf16End: utf16End,
+        entity: entity,
+        feature: feature,
+        isOverflow: overflowByteStart != null && startByte >= overflowByteStart,
+      ),
+    );
+  }
+
+  int cursorByte = 0;
+  for (final span in sorted) {
+    if (span.startByte > cursorByte) {
+      addSlice(cursorByte, span.startByte, null, null);
+    }
+
+    addSlice(span.startByte, span.endByte, span.entity, span.feature);
+    cursorByte = span.endByte;
+  }
+
+  //* Trailing plain text after the last span. Its UTF-16 end is simply the
+  //* value length, so the total byte length is never needed.
+  final trailingStart = converter.convert(cursorByte);
+  if (trailingStart < value.length) {
+    if (overflowByteStart != null && cursorByte < overflowByteStart) {
+      //* The boundary lies in the trailing text (it cannot be inside a span),
+      //* so break the tail into within-limit and overflow parts.
+      final boundary = converter.convert(overflowByteStart);
+      if (trailingStart < boundary) {
+        segments.add(_plain(value, trailingStart, boundary, isOverflow: false));
+      }
+      segments.add(_plain(value, boundary, value.length, isOverflow: true));
+    } else {
+      segments.add(
+        _plain(
+          value,
+          trailingStart,
+          value.length,
+          isOverflow:
+              overflowByteStart != null && cursorByte >= overflowByteStart,
+        ),
+      );
+    }
+  }
+
+  return segments;
+}
+
+TextSegment _plain(
+  final String value,
+  final int utf16Start,
+  final int utf16End, {
+  required final bool isOverflow,
+}) => TextSegment(
+  text: value.substring(utf16Start, utf16End),
+  utf16Start: utf16Start,
+  utf16End: utf16End,
+  isOverflow: isOverflow,
+);
+
 sealed class Segmenter {
   const factory Segmenter() = _Segmenter;
 
@@ -31,105 +153,12 @@ final class _Segmenter implements Segmenter {
     final String value,
     final List<Entity> entities,
     final TextLengthOverflow? overflow,
-  ) {
-    if (value.isEmpty) return const [];
-
-    //* Entities are non-overlapping (the extractor dedups) but not necessarily
-    //* sorted; order them so the partition is built left-to-right and the
-    //* byte→UTF-16 converter can stay monotonic.
-    final sorted = [...entities]
-      ..sort((a, b) => a.indices.start.compareTo(b.indices.start));
-
-    //* The overflow boundary in UTF-8 bytes, or null when within the limit.
-    //* Snapping guarantees it never falls strictly inside an entity, so it only
-    //* ever splits a plain-text slice.
-    final overflowByteStart = overflow?.byteStart;
-
-    final converter = Utf16IndexConverter(value);
-    final segments = <TextSegment>[];
-
-    void addSlice(
-      final int startByte,
-      final int endByte,
-      final Entity? entity,
-    ) {
-      if (startByte >= endByte) return;
-
-      //* Split a slice that straddles the overflow boundary into a within-limit
-      //* part and an overflowing part.
-      if (overflowByteStart != null &&
-          startByte < overflowByteStart &&
-          overflowByteStart < endByte) {
-        addSlice(startByte, overflowByteStart, entity);
-        addSlice(overflowByteStart, endByte, entity);
-        return;
-      }
-
-      final utf16Start = converter.convert(startByte);
-      final utf16End = converter.convert(endByte);
-
-      segments.add(
-        TextSegment(
-          text: value.substring(utf16Start, utf16End),
-          utf16Start: utf16Start,
-          utf16End: utf16End,
-          entity: entity,
-          isOverflow:
-              overflowByteStart != null && startByte >= overflowByteStart,
-        ),
-      );
-    }
-
-    int cursorByte = 0;
-    for (final entity in sorted) {
-      if (entity.indices.start > cursorByte) {
-        addSlice(cursorByte, entity.indices.start, null);
-      }
-
-      addSlice(entity.indices.start, entity.indices.end, entity);
-      cursorByte = entity.indices.end;
-    }
-
-    //* Trailing plain text after the last entity. Its UTF-16 end is simply the
-    //* value length, so the total byte length is never needed.
-    final trailingStart = converter.convert(cursorByte);
-    if (trailingStart < value.length) {
-      if (overflowByteStart != null && cursorByte < overflowByteStart) {
-        //* The boundary lies in the trailing text (it cannot be inside an
-        //* entity), so break the tail into within-limit and overflow parts.
-        final boundary = converter.convert(overflowByteStart);
-        if (trailingStart < boundary) {
-          segments.add(
-            _plain(value, trailingStart, boundary, isOverflow: false),
-          );
-        }
-        segments.add(_plain(value, boundary, value.length, isOverflow: true));
-      } else {
-        segments.add(
-          _plain(
-            value,
-            trailingStart,
-            value.length,
-            isOverflow:
-                overflowByteStart != null && cursorByte >= overflowByteStart,
-          ),
-        );
-      }
-    }
-
-    return segments;
-  }
-
-  TextSegment _plain(
-    final String value,
-    final int utf16Start,
-    final int utf16End, {
-    required final bool isOverflow,
-  }) => TextSegment(
-    text: value.substring(utf16Start, utf16End),
-    utf16Start: utf16Start,
-    utf16End: utf16End,
-    entity: null,
-    isOverflow: isOverflow,
-  );
+  ) => buildTextSegments(value, [
+    for (final entity in entities)
+      SegmentSpan(
+        startByte: entity.indices.start,
+        endByte: entity.indices.end,
+        entity: entity,
+      ),
+  ], overflow?.byteStart);
 }

--- a/packages/bluesky_text/lib/src/splitter.dart
+++ b/packages/bluesky_text/lib/src/splitter.dart
@@ -9,6 +9,7 @@ import 'package:characters/characters.dart';
 import 'bluesky_text.dart';
 import 'config/link_config.dart';
 import 'const.dart';
+import 'extractor/markdown_extractor.dart';
 import 'unicode_string.dart';
 
 const splitter = Splitter();
@@ -23,6 +24,21 @@ sealed class Splitter {
   });
 }
 
+/// One token of the source text: either a whitespace run or a word. A word may
+/// be `atomic` (a markdown link, which must never be broken across chunks even
+/// though its label contains spaces).
+class _Token {
+  _Token(this.text, {required this.isSpace, this.atomic = false})
+    : graphemes = text.characters.length,
+      bytes = utf8ByteLength(text);
+
+  final String text;
+  final bool isSpace;
+  final bool atomic;
+  final int graphemes;
+  final int bytes;
+}
+
 final class _Splitter implements Splitter {
   const _Splitter();
 
@@ -35,74 +51,103 @@ final class _Splitter implements Splitter {
     if (text.isEmpty) return [text];
     if (text.isNotLengthLimitExceeded) return [text];
 
+    final source = text.value;
+    final tokens = _tokenize(
+      source,
+      enableMarkdown ? _atomicRanges(text) : const [],
+    );
+
     final chunks = <BlueskyText>[];
     final buffer = StringBuffer();
+    int bufferGraphemes = 0; //* graphemes in [buffer]
+    int bufferBytes = 0; //* UTF-8 bytes in [buffer]
 
-    //* Each chunk is budgeted against BOTH post limits: [maxLength] graphemes
-    //* and [maxByteLength] UTF-8 bytes. Tracking only graphemes (as before) let
-    //* a byte-heavy chunk — e.g. many multi-byte ZWJ emoji — stay under 300
-    //* graphemes yet exceed 3000 bytes, so the produced chunk was still
-    //* rejected by the server.
-    int bufferLength = 0; //* graphemes
-    int bufferBytes = 0; //* UTF-8 bytes
+    //* Whitespace that follows the last word, held back until the next word so
+    //* it is written *between* words (preserving the author's newlines / spaces)
+    //* but dropped at a chunk break — no chunk starts or ends with whitespace.
+    String pendingSpace = '';
+    int pendingSpaceGraphemes = 0;
+    int pendingSpaceBytes = 0;
 
     //* Propagate the markdown / link configuration to each produced chunk so a
     //* split preserves the same rendering behavior as the source text. The
     //* position-bound `replacements` are intentionally not carried over: they
-    //* only make sense relative to the original, unsplit text.
+    //* only make sense relative to the original, unsplit text (and `split` is
+    //* already fed the original text, not a formatted value).
     BlueskyText create(final String value) => BlueskyText(
       value,
       enableMarkdown: enableMarkdown,
       linkConfig: linkConfig,
     );
 
+    void clearPending() {
+      pendingSpace = '';
+      pendingSpaceGraphemes = 0;
+      pendingSpaceBytes = 0;
+    }
+
     void flush() {
       if (buffer.isEmpty) return;
       chunks.add(create(buffer.toString()));
       buffer.clear();
-      bufferLength = 0;
+      bufferGraphemes = 0;
       bufferBytes = 0;
+      clearPending();
     }
 
-    void appendToBuffer(final String value, final int length, final int bytes) {
-      //* The `+ 1` accounts for the joining space (one grapheme, one byte) that
-      //* is written before [value] when the buffer is non-empty.
-      if (bufferLength > 0 &&
-          (bufferLength + length + 1 > maxLength ||
-              bufferBytes + bytes + 1 > maxByteLength)) {
+    void appendWord(final String value, final int graphemes, final int bytes) {
+      //* Flush first if this word (plus the pending separator) would overflow
+      //* either budget, so the word moves to a fresh chunk intact.
+      if (bufferGraphemes > 0 &&
+          (bufferGraphemes + pendingSpaceGraphemes + graphemes > maxLength ||
+              bufferBytes + pendingSpaceBytes + bytes > maxByteLength)) {
         flush();
       }
 
-      if (buffer.isNotEmpty) {
-        buffer.write(' ');
-        bufferLength += 1;
-        bufferBytes += 1;
+      if (buffer.isNotEmpty && pendingSpace.isNotEmpty) {
+        buffer.write(pendingSpace);
+        bufferGraphemes += pendingSpaceGraphemes;
+        bufferBytes += pendingSpaceBytes;
       }
+      clearPending();
 
       buffer.write(value);
-      bufferLength += length;
+      bufferGraphemes += graphemes;
       bufferBytes += bytes;
     }
 
-    for (final word in text.value.split(' ')) {
-      final graphemes = word.characters.toList();
-      final wordLength = graphemes.length;
-      final wordBytes = utf8ByteLength(word);
+    for (final token in tokens) {
+      if (token.isSpace) {
+        //* Accumulate as the pending separator (runs never repeat, but be safe).
+        pendingSpace += token.text;
+        pendingSpaceGraphemes += token.graphemes;
+        pendingSpaceBytes += token.bytes;
+        continue;
+      }
 
-      if (wordLength > maxLength || wordBytes > maxByteLength) {
-        //* Hard-split a single word that alone blows either budget, flushing
-        //* whatever is buffered first so the oversized pieces stand on their
-        //* own. Each piece is the largest prefix fitting both budgets.
+      final fitsChunk =
+          token.graphemes <= maxLength && token.bytes <= maxByteLength;
+
+      if (fitsChunk) {
+        appendWord(token.text, token.graphemes, token.bytes);
+      } else if (token.atomic) {
+        //* An atomic word (markdown link) larger than a whole chunk cannot be
+        //* broken, so it stands alone — it will be over-limit and the caller
+        //* detects that via `isLengthLimitExceeded`.
+        flush();
+        chunks.add(create(token.text));
+      } else {
+        //* Hard-split an over-long plain word into the largest prefixes fitting
+        //* both budgets; the trailing remainder rejoins the following words.
+        final graphemes = token.text.characters.toList();
         int offset = 0;
         int consumedBytes = 0;
         while (offset < graphemes.length) {
           final remaining = graphemes.length - offset;
-          final remainingBytes = wordBytes - consumedBytes;
+          final remainingBytes = token.bytes - consumedBytes;
 
           if (remaining <= maxLength && remainingBytes <= maxByteLength) {
-            //* The trailing remainder fits, so accumulate it with the following
-            //* words instead of forcing its own chunk.
-            appendToBuffer(
+            appendWord(
               graphemes.skip(offset).join(),
               remaining,
               remainingBytes,
@@ -116,8 +161,6 @@ final class _Splitter implements Splitter {
           offset += take;
           consumedBytes += takeBytes;
         }
-      } else {
-        appendToBuffer(word, wordLength, wordBytes);
       }
     }
 
@@ -125,6 +168,85 @@ final class _Splitter implements Splitter {
 
     return chunks;
   }
+
+  /// Markdown-link ranges as sorted `[startUtf16, endUtf16)` code-unit spans,
+  /// so the tokenizer keeps each link whole (its label contains spaces).
+  List<List<int>> _atomicRanges(final BlueskyText text) {
+    final links = markdownLinksExtractor.execute(text);
+    if (links.isEmpty) return const [];
+
+    final converter = Utf16IndexConverter(text.value);
+
+    return [
+      for (final link in links)
+        [
+          converter.convert(link.indices.start),
+          converter.convert(link.indices.end),
+        ],
+    ]..sort((a, b) => a[0].compareTo(b[0]));
+  }
+
+  /// Splits [source] into whitespace and word tokens, treating each range in
+  /// [atomic] as a single indivisible word. Breaks on any Unicode whitespace
+  /// (spaces, tabs, newlines and the ideographic space `U+3000`), not just the
+  /// ASCII space — so multi-line and CJK text is never torn mid-word.
+  List<_Token> _tokenize(final String source, final List<List<int>> atomic) {
+    final tokens = <_Token>[];
+    final length = source.length;
+    int i = 0;
+    int nextAtomic = 0;
+
+    while (i < length) {
+      if (nextAtomic < atomic.length && i == atomic[nextAtomic][0]) {
+        final end = atomic[nextAtomic][1];
+        tokens.add(
+          _Token(source.substring(i, end), isSpace: false, atomic: true),
+        );
+        i = end;
+        nextAtomic++;
+        continue;
+      }
+
+      if (_isWhitespace(source.codeUnitAt(i))) {
+        int end = i + 1;
+        while (end < length && _isWhitespace(source.codeUnitAt(end))) {
+          //* Never let a whitespace run swallow the start of an atomic range.
+          if (nextAtomic < atomic.length && end == atomic[nextAtomic][0]) break;
+          end++;
+        }
+        tokens.add(_Token(source.substring(i, end), isSpace: true));
+        i = end;
+        continue;
+      }
+
+      int end = i + 1;
+      while (end < length &&
+          !_isWhitespace(source.codeUnitAt(end)) &&
+          !(nextAtomic < atomic.length && end == atomic[nextAtomic][0])) {
+        end++;
+      }
+      tokens.add(_Token(source.substring(i, end), isSpace: false));
+      i = end;
+    }
+
+    return tokens;
+  }
+
+  /// Whether [codeUnit] is Unicode whitespace, matching Dart's `\s`. All
+  /// whitespace code points are in the BMP, so a code-unit test is exact.
+  bool _isWhitespace(final int codeUnit) =>
+      codeUnit == 0x20 || //* space
+      (codeUnit >= 0x09 && codeUnit <= 0x0D) || //* tab, LF, VT, FF, CR
+      codeUnit == 0x85 || //* next line
+      codeUnit == 0xA0 || //* no-break space
+      codeUnit == 0x1680 ||
+      (codeUnit >= 0x2000 && codeUnit <= 0x200A) ||
+      codeUnit == 0x2028 ||
+      codeUnit == 0x2029 ||
+      codeUnit == 0x202F ||
+      codeUnit == 0x205F ||
+      codeUnit == 0x3000 || //* ideographic (full-width) space
+      codeUnit == 0xFEFF;
 
   /// Returns `(graphemeCount, byteLength)` of the largest prefix of [graphemes]
   /// starting at [offset] that fits within both a single chunk's grapheme

--- a/packages/bluesky_text/lib/src/splitter.dart
+++ b/packages/bluesky_text/lib/src/splitter.dart
@@ -9,6 +9,7 @@ import 'package:characters/characters.dart';
 import 'bluesky_text.dart';
 import 'config/link_config.dart';
 import 'const.dart';
+import 'unicode_string.dart';
 
 const splitter = Splitter();
 
@@ -37,11 +38,13 @@ final class _Splitter implements Splitter {
     final chunks = <BlueskyText>[];
     final buffer = StringBuffer();
 
-    //* The running length of [buffer] is tracked in graphemes (not UTF-16 code
-    //* units) so the budget matches [maxLength], which is a grapheme count.
-    //* Mixing UTF-16 length with grapheme counts previously under-filled every
-    //* chunk that contained emoji or other non-BMP characters.
-    int bufferLength = 0;
+    //* Each chunk is budgeted against BOTH post limits: [maxLength] graphemes
+    //* and [maxByteLength] UTF-8 bytes. Tracking only graphemes (as before) let
+    //* a byte-heavy chunk — e.g. many multi-byte ZWJ emoji — stay under 300
+    //* graphemes yet exceed 3000 bytes, so the produced chunk was still
+    //* rejected by the server.
+    int bufferLength = 0; //* graphemes
+    int bufferBytes = 0; //* UTF-8 bytes
 
     //* Propagate the markdown / link configuration to each produced chunk so a
     //* split preserves the same rendering behavior as the source text. The
@@ -58,52 +61,88 @@ final class _Splitter implements Splitter {
       chunks.add(create(buffer.toString()));
       buffer.clear();
       bufferLength = 0;
+      bufferBytes = 0;
     }
 
-    void appendToBuffer(final String value, final int length) {
-      if (bufferLength > 0 && bufferLength + length + 1 > maxLength) {
+    void appendToBuffer(final String value, final int length, final int bytes) {
+      //* The `+ 1` accounts for the joining space (one grapheme, one byte) that
+      //* is written before [value] when the buffer is non-empty.
+      if (bufferLength > 0 &&
+          (bufferLength + length + 1 > maxLength ||
+              bufferBytes + bytes + 1 > maxByteLength)) {
         flush();
       }
 
       if (buffer.isNotEmpty) {
         buffer.write(' ');
         bufferLength += 1;
+        bufferBytes += 1;
       }
 
       buffer.write(value);
       bufferLength += length;
+      bufferBytes += bytes;
     }
 
     for (final word in text.value.split(' ')) {
-      final characters = word.characters;
-      final wordLength = characters.length;
+      final graphemes = word.characters.toList();
+      final wordLength = graphemes.length;
+      final wordBytes = utf8ByteLength(word);
 
-      if (wordLength > maxLength) {
-        //* Hard-split a single word that is longer than the limit into
-        //* [maxLength]-grapheme chunks, flushing whatever is buffered first so
-        //* the oversized segments stand on their own.
+      if (wordLength > maxLength || wordBytes > maxByteLength) {
+        //* Hard-split a single word that alone blows either budget, flushing
+        //* whatever is buffered first so the oversized pieces stand on their
+        //* own. Each piece is the largest prefix fitting both budgets.
         int offset = 0;
-        while (characters.length - offset > maxLength) {
-          flush();
-          chunks.add(
-            create(characters.skip(offset).take(maxLength).toString()),
-          );
-          offset += maxLength;
-        }
+        int consumedBytes = 0;
+        while (offset < graphemes.length) {
+          final remaining = graphemes.length - offset;
+          final remainingBytes = wordBytes - consumedBytes;
 
-        //* The trailing remainder continues to accumulate with the following
-        //* words instead of forcing its own chunk.
-        appendToBuffer(
-          characters.skip(offset).toString(),
-          characters.length - offset,
-        );
+          if (remaining <= maxLength && remainingBytes <= maxByteLength) {
+            //* The trailing remainder fits, so accumulate it with the following
+            //* words instead of forcing its own chunk.
+            appendToBuffer(
+              graphemes.skip(offset).join(),
+              remaining,
+              remainingBytes,
+            );
+            break;
+          }
+
+          final (take, takeBytes) = _fit(graphemes, offset);
+          flush();
+          chunks.add(create(graphemes.skip(offset).take(take).join()));
+          offset += take;
+          consumedBytes += takeBytes;
+        }
       } else {
-        appendToBuffer(word, wordLength);
+        appendToBuffer(word, wordLength, wordBytes);
       }
     }
 
     flush();
 
     return chunks;
+  }
+
+  /// Returns `(graphemeCount, byteLength)` of the largest prefix of [graphemes]
+  /// starting at [offset] that fits within both a single chunk's grapheme
+  /// ([maxLength]) and byte ([maxByteLength]) budgets. Always takes at least the
+  /// first grapheme — even one that alone exceeds the byte budget (which cannot
+  /// be posted anyway) — so the split always makes progress.
+  (int, int) _fit(final List<String> graphemes, final int offset) {
+    int count = 0;
+    int bytes = 0;
+
+    for (int i = offset; i < graphemes.length && count < maxLength; i++) {
+      final graphemeBytes = utf8ByteLength(graphemes[i]);
+      if (count > 0 && bytes + graphemeBytes > maxByteLength) break;
+
+      bytes += graphemeBytes;
+      count++;
+    }
+
+    return (count, bytes);
   }
 }

--- a/packages/bluesky_text/lib/src/text_length_overflow.dart
+++ b/packages/bluesky_text/lib/src/text_length_overflow.dart
@@ -1,0 +1,97 @@
+// Copyright (c) 2023-2025, Shinya Kato.
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// The kind of post-length limit that a text first exceeds.
+///
+/// The `app.bsky.feed.post` lexicon caps the text at both 300 graphemes and
+/// 3000 UTF-8 bytes, so a text can trip either limit first depending on its
+/// content (e.g. 300 multi-byte ZWJ emoji exceed the byte limit while still
+/// within the grapheme limit).
+enum LengthLimit {
+  /// The 300-grapheme limit was reached first.
+  grapheme,
+
+  /// The 3000 UTF-8 byte limit was reached first.
+  byte,
+}
+
+/// Describes the range of a [BlueskyText] value that exceeds the post-length
+/// limit, so a UI can render the overflowing tail differently (for example in
+/// red).
+///
+/// The overflow always spans from a boundary offset to the end of the value.
+/// The boundary is reported in three coordinate systems because each consumer
+/// needs a different one:
+///
+/// - [utf16Start] / [utf16End] are UTF-16 code-unit offsets, directly usable
+///   with `String.substring` and Flutter's `TextSpan` / `RichText`.
+/// - [byteStart] / [byteEnd] are UTF-8 byte offsets, on the same axis as
+///   `Entity.indices` ([ByteIndices]) and Bluesky facet `byteSlice`s.
+/// - [graphemeStart] is a grapheme index, matching how `BlueskyText.length`
+///   and the 300-character limit are counted.
+///
+/// The boundary always lands on a grapheme cluster boundary, so an emoji or
+/// other multi-code-unit character is never split in half.
+class TextLengthOverflow {
+  const TextLengthOverflow({
+    required this.limit,
+    required this.graphemeStart,
+    required this.utf16Start,
+    required this.byteStart,
+    required this.utf16End,
+    required this.byteEnd,
+  });
+
+  /// Which limit ([LengthLimit.grapheme] or [LengthLimit.byte]) caused the
+  /// overflow. When both limits are exceeded, this is the one reached first.
+  final LengthLimit limit;
+
+  /// The grapheme index (0-based) at which the overflow begins.
+  final int graphemeStart;
+
+  /// The UTF-16 code-unit offset at which the overflow begins.
+  ///
+  /// `value.substring(0, utf16Start)` is within the limit and
+  /// `value.substring(utf16Start)` is the overflowing tail.
+  final int utf16Start;
+
+  /// The UTF-8 byte offset at which the overflow begins, on the same axis as
+  /// `Entity.indices`.
+  final int byteStart;
+
+  /// The UTF-16 code-unit length of the whole value (the end of the overflow).
+  final int utf16End;
+
+  /// The UTF-8 byte length of the whole value (the end of the overflow).
+  final int byteEnd;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+
+    return other is TextLengthOverflow &&
+        other.limit == limit &&
+        other.graphemeStart == graphemeStart &&
+        other.utf16Start == utf16Start &&
+        other.byteStart == byteStart &&
+        other.utf16End == utf16End &&
+        other.byteEnd == byteEnd;
+  }
+
+  @override
+  int get hashCode => Object.hash(
+    limit,
+    graphemeStart,
+    utf16Start,
+    byteStart,
+    utf16End,
+    byteEnd,
+  );
+
+  @override
+  String toString() =>
+      'TextLengthOverflow(limit: $limit, graphemeStart: $graphemeStart, '
+      'utf16Start: $utf16Start, byteStart: $byteStart, '
+      'utf16End: $utf16End, byteEnd: $byteEnd)';
+}

--- a/packages/bluesky_text/lib/src/text_segment.dart
+++ b/packages/bluesky_text/lib/src/text_segment.dart
@@ -1,0 +1,98 @@
+// Copyright (c) 2023-2025, Shinya Kato.
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// Project imports:
+import 'entities/entity.dart';
+
+/// A contiguous slice of a [BlueskyText] value, tagged with how it should be
+/// rendered.
+///
+/// The full list returned by `BlueskyText.segments` partitions the value into
+/// non-overlapping, gap-free slices in document order, so concatenating every
+/// [text] reproduces the original value. Each slice carries enough information
+/// to pick a style — whether it is part of an entity ([entity] / [isEntity])
+/// and whether it lies in the over-limit region ([isOverflow]) — which makes it
+/// a natural input for a Flutter `TextSpan` tree:
+///
+/// ```dart
+/// TextSpan buildSpan(BlueskyText text) => TextSpan(
+///   children: [
+///     for (final s in text.segments)
+///       TextSpan(
+///         text: s.text,
+///         style: TextStyle(
+///           color: s.isOverflow
+///               ? Colors.red
+///               : s.isEntity
+///                   ? Colors.blue
+///                   : null,
+///         ),
+///       ),
+///   ],
+/// );
+/// ```
+///
+/// The offsets are UTF-16 code units, directly usable with `String.substring`
+/// and Flutter. A segment is never split across an entity boundary, and because
+/// an entity that straddled the overflow boundary is snapped wholly into the
+/// overflow, [isEntity] and [isOverflow] are always consistent for a slice.
+class TextSegment {
+  const TextSegment({
+    required this.text,
+    required this.utf16Start,
+    required this.utf16End,
+    required this.entity,
+    required this.isOverflow,
+  });
+
+  /// The substring of the value this segment covers,
+  /// `value.substring(utf16Start, utf16End)`.
+  final String text;
+
+  /// The UTF-16 code-unit offset where this segment starts (inclusive).
+  final int utf16Start;
+
+  /// The UTF-16 code-unit offset where this segment ends (exclusive).
+  final int utf16End;
+
+  /// The entity this segment belongs to, or `null` when it is plain text.
+  final Entity? entity;
+
+  /// Whether this segment lies in the region that exceeds the post-length
+  /// limit (see `BlueskyText.overflow`).
+  final bool isOverflow;
+
+  /// Whether this segment is part of an entity ([entity] is non-null).
+  bool get isEntity => entity != null;
+
+  /// The type of the [entity] this segment belongs to, or `null` for plain
+  /// text.
+  EntityType? get type => entity?.type;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+
+    //* Equality is by value, using the entity [type] rather than the [entity]
+    //* instance: [Entity] has identity equality, so two independent `segments`
+    //* calls produce distinct entity objects for the same span. Keying on
+    //* [type] (plus the offsets and text, which already pin down the exact
+    //* entity) keeps equal renders equal across rebuilds, so a Flutter widget
+    //* can memoize spans without every rebuild looking different.
+    return other is TextSegment &&
+        other.text == text &&
+        other.utf16Start == utf16Start &&
+        other.utf16End == utf16End &&
+        other.type == type &&
+        other.isOverflow == isOverflow;
+  }
+
+  @override
+  int get hashCode => Object.hash(text, utf16Start, utf16End, type, isOverflow);
+
+  @override
+  String toString() =>
+      'TextSegment(text: $text, utf16Start: $utf16Start, '
+      'utf16End: $utf16End, type: $type, isOverflow: $isOverflow)';
+}

--- a/packages/bluesky_text/lib/src/text_segment.dart
+++ b/packages/bluesky_text/lib/src/text_segment.dart
@@ -5,26 +5,64 @@
 // Project imports:
 import 'entities/entity.dart';
 
-/// A contiguous slice of a [BlueskyText] value, tagged with how it should be
-/// rendered.
+/// The actionable payload of a rendered rich-text slice that came from a
+/// server-provided facet (see `renderFacets`).
 ///
-/// The full list returned by `BlueskyText.segments` partitions the value into
-/// non-overlapping, gap-free slices in document order, so concatenating every
-/// [text] reproduces the original value. Each slice carries enough information
-/// to pick a style — whether it is part of an entity ([entity] / [isEntity])
-/// and whether it lies in the over-limit region ([isOverflow]) — which makes it
-/// a natural input for a Flutter `TextSpan` tree:
+/// Unlike an [Entity], which is re-detected from raw text and positioned by
+/// byte range, a [FacetFeature] carries the *resolved* target the client needs
+/// to make the slice interactive — a mention's DID, a link's URI, or a tag —
+/// exactly as the author's post committed it.
+class FacetFeature {
+  const FacetFeature({required this.type, required this.value});
+
+  /// The kind of feature. Mentions use [EntityType.handle], links use
+  /// [EntityType.link] and tags use [EntityType.tag]; the facet lexicon has no
+  /// dedicated cashtag feature, so cashtags arrive as [EntityType.tag].
+  final EntityType type;
+
+  /// The resolved target: a DID for a mention, a URI for a link, or the tag
+  /// value for a tag.
+  final String value;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is FacetFeature && other.type == type && other.value == value;
+
+  @override
+  int get hashCode => Object.hash(type, value);
+
+  @override
+  String toString() => 'FacetFeature(type: $type, value: $value)';
+}
+
+/// A contiguous slice of a [BlueskyText] value (or of a rendered post), tagged
+/// with how it should be styled.
+///
+/// The full list returned by `BlueskyText.segments` (compose) or `renderFacets`
+/// (display) partitions the text into non-overlapping, gap-free slices in
+/// document order, so concatenating every [text] reproduces the original. Each
+/// slice carries enough information to pick a style:
+///
+/// - [entity] — set when the slice came from re-detecting entities in text
+///   (the compose path); `null` otherwise.
+/// - [feature] — set when the slice came from a server-provided facet (the
+///   display path); carries the resolved DID / URI / tag; `null` otherwise.
+/// - [type] — the [EntityType] regardless of which of the two produced it, so
+///   one `TextSpan` builder styles both paths.
+/// - [isOverflow] — whether the slice lies past the post-length limit (only
+///   meaningful for the compose path; always `false` for [renderFacets]).
 ///
 /// ```dart
-/// TextSpan buildSpan(BlueskyText text) => TextSpan(
+/// TextSpan buildSpan(Iterable<TextSegment> segments) => TextSpan(
 ///   children: [
-///     for (final s in text.segments)
+///     for (final s in segments)
 ///       TextSpan(
 ///         text: s.text,
 ///         style: TextStyle(
 ///           color: s.isOverflow
 ///               ? Colors.red
-///               : s.isEntity
+///               : s.type != null
 ///                   ? Colors.blue
 ///                   : null,
 ///         ),
@@ -34,16 +72,15 @@ import 'entities/entity.dart';
 /// ```
 ///
 /// The offsets are UTF-16 code units, directly usable with `String.substring`
-/// and Flutter. A segment is never split across an entity boundary, and because
-/// an entity that straddled the overflow boundary is snapped wholly into the
-/// overflow, [isEntity] and [isOverflow] are always consistent for a slice.
+/// and Flutter. A slice is never split across an entity/facet boundary.
 class TextSegment {
   const TextSegment({
     required this.text,
     required this.utf16Start,
     required this.utf16End,
-    required this.entity,
-    required this.isOverflow,
+    this.entity,
+    this.feature,
+    this.isOverflow = false,
   });
 
   /// The substring of the value this segment covers,
@@ -56,30 +93,38 @@ class TextSegment {
   /// The UTF-16 code-unit offset where this segment ends (exclusive).
   final int utf16End;
 
-  /// The entity this segment belongs to, or `null` when it is plain text.
+  /// The re-detected entity this segment belongs to (compose path), or `null`.
   final Entity? entity;
 
+  /// The server facet feature this segment belongs to (display path), or
+  /// `null`. Carries the resolved DID / URI / tag.
+  final FacetFeature? feature;
+
   /// Whether this segment lies in the region that exceeds the post-length
-  /// limit (see `BlueskyText.overflow`).
+  /// limit (see `BlueskyText.overflow`). Always `false` for `renderFacets`.
   final bool isOverflow;
 
-  /// Whether this segment is part of an entity ([entity] is non-null).
+  /// Whether this segment is part of a re-detected [entity] (compose path).
   bool get isEntity => entity != null;
 
-  /// The type of the [entity] this segment belongs to, or `null` for plain
-  /// text.
-  EntityType? get type => entity?.type;
+  /// Whether this segment is part of a server [feature] (display path).
+  bool get isFeature => feature != null;
+
+  /// The entity type this segment carries, from either the [entity] (compose)
+  /// or the [feature] (display), or `null` for plain text. Use `type != null`
+  /// as the "should be styled" predicate for either path.
+  EntityType? get type => entity?.type ?? feature?.type;
 
   @override
   bool operator ==(Object other) {
     if (identical(this, other)) return true;
 
-    //* Equality is by value, using the entity [type] rather than the [entity]
-    //* instance: [Entity] has identity equality, so two independent `segments`
-    //* calls produce distinct entity objects for the same span. Keying on
-    //* [type] (plus the offsets and text, which already pin down the exact
-    //* entity) keeps equal renders equal across rebuilds, so a Flutter widget
-    //* can memoize spans without every rebuild looking different.
+    //* Equality is by value, keyed on [type] rather than the [entity] instance:
+    //* [Entity] has identity equality, so two independent `segments` calls
+    //* produce distinct entity objects for the same span. Keying on [type]
+    //* (plus the offsets and text, which already pin down the exact slice) keeps
+    //* equal renders equal across rebuilds, so a Flutter widget can memoize
+    //* spans without every rebuild looking different.
     return other is TextSegment &&
         other.text == text &&
         other.utf16Start == utf16Start &&

--- a/packages/bluesky_text/lib/src/unicode_string.dart
+++ b/packages/bluesky_text/lib/src/unicode_string.dart
@@ -53,6 +53,41 @@ extension UnicodeString on String {
   }
 }
 
+/// Returns the UTF-8 byte length of [value] without allocating an intermediate
+/// byte list.
+///
+/// Behaviorally identical to `utf8.encode(value).length` (unpaired surrogates
+/// count as 3 bytes, matching Dart's encoder), but counts widths directly over
+/// the code units. Used on the per-keystroke hot path where re-encoding each
+/// grapheme cluster to a `Uint8List` just to read its length is pure garbage.
+int utf8ByteLength(final String value) {
+  int bytes = 0;
+
+  for (int j = 0; j < value.length; j++) {
+    final unit = value.codeUnitAt(j);
+
+    if (unit < 0x80) {
+      bytes += 1;
+    } else if (unit < 0x800) {
+      bytes += 2;
+    } else if (unit >= 0xD800 && unit <= 0xDBFF && j + 1 < value.length) {
+      final next = value.codeUnitAt(j + 1);
+      if (next >= 0xDC00 && next <= 0xDFFF) {
+        bytes += 4;
+        j += 1;
+      } else {
+        //* Unpaired high surrogate.
+        bytes += 3;
+      }
+    } else {
+      //* Any other BMP code unit (including an unpaired low surrogate).
+      bytes += 3;
+    }
+  }
+
+  return bytes;
+}
+
 /// A forward-only converter from UTF-16 code-unit indices to UTF-8 byte
 /// offsets over a fixed [String].
 ///
@@ -137,5 +172,71 @@ class Utf8IndexConverter {
     _bytes = bytes;
 
     return bytes;
+  }
+}
+
+/// A forward-only converter from UTF-8 byte offsets back to UTF-16 code-unit
+/// indices over a fixed [String] — the inverse of [Utf8IndexConverter].
+///
+/// Entity `ByteIndices` and `TextLengthOverflow.byteStart` live on the UTF-8
+/// byte axis, but Flutter's `TextSpan` / `String.substring` work on UTF-16 code
+/// units. When building a segment partition the requested byte offsets are
+/// monotonically non-decreasing (segment boundaries are emitted left-to-right),
+/// so this converter keeps a running cursor and only walks the code units
+/// *between* successive requests — an `O(n)` pass over the whole string.
+///
+/// Every requested [byteOffset] is expected to fall on a character boundary (all
+/// entity and overflow boundaries do); the walk stops at the first code-unit
+/// boundary whose byte total reaches it. An out-of-order (smaller) request
+/// transparently falls back to a fresh scan from the start.
+class Utf16IndexConverter {
+  Utf16IndexConverter(this._value);
+
+  final String _value;
+
+  int _codeUnit = 0;
+  int _bytes = 0;
+
+  /// Returns the UTF-16 code-unit index whose UTF-8 prefix length is
+  /// [byteOffset].
+  int convert(final int byteOffset) {
+    if (byteOffset <= _bytes) {
+      return byteOffset == _bytes ? _codeUnit : _scan(byteOffset, 0, 0);
+    }
+
+    return _scan(byteOffset, _codeUnit, _bytes);
+  }
+
+  int _scan(final int byteOffset, int j, int bytes) {
+    while (bytes < byteOffset && j < _value.length) {
+      final unit = _value.codeUnitAt(j);
+
+      if (unit < 0x80) {
+        bytes += 1;
+        j += 1;
+      } else if (unit < 0x800) {
+        bytes += 2;
+        j += 1;
+      } else if (unit >= 0xD800 && unit <= 0xDBFF && j + 1 < _value.length) {
+        final next = _value.codeUnitAt(j + 1);
+        if (next >= 0xDC00 && next <= 0xDFFF) {
+          bytes += 4;
+          j += 2;
+        } else {
+          //* Unpaired high surrogate.
+          bytes += 3;
+          j += 1;
+        }
+      } else {
+        //* Any other BMP code unit (including an unpaired low surrogate).
+        bytes += 3;
+        j += 1;
+      }
+    }
+
+    _codeUnit = j;
+    _bytes = bytes;
+
+    return j;
   }
 }

--- a/packages/bluesky_text/lib/src/utils.dart
+++ b/packages/bluesky_text/lib/src/utils.dart
@@ -8,6 +8,8 @@ import 'package:characters/characters.dart';
 // Project imports:
 import 'const.dart';
 import 'regex/emoji.dart';
+import 'text_length_overflow.dart';
+import 'unicode_string.dart';
 
 /// Matches an explicit `http://` or `https://` scheme at the start of a string,
 /// case-insensitively.
@@ -42,3 +44,125 @@ bool isEmojiOnly(final String value) {
 
 /// Returns the grapheme length of [value].
 int getGraphemeLength(final String value) => value.characters.length;
+
+/// Scans [value] once by grapheme cluster and returns the boundary at which it
+/// first exceeds either post-length limit — more than [maxLength] graphemes or
+/// more than [maxByteLength] UTF-8 bytes — or `null` when [value] is within
+/// both limits.
+///
+/// When both limits are exceeded the earlier boundary (the smaller UTF-16
+/// offset) wins, since the text must stop at whichever comes first to satisfy
+/// both. The returned boundary always sits on a grapheme cluster boundary, so a
+/// multi-code-unit character is never split.
+///
+/// This is the raw, content-only boundary. Snapping the boundary to an entity
+/// edge (so a link or mention that straddles it is treated atomically) is layered
+/// on top by `BlueskyText.overflow`.
+TextLengthOverflow? computeLengthOverflow(final String value) {
+  //* Running totals at the current grapheme boundary; `[0, cursor)` has been
+  //* consumed. All three axes advance together so every recorded boundary is
+  //* internally consistent.
+  int grapheme = 0;
+  int utf16 = 0;
+  int bytes = 0;
+
+  //* Snapshot of the boundary right after [maxLength] graphemes, set only if a
+  //* further grapheme exists (i.e. the grapheme limit is actually exceeded).
+  int? graphemeLimitUtf16;
+  int? graphemeLimitByte;
+
+  //* Snapshot of the last boundary whose prefix still fits in [maxByteLength],
+  //* set when the next grapheme would push the byte total over the limit.
+  int? byteLimitUtf16;
+  int? byteLimitGrapheme;
+  int? byteLimitByte;
+
+  for (final character in value.characters) {
+    final characterBytes = utf8ByteLength(character);
+
+    if (byteLimitUtf16 == null && bytes + characterBytes > maxByteLength) {
+      byteLimitUtf16 = utf16;
+      byteLimitGrapheme = grapheme;
+      byteLimitByte = bytes;
+    }
+
+    if (graphemeLimitUtf16 == null && grapheme == maxLength) {
+      graphemeLimitUtf16 = utf16;
+      graphemeLimitByte = bytes;
+    }
+
+    grapheme += 1;
+    utf16 += character.length;
+    bytes += characterBytes;
+  }
+
+  if (graphemeLimitUtf16 == null && byteLimitUtf16 == null) return null;
+
+  //* Pick the earlier boundary. When only one limit is exceeded, use it; when
+  //* both are, the smaller UTF-16 offset is the binding one (ties resolve to the
+  //* grapheme limit, the primary "300 characters" concept).
+  final bool useGrapheme;
+  if (graphemeLimitUtf16 == null) {
+    useGrapheme = false;
+  } else if (byteLimitUtf16 == null) {
+    useGrapheme = true;
+  } else {
+    useGrapheme = graphemeLimitUtf16 <= byteLimitUtf16;
+  }
+
+  if (useGrapheme) {
+    return TextLengthOverflow(
+      limit: LengthLimit.grapheme,
+      graphemeStart: maxLength,
+      utf16Start: graphemeLimitUtf16!,
+      byteStart: graphemeLimitByte!,
+      utf16End: utf16,
+      byteEnd: bytes,
+    );
+  }
+
+  return TextLengthOverflow(
+    limit: LengthLimit.byte,
+    graphemeStart: byteLimitGrapheme!,
+    utf16Start: byteLimitUtf16!,
+    byteStart: byteLimitByte!,
+    utf16End: utf16,
+    byteEnd: bytes,
+  );
+}
+
+/// Rebuilds a [TextLengthOverflow] whose boundary has been snapped back to the
+/// UTF-8 [byteStart] of a straddled entity, recomputing the UTF-16 and grapheme
+/// offsets for that boundary while keeping the original [limit] label and the
+/// value's [utf16End] / [byteEnd].
+///
+/// [byteStart] is expected to fall on a grapheme boundary (all entity starts
+/// do); the scan stops at the first boundary whose byte total reaches it.
+TextLengthOverflow snapLengthOverflowToByte(
+  final String value, {
+  required final int byteStart,
+  required final LengthLimit limit,
+  required final int utf16End,
+  required final int byteEnd,
+}) {
+  int grapheme = 0;
+  int utf16 = 0;
+  int bytes = 0;
+
+  for (final character in value.characters) {
+    if (bytes >= byteStart) break;
+
+    grapheme += 1;
+    utf16 += character.length;
+    bytes += utf8ByteLength(character);
+  }
+
+  return TextLengthOverflow(
+    limit: limit,
+    graphemeStart: grapheme,
+    utf16Start: utf16,
+    byteStart: byteStart,
+    utf16End: utf16End,
+    byteEnd: byteEnd,
+  );
+}

--- a/packages/bluesky_text/pubspec.yaml
+++ b/packages/bluesky_text/pubspec.yaml
@@ -1,7 +1,7 @@
 name: bluesky_text
 resolution: workspace
 description: Provides the easiest and most powerful way to analyze the text for Bluesky Social.
-version: 1.4.1
+version: 1.5.0
 homepage: https://atprotodart.com
 repository: https://github.com/myConsciousness/atproto.dart/tree/main/packages/bluesky_text
 issue_tracker: https://github.com/myConsciousness/atproto.dart/issues

--- a/packages/bluesky_text/test/src/facet_render_test.dart
+++ b/packages/bluesky_text/test/src/facet_render_test.dart
@@ -1,0 +1,131 @@
+// Copyright (c) 2023-2025, Shinya Kato.
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// Package imports:
+import 'package:test/test.dart';
+
+// Project imports:
+import 'package:bluesky_text/src/bluesky_text.dart';
+import 'package:bluesky_text/src/entities/entity.dart';
+import 'package:bluesky_text/src/facet.dart';
+import 'package:bluesky_text/src/facet_segmenter.dart';
+import 'package:bluesky_text/src/text_segment.dart';
+
+void _expectPartition(final String text, final List<TextSegment> segments) {
+  if (text.isEmpty) {
+    expect(segments, isEmpty);
+    return;
+  }
+
+  expect(segments.first.utf16Start, 0);
+  expect(segments.last.utf16End, text.length);
+
+  final buffer = StringBuffer();
+  var cursor = 0;
+  for (final s in segments) {
+    expect(s.utf16Start, cursor);
+    expect(s.utf16End, greaterThan(s.utf16Start));
+    expect(s.text, text.substring(s.utf16Start, s.utf16End));
+    expect(s.isOverflow, isFalse); // display context has no limit
+    buffer.write(s.text);
+    cursor = s.utf16End;
+  }
+  expect(buffer.toString(), text);
+}
+
+Future<List<PostFacet>> _facetsFor(
+  final String text, {
+  HandleResolver? resolver,
+}) async {
+  final result = await BlueskyText(
+    text,
+  ).entities.toFacetsResult(resolver: resolver ?? (h) async => 'did:plc:$h');
+  return result.facets.map(PostFacet.fromJson).toList();
+}
+
+void main() {
+  group('renderFacets', () {
+    test('empty text yields no segments', () {
+      expect(renderFacets('', const []), isEmpty);
+    });
+
+    test('no facets yields a single plain segment', () {
+      final segments = renderFacets('hello world', const []);
+
+      expect(segments, hasLength(1));
+      expect(segments.single.type, isNull);
+      _expectPartition('hello world', segments);
+    });
+
+    test(
+      'maps facet byte ranges back onto UTF-16 spans (with emoji)',
+      () async {
+        // The 🚀 shifts UTF-8 bytes vs UTF-16 units, so the link/tag facet byte
+        // offsets must be converted back correctly.
+        const text = 'hi @alice.bsky.social 🚀 https://example.com #dart';
+        final facets = await _facetsFor(text);
+
+        final segments = renderFacets(text, facets);
+        _expectPartition(text, segments);
+
+        final mention = segments.singleWhere(
+          (s) => s.type == EntityType.handle,
+        );
+        expect(mention.text, '@alice.bsky.social');
+        expect(mention.feature!.value, 'did:plc:alice.bsky.social');
+        expect(mention.isFeature, isTrue);
+        expect(mention.isEntity, isFalse);
+
+        final link = segments.singleWhere((s) => s.type == EntityType.link);
+        expect(link.text, 'https://example.com');
+        expect(link.feature!.value, 'https://example.com');
+
+        final tag = segments.singleWhere((s) => s.type == EntityType.tag);
+        expect(tag.text, '#dart');
+      },
+    );
+
+    test('drops overlapping and featureless facets', () {
+      const text = 'hello world';
+      final facets = [
+        const PostFacet(
+          byteStart: 0,
+          byteEnd: 5,
+          features: [FacetFeature(type: EntityType.link, value: 'x')],
+        ),
+        //* Overlaps the first — must be dropped.
+        const PostFacet(
+          byteStart: 3,
+          byteEnd: 7,
+          features: [FacetFeature(type: EntityType.tag, value: 'y')],
+        ),
+        //* No features — must be dropped.
+        const PostFacet(byteStart: 6, byteEnd: 11, features: []),
+      ];
+
+      final segments = renderFacets(text, facets);
+      _expectPartition(text, segments);
+
+      final styled = segments.where((s) => s.type != null).toList();
+      expect(styled, hasLength(1));
+      expect(styled.single.text, 'hello');
+    });
+
+    test('PostFacet.fromJson parses the lexicon shape', () {
+      final facet = PostFacet.fromJson({
+        'index': {'byteStart': 2, 'byteEnd': 10},
+        'features': [
+          {'\$type': 'app.bsky.richtext.facet#mention', 'did': 'did:plc:x'},
+          {'\$type': 'app.bsky.unknown#thing', 'foo': 'bar'},
+        ],
+      });
+
+      expect(facet.byteStart, 2);
+      expect(facet.byteEnd, 10);
+      expect(facet.features, hasLength(1)); // unknown feature skipped
+      expect(facet.features.single.type, EntityType.handle);
+      expect(facet.features.single.value, 'did:plc:x');
+    });
+  });
+}

--- a/packages/bluesky_text/test/src/facet_render_test.dart
+++ b/packages/bluesky_text/test/src/facet_render_test.dart
@@ -112,6 +112,39 @@ void main() {
       expect(styled.single.text, 'hello');
     });
 
+    test('a facet entirely beyond the text is dropped (no empty segment)', () {
+      // 'hello' is 5 bytes; the facet claims bytes 10..20 (malformed data from
+      // a third-party PDS). It must be dropped — not emitted as an empty
+      // segment that breaks the non-empty partition invariant.
+      final segments = renderFacets('hello', const [
+        PostFacet(
+          byteStart: 10,
+          byteEnd: 20,
+          features: [FacetFeature(type: EntityType.link, value: 'x')],
+        ),
+      ]);
+
+      _expectPartition('hello', segments);
+      expect(segments, hasLength(1));
+      expect(segments.single.type, isNull);
+    });
+
+    test('a facet extending past the end of the text is clamped', () {
+      // 'héllo' is 6 bytes / 5 UTF-16 units; the facet runs 3..99.
+      final segments = renderFacets('héllo', const [
+        PostFacet(
+          byteStart: 3,
+          byteEnd: 99,
+          features: [FacetFeature(type: EntityType.tag, value: 't')],
+        ),
+      ]);
+
+      _expectPartition('héllo', segments);
+      final tag = segments.singleWhere((s) => s.type == EntityType.tag);
+      expect(tag.text, 'llo');
+      expect(tag.utf16End, 5);
+    });
+
     test('PostFacet.fromJson parses the lexicon shape', () {
       final facet = PostFacet.fromJson({
         'index': {'byteStart': 2, 'byteEnd': 10},

--- a/packages/bluesky_text/test/src/facet_resolver_test.dart
+++ b/packages/bluesky_text/test/src/facet_resolver_test.dart
@@ -58,6 +58,16 @@ void main() {
       expect(facets, hasLength(1)); // only alice resolved
     });
 
+    test('a handle mentioned twice is reported unresolved once', () async {
+      final text = BlueskyText('@ghost.bsky.social and @ghost.bsky.social');
+
+      final result = await text.entities.toFacetsResult(
+        resolver: (handle) async => null,
+      );
+
+      expect(result.unresolvedHandles, ['ghost.bsky.social']);
+    });
+
     test('an all-resolving resolver leaves no unresolved handles', () async {
       final text = BlueskyText('@a.bsky.social @b.bsky.social');
 

--- a/packages/bluesky_text/test/src/facet_resolver_test.dart
+++ b/packages/bluesky_text/test/src/facet_resolver_test.dart
@@ -1,0 +1,72 @@
+// Copyright (c) 2023-2025, Shinya Kato.
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// Package imports:
+import 'package:test/test.dart';
+
+// Project imports:
+import 'package:bluesky_text/src/bluesky_text.dart';
+
+void main() {
+  group('toFacetsResult with an injected resolver', () {
+    test('resolves known handles and reports unresolved ones', () async {
+      final text = BlueskyText(
+        '@alice.bsky.social and @ghost.bsky.social see https://example.com #tag',
+      );
+
+      final result = await text.entities.toFacetsResult(
+        resolver: (handle) async =>
+            handle == 'alice.bsky.social' ? 'did:plc:alice' : null,
+      );
+
+      // Unknown handle is surfaced instead of silently dropped.
+      expect(result.unresolvedHandles, ['ghost.bsky.social']);
+
+      // The resolved mention, the link and the tag all produce facets.
+      final mentions = result.facets
+          .where(
+            (f) => (f['features'] as List).any(
+              (x) => x['\$type'] == 'app.bsky.richtext.facet#mention',
+            ),
+          )
+          .toList();
+      expect(mentions, hasLength(1));
+      expect(
+        (mentions.single['features'] as List).single['did'],
+        'did:plc:alice',
+      );
+
+      final links = result.facets.where(
+        (f) => (f['features'] as List).any(
+          (x) => x['\$type'] == 'app.bsky.richtext.facet#link',
+        ),
+      );
+      expect(links, hasLength(1));
+    });
+
+    test('toFacets is a thin wrapper returning only the facets', () async {
+      final text = BlueskyText('@alice.bsky.social @ghost.bsky.social');
+
+      resolver(String handle) async =>
+          handle == 'alice.bsky.social' ? 'did:plc:alice' : null;
+
+      final result = await text.entities.toFacetsResult(resolver: resolver);
+      final facets = await text.entities.toFacets(resolver: resolver);
+
+      expect(facets, result.facets);
+      expect(facets, hasLength(1)); // only alice resolved
+    });
+
+    test('an all-resolving resolver leaves no unresolved handles', () async {
+      final text = BlueskyText('@a.bsky.social @b.bsky.social');
+
+      final result = await text.entities.toFacetsResult(
+        resolver: (handle) async => 'did:plc:$handle',
+      );
+
+      expect(result.unresolvedHandles, isEmpty);
+      expect(result.facets, hasLength(2));
+    });
+  });
+}

--- a/packages/bluesky_text/test/src/post_data_test.dart
+++ b/packages/bluesky_text/test/src/post_data_test.dart
@@ -1,0 +1,71 @@
+// Copyright (c) 2023-2025, Shinya Kato.
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// Package imports:
+import 'package:test/test.dart';
+
+// Project imports:
+import 'package:bluesky_text/src/bluesky_text.dart';
+
+void main() {
+  group('.formatted', () {
+    test('is memoized (same instance across calls)', () {
+      final text = BlueskyText(
+        'see https://example.com/a/very/long/path/x now',
+      );
+
+      expect(identical(text.formatted, text.formatted), isTrue);
+      expect(identical(text.formatted, text.format()), isTrue);
+    });
+
+    test('an already-formatted instance is its own formatted form', () {
+      final formatted = BlueskyText('hello https://example.com').format();
+
+      expect(identical(formatted.formatted, formatted), isTrue);
+    });
+  });
+
+  group('.toPostData', () {
+    test('formats markdown into a link facet in one call', () async {
+      final post = await BlueskyText(
+        'see [example](https://example.com/very/long/path)',
+      ).toPostData();
+
+      // The posted text is the formatted (collapsed) markdown, not the raw one.
+      expect(post.text, 'see example');
+      expect(post.unresolvedHandles, isEmpty);
+
+      final links = post.facets.where(
+        (f) => (f['features'] as List).any(
+          (x) => x['\$type'] == 'app.bsky.richtext.facet#link',
+        ),
+      );
+      expect(links, hasLength(1));
+      expect(
+        (links.single['features'] as List).single['uri'],
+        'https://example.com/very/long/path',
+      );
+    });
+
+    test('resolves mentions and surfaces unresolved handles', () async {
+      final post =
+          await BlueskyText(
+            '@alice.bsky.social and @ghost.bsky.social',
+          ).toPostData(
+            resolver: (h) async =>
+                h == 'alice.bsky.social' ? 'did:plc:alice' : null,
+          );
+
+      expect(post.text, '@alice.bsky.social and @ghost.bsky.social');
+      expect(post.unresolvedHandles, ['ghost.bsky.social']);
+
+      final mentions = post.facets.where(
+        (f) => (f['features'] as List).any(
+          (x) => x['\$type'] == 'app.bsky.richtext.facet#mention',
+        ),
+      );
+      expect(mentions, hasLength(1));
+    });
+  });
+}

--- a/packages/bluesky_text/test/src/post_data_test.dart
+++ b/packages/bluesky_text/test/src/post_data_test.dart
@@ -26,6 +26,24 @@ void main() {
     });
   });
 
+  group('memoized collections are unmodifiable', () {
+    test('mutating .segments throws and does not corrupt later reads', () {
+      final text = BlueskyText('hello @alice.bsky.social');
+      final before = text.segments.length;
+
+      expect(() => text.segments.clear(), throwsUnsupportedError);
+      expect(text.segments.length, before);
+    });
+
+    test('mutating .split() throws and does not corrupt later calls', () {
+      final text = BlueskyText('a' * 700);
+      final before = text.split().length;
+
+      expect(() => text.split().clear(), throwsUnsupportedError);
+      expect(text.split().length, before);
+    });
+  });
+
   group('.toPostData', () {
     test('formats markdown into a link facet in one call', () async {
       final post = await BlueskyText(

--- a/packages/bluesky_text/test/src/segments_property_test.dart
+++ b/packages/bluesky_text/test/src/segments_property_test.dart
@@ -1,0 +1,155 @@
+// Copyright (c) 2023-2025, Shinya Kato.
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// Dart imports:
+import 'dart:convert';
+import 'dart:math';
+
+// Package imports:
+import 'package:test/test.dart';
+
+// Project imports:
+import 'package:bluesky_text/src/bluesky_text.dart';
+
+/// A pool of tokens that stresses every axis the segmenter cares about:
+/// multi-byte characters, grapheme clusters (ZWJ, flags, skin tones), all
+/// entity kinds, whitespace and newlines.
+const _tokens = <String>[
+  'hello',
+  'world',
+  'the',
+  'quick',
+  'こんにちは',
+  '世界',
+  '😳',
+  '🚀',
+  '👍',
+  '👨‍👩‍👧‍👦', // ZWJ family: one grapheme, 25 bytes, 11 code units.
+  '🇯🇵', // regional-indicator flag: one grapheme, two code points.
+  '👍🏽', // skin-tone modifier.
+  '@shinyakato.dev',
+  '@alice.bsky.social',
+  'https://example.com',
+  'https://example.com/some/long/path/here',
+  'http://test.org/a',
+  '#dart',
+  '#bluesky',
+  '#タグ',
+  r'$AAPL',
+  '\n',
+  '  ',
+];
+
+String _generate(final Random random) {
+  final count = 1 + random.nextInt(120);
+  final buffer = StringBuffer();
+
+  for (var i = 0; i < count; i++) {
+    if (i > 0) buffer.write(random.nextBool() ? ' ' : '\n');
+    buffer.write(_tokens[random.nextInt(_tokens.length)]);
+  }
+
+  return buffer.toString();
+}
+
+/// Asserts every structural guarantee `segments` must uphold for [text].
+void _assertInvariants(final BlueskyText text) {
+  final segments = text.segments;
+  final value = text.value;
+
+  if (value.isEmpty) {
+    expect(segments, isEmpty);
+    return;
+  }
+
+  // 1. Gap-free, ordered partition whose concatenation reproduces the value.
+  expect(segments.first.utf16Start, 0);
+  expect(segments.last.utf16End, value.length);
+
+  final buffer = StringBuffer();
+  var cursor = 0;
+  for (final s in segments) {
+    expect(s.utf16Start, cursor, reason: 'gap/overlap in "$value"');
+    expect(s.utf16End, greaterThan(s.utf16Start));
+    expect(s.text, value.substring(s.utf16Start, s.utf16End));
+    buffer.write(s.text);
+    cursor = s.utf16End;
+  }
+  expect(buffer.toString(), value);
+
+  // 2. Each entity is represented by exactly one, unsplit segment. `Entity`
+  //    has identity equality and every `entities` call builds fresh instances,
+  //    so compare by value (type + byte range).
+  final segmentKeys =
+      segments
+          .where((s) => s.isEntity)
+          .map(
+            (s) =>
+                '${s.type}:${s.entity!.indices.start}:${s.entity!.indices.end}',
+          )
+          .toList()
+        ..sort();
+  final entityKeys =
+      text.entities
+          .where((e) => e.indices.start < e.indices.end)
+          .map((e) => '${e.type}:${e.indices.start}:${e.indices.end}')
+          .toList()
+        ..sort();
+  expect(
+    segmentKeys,
+    entityKeys,
+    reason: 'entities and entity segments must match 1:1 in "$value"',
+  );
+
+  // 3. Overflow flag is exactly "at or past the boundary", and no segment
+  //    straddles the boundary.
+  final overflow = text.overflow;
+  if (overflow == null) {
+    expect(segments.every((s) => !s.isOverflow), isTrue);
+  } else {
+    for (final s in segments) {
+      expect(
+        s.isOverflow,
+        s.utf16Start >= overflow.utf16Start,
+        reason: 'isOverflow mismatch at ${s.utf16Start} in "$value"',
+      );
+      expect(
+        s.utf16Start < overflow.utf16Start && overflow.utf16Start < s.utf16End,
+        isFalse,
+        reason: 'segment straddles the overflow boundary in "$value"',
+      );
+    }
+
+    final overflowText = segments
+        .where((s) => s.isOverflow)
+        .map((s) => s.text)
+        .join();
+    expect(overflowText, value.substring(overflow.utf16Start));
+  }
+
+  // 4. Offsets are self-consistent across the byte / UTF-16 axes.
+  if (overflow != null) {
+    expect(overflow.utf16End, value.length);
+    expect(overflow.byteEnd, utf8.encode(value).length);
+    expect(
+      utf8.encode(value.substring(0, overflow.utf16Start)).length,
+      overflow.byteStart,
+    );
+  }
+
+  // 5. Deterministic: a second call is equal.
+  expect(text.segments, segments);
+}
+
+void main() {
+  test('.segments upholds its invariants across generated inputs', () {
+    final random = Random(42);
+
+    for (var i = 0; i < 800; i++) {
+      final value = _generate(random);
+      _assertInvariants(BlueskyText(value));
+      _assertInvariants(BlueskyText(value).format());
+    }
+  });
+}

--- a/packages/bluesky_text/test/src/split_byte_budget_test.dart
+++ b/packages/bluesky_text/test/src/split_byte_budget_test.dart
@@ -1,0 +1,61 @@
+// Copyright (c) 2023-2025, Shinya Kato.
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// Package imports:
+import 'package:test/test.dart';
+
+// Project imports:
+import 'package:bluesky_text/src/bluesky_text.dart';
+
+/// A ZWJ family cluster: one grapheme, 25 UTF-8 bytes.
+const _family = '\u{1F468}‍\u{1F469}‍\u{1F467}‍\u{1F466}';
+
+void main() {
+  group('.split respects the 3000-byte budget', () {
+    test('every chunk is within BOTH limits for byte-heavy text', () {
+      // 250 family clusters = 250 graphemes (< 300) but 6250 bytes (> 3000):
+      // the old grapheme-only splitter returned it as one over-limit chunk.
+      final chunks = BlueskyText(_family * 250).split();
+
+      expect(chunks.length, greaterThan(1));
+      for (final chunk in chunks) {
+        expect(chunk.isNotEmpty, isTrue);
+        expect(
+          chunk.isLengthLimitExceeded,
+          isFalse,
+          reason: 'chunk "${chunk.length} graphemes" still exceeds a limit',
+        );
+      }
+    });
+
+    test('byte budget flushes across space-separated words', () {
+      // 200 family "words" separated by spaces: each word is tiny but the byte
+      // total is huge, so chunks must flush on the byte budget.
+      final value = List.filled(200, _family).join(' ');
+      final chunks = BlueskyText(value).split();
+
+      expect(chunks.length, greaterThan(1));
+      for (final chunk in chunks) {
+        expect(chunk.isLengthLimitExceeded, isFalse);
+      }
+    });
+
+    test('grapheme-heavy text still splits by the 300 budget', () {
+      final chunks = BlueskyText('a' * 700).split();
+
+      for (final chunk in chunks) {
+        expect(chunk.length, lessThanOrEqualTo(300));
+        expect(chunk.isLengthLimitExceeded, isFalse);
+      }
+    });
+
+    test('within-limit text is returned unchanged', () {
+      final text = BlueskyText('hello world');
+      final chunks = text.split();
+
+      expect(chunks, hasLength(1));
+      expect(chunks.single.value, 'hello world');
+    });
+  });
+}

--- a/packages/bluesky_text/test/src/split_byte_budget_test.dart
+++ b/packages/bluesky_text/test/src/split_byte_budget_test.dart
@@ -50,6 +50,20 @@ void main() {
       }
     });
 
+    test('a single grapheme cluster over 3000 bytes does not hang', () {
+      // ~500 ZWJ-joined emoji form ONE grapheme cluster of ~3500 bytes. It
+      // cannot fit any chunk, so it is emitted as its own over-limit chunk
+      // (detectable via isLengthLimitExceeded) and the split makes progress
+      // instead of looping forever.
+      final monster = List.filled(500, '\u{1F469}').join('‍');
+      final chunks = BlueskyText('$monster tail').split();
+
+      expect(chunks, hasLength(2));
+      expect(chunks.first.isLengthLimitExceeded, isTrue);
+      expect(chunks.last.isLengthLimitExceeded, isFalse);
+      expect(chunks.last.value, 'tail');
+    });
+
     test('within-limit text is returned unchanged', () {
       final text = BlueskyText('hello world');
       final chunks = text.split();

--- a/packages/bluesky_text/test/src/split_byte_budget_test.dart
+++ b/packages/bluesky_text/test/src/split_byte_budget_test.dart
@@ -7,9 +7,24 @@ import 'package:test/test.dart';
 
 // Project imports:
 import 'package:bluesky_text/src/bluesky_text.dart';
+import 'package:bluesky_text/src/config/link_config.dart';
 
 /// A ZWJ family cluster: one grapheme, 25 UTF-8 bytes.
 const _family = '\u{1F468}‍\u{1F469}‍\u{1F467}‍\u{1F466}';
+
+Future<List<String>> _linkUris(final List<BlueskyText> chunks) async {
+  final uris = <String>[];
+  for (final chunk in chunks) {
+    final data = await chunk.toPostData();
+    for (final facet in data.facets) {
+      final feature = (facet['features'] as List).first;
+      if (feature[r'$type'] == 'app.bsky.richtext.facet#link') {
+        uris.add(feature['uri'] as String);
+      }
+    }
+  }
+  return uris;
+}
 
 void main() {
   group('.split respects the 3000-byte budget', () {
@@ -71,5 +86,58 @@ void main() {
       expect(chunks, hasLength(1));
       expect(chunks.single.value, 'hello world');
     });
+  });
+
+  group('format().split() splits the original text (no facet corruption)', () {
+    const shortening = LinkConfig(enableShortening: true);
+    const url = 'https://example.com/very/long/path/to/some/article-12345';
+
+    test('formatted chunks equal raw chunks', () {
+      final raw = BlueskyText('${'a' * 300} $url', linkConfig: shortening);
+
+      expect(
+        raw.format().split().map((c) => c.value),
+        raw.split().map((c) => c.value),
+      );
+    });
+
+    test(
+      'a shortened link keeps its full URI through format().split()',
+      () async {
+        final chunks = BlueskyText(
+          '${'a' * 300} $url',
+          linkConfig: shortening,
+        ).format().split();
+
+        // Before the fix this became the truncated display text
+        // "https://example.com/very/long/pa".
+        expect(await _linkUris(chunks), [url]);
+      },
+    );
+
+    test('a markdown link survives format().split()', () async {
+      const target = 'https://example.com/very/long/path/to/article';
+      final chunks = BlueskyText(
+        '${'a' * 300} [my article]($target)',
+      ).format().split();
+
+      // Before the fix the markdown link facet vanished entirely.
+      expect(await _linkUris(chunks), [target]);
+    });
+
+    test(
+      'a within-limit formatted instance yields one postable chunk',
+      () async {
+        final chunks = BlueskyText(
+          'hello $url',
+          linkConfig: shortening,
+        ).format().split();
+
+        expect(chunks, hasLength(1));
+        final data = await chunks.single.toPostData();
+        expect(data.facets, hasLength(1));
+        expect((data.facets.single['features'] as List).single['uri'], url);
+      },
+    );
   });
 }

--- a/packages/bluesky_text/test/src/split_tokenization_test.dart
+++ b/packages/bluesky_text/test/src/split_tokenization_test.dart
@@ -1,0 +1,96 @@
+// Copyright (c) 2023-2025, Shinya Kato.
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// Package imports:
+import 'package:test/test.dart';
+
+// Project imports:
+import 'package:bluesky_text/src/bluesky_text.dart';
+
+void main() {
+  group('.split breaks on all whitespace, never mid-word', () {
+    test('newline-separated words are not torn, and newlines are kept', () {
+      final value = List.generate(200, (i) => 'word$i').join('\n');
+      final chunks = BlueskyText(value).split();
+
+      expect(chunks.length, greaterThan(1));
+      for (final chunk in chunks) {
+        // Every whitespace-separated token is a complete `wordN`.
+        final words = chunk.value
+            .split(RegExp(r'\s+'))
+            .where((w) => w.isNotEmpty);
+        for (final word in words) {
+          expect(
+            RegExp(r'^word\d+$').hasMatch(word),
+            isTrue,
+            reason: 'torn word "$word"',
+          );
+        }
+        expect(chunk.isLengthLimitExceeded, isFalse);
+      }
+      // The author's newlines survive inside a chunk.
+      expect(chunks.first.value.contains('\n'), isTrue);
+    });
+
+    test('the full-width space U+3000 is a break point', () {
+      final value = List.generate(200, (i) => 'ワード$i').join('　');
+      final chunks = BlueskyText(value).split();
+
+      expect(chunks.length, greaterThan(1));
+      for (final chunk in chunks) {
+        for (final word in chunk.value.split('　').where((w) => w.isNotEmpty)) {
+          expect(RegExp(r'^ワード\d+$').hasMatch(word), isTrue, reason: word);
+        }
+      }
+    });
+
+    test('tabs are break points too', () {
+      final value = List.generate(200, (i) => 'word$i').join('\t');
+      for (final chunk in BlueskyText(value).split()) {
+        for (final word
+            in chunk.value.split(RegExp(r'\s+')).where((w) => w.isNotEmpty)) {
+          expect(RegExp(r'^word\d+$').hasMatch(word), isTrue);
+        }
+      }
+    });
+
+    test('no chunk starts or ends with whitespace', () {
+      final value = List.generate(200, (i) => 'word$i').join('\n\n');
+      for (final chunk in BlueskyText(value).split()) {
+        expect(chunk.value, chunk.value.trim());
+      }
+    });
+  });
+
+  group('.split keeps a markdown link atomic', () {
+    test('a markdown link straddling the boundary stays whole', () async {
+      const md =
+          '[my long article title](https://example.com/a/b/c/article-xyz)';
+      final raw = BlueskyText('${'x ' * 148}$md ${'y ' * 20}');
+
+      final chunks = raw.split();
+
+      // The link appears whole in exactly one chunk, never split open.
+      expect(chunks.where((c) => c.value.contains(md)), hasLength(1));
+      expect(
+        chunks.where(
+          (c) => c.value.contains('[my long') && !c.value.contains(md),
+        ),
+        isEmpty,
+      );
+
+      // That chunk still produces a link facet.
+      final linkChunk = chunks.firstWhere((c) => c.value.contains(md));
+      final data = await linkChunk.toPostData();
+      expect(
+        data.facets.any(
+          (f) => (f['features'] as List).any(
+            (x) => x['\$type'] == 'app.bsky.richtext.facet#link',
+          ),
+        ),
+        isTrue,
+      );
+    });
+  });
+}

--- a/packages/bluesky_text/test/src/text_length_overflow_test.dart
+++ b/packages/bluesky_text/test/src/text_length_overflow_test.dart
@@ -1,0 +1,167 @@
+// Copyright (c) 2023-2025, Shinya Kato.
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// Dart imports:
+import 'dart:convert';
+
+// Package imports:
+import 'package:test/test.dart';
+
+// Project imports:
+import 'package:bluesky_text/src/bluesky_text.dart';
+import 'package:bluesky_text/src/text_length_overflow.dart';
+
+/// The family emoji `👨‍👩‍👧‍👦` is a single grapheme cluster built from 4 emoji
+/// joined by 3 ZWJs: 25 UTF-8 bytes and 11 UTF-16 code units per cluster.
+const _family = '\u{1F468}‍\u{1F469}‍\u{1F467}‍\u{1F466}';
+
+/// Asserts the invariants that must hold for every overflow: it ends at the end
+/// of the value in both axes, and its start offsets are internally consistent
+/// with the value.
+void _expectConsistent(final BlueskyText text, final TextLengthOverflow o) {
+  expect(o.utf16End, text.value.length);
+  expect(o.byteEnd, utf8.encode(text.value).length);
+
+  // The UTF-16 start must map back to the same byte start.
+  final within = text.value.substring(0, o.utf16Start);
+  expect(utf8.encode(within).length, o.byteStart);
+}
+
+void main() {
+  group('.overflow within limit', () {
+    test('empty', () {
+      expect(BlueskyText('').overflow, isNull);
+    });
+
+    test('exactly 300 graphemes', () {
+      expect(BlueskyText('a' * 300).overflow, isNull);
+    });
+
+    test('exactly 300 emojis', () {
+      expect(BlueskyText('😳' * 300).overflow, isNull);
+    });
+
+    test('exactly 3000 bytes', () {
+      // 120 family clusters = 3000 bytes, 120 graphemes.
+      expect(BlueskyText(_family * 120).overflow, isNull);
+    });
+  });
+
+  group('.overflow grapheme limit', () {
+    test('301 ascii', () {
+      final text = BlueskyText('a' * 301);
+      final o = text.overflow!;
+
+      expect(o.limit, LengthLimit.grapheme);
+      expect(o.graphemeStart, 300);
+      expect(o.utf16Start, 300);
+      expect(o.byteStart, 300);
+      expect(o.utf16End, 301);
+      expect(o.byteEnd, 301);
+      _expectConsistent(text, o);
+    });
+
+    test('301 emojis — boundary lands between clusters, not inside one', () {
+      final text = BlueskyText('😳' * 301);
+      final o = text.overflow!;
+
+      expect(o.limit, LengthLimit.grapheme);
+      expect(o.graphemeStart, 300);
+      // Each 😳 is 2 UTF-16 code units and 4 UTF-8 bytes.
+      expect(o.utf16Start, 600);
+      expect(o.byteStart, 1200);
+      expect(o.utf16End, 602);
+      expect(o.byteEnd, 1204);
+      _expectConsistent(text, o);
+    });
+
+    test('emoji straddling the boundary is not split', () {
+      // 299 ascii + 2 emojis = 301 graphemes; the 300th grapheme is the first
+      // emoji, so the boundary sits right after it.
+      final text = BlueskyText('${'a' * 299}😳😳');
+      final o = text.overflow!;
+
+      expect(o.graphemeStart, 300);
+      expect(o.utf16Start, 299 + 2); // 299 ascii + 1 emoji (2 code units)
+      expect(o.byteStart, 299 + 4); // 299 ascii + 1 emoji (4 bytes)
+      _expectConsistent(text, o);
+
+      // The overflowing tail is exactly the second emoji, whole.
+      expect(text.value.substring(o.utf16Start), '😳');
+    });
+  });
+
+  group('.overflow byte limit first', () {
+    test('121 family emojis exceed 3000 bytes within 300 graphemes', () {
+      final text = BlueskyText(_family * 121);
+      final o = text.overflow!;
+
+      expect(o.limit, LengthLimit.byte);
+      expect(o.graphemeStart, 120);
+      expect(o.byteStart, 3000); // 25 bytes * 120
+      expect(o.utf16Start, 1320); // 11 code units * 120
+      expect(o.byteEnd, 3025);
+      expect(o.utf16End, 1331);
+      _expectConsistent(text, o);
+    });
+  });
+
+  group('.overflow entity snapping', () {
+    test('a link straddling the boundary is pushed wholly into overflow', () {
+      // 290 ascii + space (291 chars), then a link. The raw 300-grapheme
+      // boundary falls inside the link, so it should snap back to the link
+      // start.
+      final text = BlueskyText('${'a' * 290} https://example.com/some/path');
+      final link = text.links.single;
+      final o = text.overflow!;
+
+      expect(o.byteStart, link.indices.start);
+      _expectConsistent(text, o);
+
+      // Nothing of the link is left on the within-limit side.
+      final within = text.value.substring(0, o.utf16Start);
+      expect(within.contains('https://'), isFalse);
+      // The whole link value opens the overflowing tail.
+      expect(text.value.substring(o.utf16Start).startsWith('https://'), isTrue);
+    });
+  });
+
+  group('.overflow with format()', () {
+    test('reports overflow on the formatted value, snapped to the link', () {
+      // A long URL near the boundary; overflow must be measured against the
+      // formatted value and snapped to the formatted link's start.
+      final formatted = BlueskyText(
+        '${'a' * 290} https://example.com/a/very/long/path/that/gets/shortened',
+      ).format();
+
+      final o = formatted.overflow!;
+      _expectConsistent(formatted, o);
+      expect(o.byteStart, formatted.links.single.indices.start);
+      expect(
+        formatted.value.substring(o.utf16Start).startsWith('https://'),
+        isTrue,
+      );
+    });
+
+    test('markdown link text after format is pushed wholly into overflow', () {
+      // `[example](url)` collapses to `example`; the raw 300-grapheme boundary
+      // falls inside that link text, so it snaps to the link's start and the
+      // whole `example` becomes the overflowing tail.
+      final formatted = BlueskyText(
+        '${'a' * 295} [example](https://example.com/very/long/path)',
+      ).format();
+
+      final o = formatted.overflow!;
+      _expectConsistent(formatted, o);
+      expect(formatted.value.substring(o.utf16Start), 'example');
+    });
+  });
+
+  test('.isLengthLimitExceeded matches .overflow presence', () {
+    expect(BlueskyText('a' * 300).isLengthLimitExceeded, isFalse);
+    expect(BlueskyText('a' * 300).overflow, isNull);
+    expect(BlueskyText('a' * 301).isLengthLimitExceeded, isTrue);
+    expect(BlueskyText('a' * 301).overflow, isNotNull);
+  });
+}

--- a/packages/bluesky_text/test/src/text_segment_test.dart
+++ b/packages/bluesky_text/test/src/text_segment_test.dart
@@ -1,0 +1,247 @@
+// Copyright (c) 2023-2025, Shinya Kato.
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// Dart imports:
+import 'dart:convert';
+
+// Package imports:
+import 'package:test/test.dart';
+
+// Project imports:
+import 'package:bluesky_text/src/bluesky_text.dart';
+import 'package:bluesky_text/src/entities/entity.dart';
+import 'package:bluesky_text/src/text_length_overflow.dart';
+import 'package:bluesky_text/src/unicode_string.dart';
+
+/// Asserts the partition invariants: gap-free, in order, and concatenating the
+/// slices reproduces the value.
+void _expectPartitions(final BlueskyText text) {
+  final segments = text.segments;
+  if (text.value.isEmpty) {
+    expect(segments, isEmpty);
+    return;
+  }
+
+  expect(segments.first.utf16Start, 0);
+  expect(segments.last.utf16End, text.value.length);
+
+  final buffer = StringBuffer();
+  var cursor = 0;
+  for (final s in segments) {
+    expect(s.utf16Start, cursor, reason: 'segments must be gap-free');
+    expect(s.utf16End, greaterThan(s.utf16Start));
+    expect(s.text, text.value.substring(s.utf16Start, s.utf16End));
+    buffer.write(s.text);
+    cursor = s.utf16End;
+  }
+
+  expect(buffer.toString(), text.value);
+}
+
+void main() {
+  group('.segments partition invariants', () {
+    test('empty', () {
+      expect(BlueskyText('').segments, isEmpty);
+    });
+
+    test('plain text within limit', () {
+      final text = BlueskyText('hello world');
+      _expectPartitions(text);
+
+      expect(text.segments, hasLength(1));
+      expect(text.segments.single.isEntity, isFalse);
+      expect(text.segments.single.isOverflow, isFalse);
+    });
+
+    test('entities and plain text interleave', () {
+      final text = BlueskyText(
+        'hi @shinyakato.dev see https://example.com and #tag done',
+      );
+      _expectPartitions(text);
+
+      final entitySegments = text.segments.where((s) => s.isEntity).toList();
+      expect(entitySegments.map((s) => s.type), [
+        EntityType.handle,
+        EntityType.link,
+        EntityType.tag,
+      ]);
+      expect(entitySegments.every((s) => !s.isOverflow), isTrue);
+    });
+  });
+
+  group('.segments overflow', () {
+    test('plain overflow splits the tail', () {
+      final text = BlueskyText('a' * 305);
+      _expectPartitions(text);
+
+      final within = text.segments.where((s) => !s.isOverflow).toList();
+      final over = text.segments.where((s) => s.isOverflow).toList();
+
+      expect(within, hasLength(1));
+      expect(within.single.text, 'a' * 300);
+      expect(over, hasLength(1));
+      expect(over.single.text, 'a' * 5);
+    });
+
+    test('an entity past the boundary is a whole overflow segment', () {
+      // The link straddles the 300-grapheme boundary, so it is snapped wholly
+      // into the overflow: no segment is both an entity and split.
+      final text = BlueskyText('${'a' * 290} https://example.com/some/path');
+      _expectPartitions(text);
+
+      final linkSegments = text.segments
+          .where((s) => s.type == EntityType.link)
+          .toList();
+      expect(linkSegments, hasLength(1));
+      expect(linkSegments.single.isOverflow, isTrue);
+
+      // Everything before the link is within the limit.
+      for (final s in text.segments.where((s) => !s.isEntity)) {
+        if (s.utf16End <= linkSegments.single.utf16Start) {
+          expect(s.isOverflow, isFalse);
+        }
+      }
+    });
+  });
+
+  group('.segments with emoji', () {
+    test('multi-byte characters around an entity are sliced correctly', () {
+      final text = BlueskyText('🚀 hello @shinyakato.dev 👨‍👩‍👧‍👦 end');
+      _expectPartitions(text);
+
+      final handle = text.segments.singleWhere(
+        (s) => s.type == EntityType.handle,
+      );
+      expect(handle.text, '@shinyakato.dev');
+    });
+  });
+
+  group('Utf16IndexConverter matches a reference', () {
+    test('byte offset maps back to the code-unit index for tricky inputs', () {
+      const value = 'a🚀b日本👨‍👩‍👧‍👦c😳';
+      final converter = Utf16IndexConverter(value);
+
+      // Collect the code-unit index at every code-point boundary (the offsets
+      // entity/overflow boundaries can actually land on — never mid-surrogate).
+      final offsets = <int>[0];
+      var codeUnits = 0;
+      for (final rune in value.runes) {
+        codeUnits += rune > 0xFFFF ? 2 : 1;
+        offsets.add(codeUnits);
+      }
+
+      // Each byte prefix length must convert back to that same code-unit index
+      // (monotonic, increasing requests).
+      for (final i in offsets) {
+        final byteOffset = utf8.encode(value.substring(0, i)).length;
+        expect(converter.convert(byteOffset), i, reason: 'at code unit $i');
+      }
+    });
+  });
+
+  group('.segments Flutter edge cases', () {
+    test('entity at the very start of the value', () {
+      final text = BlueskyText('@shinyakato.dev hello');
+      _expectPartitions(text);
+
+      expect(text.segments.first.type, EntityType.handle);
+      expect(text.segments.first.utf16Start, 0);
+    });
+
+    test('entity at the very end of the value', () {
+      final text = BlueskyText('hello #dart');
+      _expectPartitions(text);
+
+      expect(text.segments.last.type, EntityType.tag);
+      expect(text.segments.last.utf16End, text.value.length);
+    });
+
+    test('multi-line text with entities on separate lines', () {
+      final text = BlueskyText('line one @shinyakato.dev\nline two #dart');
+      _expectPartitions(text);
+
+      expect(text.segments.any((s) => s.type == EntityType.handle), isTrue);
+      expect(text.segments.any((s) => s.type == EntityType.tag), isTrue);
+      // The newline is preserved in a plain segment.
+      expect(text.segments.any((s) => s.text.contains('\n')), isTrue);
+    });
+
+    test('boundary exactly at an entity end keeps the entity within limit', () {
+      // 284 ascii + space + a 15-char handle ends exactly at grapheme 300, so
+      // the boundary is the handle's end (not inside it): the handle stays
+      // within the limit and the following text overflows.
+      final text = BlueskyText('${'a' * 284} @shinyakato.dev overflow');
+      _expectPartitions(text);
+
+      final overflow = text.overflow!;
+      expect(overflow.utf16Start, 300);
+      expect(overflow.limit, LengthLimit.grapheme);
+
+      final handle = text.segments.singleWhere(
+        (s) => s.type == EntityType.handle,
+      );
+      expect(handle.isOverflow, isFalse);
+      expect(handle.utf16End, 300);
+    });
+
+    test('a grapheme cluster is never split by the overflow boundary', () {
+      // 300 ascii (within the limit) then a ZWJ family cluster as the 301st
+      // grapheme: the boundary must sit before the whole cluster, never inside
+      // it, so the cluster opens the overflow intact.
+      final text = BlueskyText('${'a' * 300}👨‍👩‍👧‍👦tail');
+      _expectPartitions(text);
+
+      final overflow = text.overflow!;
+      expect(overflow.utf16Start, 300);
+
+      final overflowSegments = text.segments
+          .where((s) => s.isOverflow)
+          .toList();
+      expect(overflowSegments.first.text.startsWith('👨‍👩‍👧‍👦'), isTrue);
+    });
+  });
+
+  group('utf8ByteLength', () {
+    test('matches utf8.encode length for tricky inputs', () {
+      const inputs = [
+        '',
+        'ascii',
+        'café',
+        'こんにちは',
+        '🚀',
+        '👨‍👩‍👧‍👦',
+        '🇯🇵',
+        'a🚀b日本c',
+      ];
+
+      for (final input in inputs) {
+        expect(utf8ByteLength(input), utf8.encode(input).length, reason: input);
+      }
+    });
+
+    test('counts an unpaired surrogate as 3 bytes like the encoder', () {
+      const loneHighSurrogate = '\uD83D'; // high surrogate with no low pair
+      expect(
+        utf8ByteLength(loneHighSurrogate),
+        utf8.encode(loneHighSurrogate).length,
+      );
+    });
+  });
+
+  group('.segments with format()', () {
+    test('measured against the formatted value', () {
+      final formatted = BlueskyText(
+        'see [example](https://example.com/very/long/path) now',
+      ).format();
+      _expectPartitions(formatted);
+
+      // The markdown collapsed to `example`, which is a link entity segment.
+      final linkSegments = formatted.segments
+          .where((s) => s.type == EntityType.link)
+          .toList();
+      expect(linkSegments, hasLength(1));
+      expect(linkSegments.single.text, 'example');
+    });
+  });
+}


### PR DESCRIPTION
## Motivation

A Flutter editor for Bluesky posts naturally wants to, on every keystroke:
color links/handles/tags, **and** show the part of the text that exceeds the
300-grapheme / 3000-byte limit in red. Today `bluesky_text` exposes entity
positions in **UTF-8 byte** offsets and nothing about *where* the overflow
starts, so the app has to compute the limit boundary and merge two coordinate
systems by hand. This PR moves that work into the library.

## What's new

### `BlueskyText.overflow → TextLengthOverflow?`
Locates where the text first exceeds either limit (or `null` when within both),
reported in three coordinate systems because each consumer needs a different
one:
- **UTF-16** (`utf16Start`) — directly usable with `String.substring` / Flutter `TextSpan`
- **UTF-8 byte** (`byteStart`) — same axis as `Entity.indices` and facet `byteSlice`s
- **grapheme** (`graphemeStart`) — matches `length` and the 300-char limit

The boundary always lands on a grapheme cluster boundary (emoji/ZWJ sequences
are never split), and when it would fall inside an entity it is **snapped back
to that entity's start**, so an entity is either wholly within the limit or
wholly in the overflow — matching what actually gets cut when posting.

### `BlueskyText.segments → List<TextSegment>`
A non-overlapping, gap-free partition of the value in document order. Each
`TextSegment` carries UTF-16 offsets, its `entity` (if any) and an `isOverflow`
flag — ready to map straight onto a `TextSpan` tree:

```dart
TextSpan(children: [
  for (final s in controllerText.format().segments)
    TextSpan(
      text: s.text,
      style: TextStyle(
        color: s.isOverflow ? Colors.red : s.isEntity ? Colors.blue : null,
      ),
    ),
]);
```

Concatenating every `TextSegment.text` reproduces the value, and no segment is
ever split across an entity boundary.

Both are derived from the value, so `.format().overflow` / `.format().segments`
measure the **formatted** text (markdown expanded, links shortened) — what is
displayed and posted.

## Performance (hot path: called per keystroke)

Measured with `benchmark/segments_benchmark.dart`:

| path (over-limit text) | before | after |
| --- | --- | --- |
| `isLengthLimitExceeded` | 487 µs | **28 µs** (~18x) |
| `segments` | 907 µs | **488 µs** (~2x) |
| `overflow` / `segments` (1500 chars) | 67 / 73 µs | **34 / 35 µs** |

- `isLengthLimitExceeded` / `overflow` skip the regex entity extraction entirely
  when the text is within the limit (a cheap grapheme scan).
- `segments` resolves entities **once** instead of re-extracting them via `overflow`.
- Grapheme byte counting is allocation-free (`utf8ByteLength`, no intermediate `Uint8List`).

A realistic 300-grapheme post segments in <0.1 ms; a full typing simulation
averages ~45 µs/keystroke (60fps frame budget = 16 ms).

## Tests

- **Property/fuzz** (`segments_property_test.dart`): 800 generated inputs × (raw + `format()`) assert the partition is gap-free and reproduces the value, each entity maps 1:1 to an unsplit segment, `isOverflow` is exact, no segment straddles the boundary, byte/UTF-16 axes are consistent, and results are deterministic.
- **Overflow** (`text_length_overflow_test.dart`): grapheme limit, byte-limit-first (ZWJ family emoji), exact-limit boundaries, emoji/entity straddle + snap, `format()` composition.
- **Segments** (`text_segment_test.dart`): partition invariants, Flutter edge cases (entity at start/end, multi-line, boundary at entity end, cluster never split), `utf8ByteLength` vs `utf8.encode`, `Utf16IndexConverter` reference match.

`dart analyze` clean; all tests pass against `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)