### PR TITLE
refactor(lex_gen): readability, standardization, optimization (v0.4.1)

### DIFF
--- a/packages/lex_gen/CHANGELOG.md
+++ b/packages/lex_gen/CHANGELOG.md
@@ -11,6 +11,7 @@ Internal readability/standardization/optimization refactor. Generated output is 
 - perf: `getExtensions` name lookup is O(1) via a precomputed set (was O(n²)); `LexUnion` resolves each ref name once instead of four times; `RepoCommitHandler` resolves each record type name once instead of six times.
 - refactor: unify `RepoCommitHandler`'s near-identical `_onCreate` / `_onUpdate` firehose event builders into a single parameterized `_getMutationEvent`.
 - refactor: split the 225-line `LexCommand._getRecordCommand` into per-subcommand emitters, unify the near-identical `create`/`put` classes into `_recordMutationClass`, and hoist the hardcoded `com.atproto.repo.getRecord` / `listRecords` method ids to named constants.
+- refactor: split `LexType` into a minimal base and a `GeneratableType` subtype, so the non-generatable `LexMessage` container no longer throws `UnsupportedError` from inherited `lexiconId` / `defName` / `getTypeName` / `format` members.
 - refactor: fix the `_LexLexXrpc*` double-`Lex` type-name typos, deduplicate the record-accessor `rkey` literal handling and the `LexOutput` upload-ref predicate, remove dead `getDescription` helpers, and use `putIfAbsent` for map aggregation.
 - test: add unit tests for `Nsid` and `LexRef`.
 

--- a/packages/lex_gen/CHANGELOG.md
+++ b/packages/lex_gen/CHANGELOG.md
@@ -12,6 +12,7 @@ Internal readability/standardization/optimization refactor. Generated output is 
 - refactor: unify `RepoCommitHandler`'s near-identical `_onCreate` / `_onUpdate` firehose event builders into a single parameterized `_getMutationEvent`.
 - refactor: split the 225-line `LexCommand._getRecordCommand` into per-subcommand emitters, unify the near-identical `create`/`put` classes into `_recordMutationClass`, and hoist the hardcoded `com.atproto.repo.getRecord` / `listRecords` method ids to named constants.
 - refactor: split `LexType` into a minimal base and a `GeneratableType` subtype, so the non-generatable `LexMessage` container no longer throws `UnsupportedError` from inherited `lexiconId` / `defName` / `getTypeName` / `format` members.
+- refactor: remove the module-level mutable state from both `rule.dart` files (the `_config` / `_defsByRef` globals and their `setLexServiceRuleConfig` / `setLexiconDocs` / `setLexCommandRuleConfig` setters) in favour of an explicit `GenContext` (and the command config) threaded through the generators and `rule.*` helpers, so generation no longer depends on hidden global state or setter-call ordering and the helpers are unit-testable.
 - refactor: fix the `_LexLexXrpc*` double-`Lex` type-name typos, deduplicate the record-accessor `rkey` literal handling and the `LexOutput` upload-ref predicate, remove dead `getDescription` helpers, and use `putIfAbsent` for map aggregation.
 - test: add unit tests for `Nsid` and `LexRef`.
 

--- a/packages/lex_gen/CHANGELOG.md
+++ b/packages/lex_gen/CHANGELOG.md
@@ -10,6 +10,7 @@ Internal readability/standardization/optimization refactor. Generated output is 
 - refactor: unify the four byte-identical freezed data-class templates (`LexObject`/`LexRecord`/`LexInput`/`LexOutput`) into a single `renderFreezedDataClass`.
 - perf: `getExtensions` name lookup is O(1) via a precomputed set (was O(n²)); `LexUnion` resolves each ref name once instead of four times; `RepoCommitHandler` resolves each record type name once instead of six times.
 - refactor: unify `RepoCommitHandler`'s near-identical `_onCreate` / `_onUpdate` firehose event builders into a single parameterized `_getMutationEvent`.
+- refactor: split the 225-line `LexCommand._getRecordCommand` into per-subcommand emitters, unify the near-identical `create`/`put` classes into `_recordMutationClass`, and hoist the hardcoded `com.atproto.repo.getRecord` / `listRecords` method ids to named constants.
 - refactor: fix the `_LexLexXrpc*` double-`Lex` type-name typos, deduplicate the record-accessor `rkey` literal handling and the `LexOutput` upload-ref predicate, remove dead `getDescription` helpers, and use `putIfAbsent` for map aggregation.
 - test: add unit tests for `Nsid` and `LexRef`.
 

--- a/packages/lex_gen/CHANGELOG.md
+++ b/packages/lex_gen/CHANGELOG.md
@@ -8,7 +8,8 @@ Internal readability/standardization/optimization refactor. Generated output is 
 - refactor: resolve a ref's related def in O(1) via a precomputed index instead of scanning every doc's every def per lookup (`getRelatedDocFromRef`).
 - refactor: replace the mutually-exclusive `isQuery`/`isProcedure`/`isSubscription`/`isRecord` (and command `isBlobProcedure`) boolean sets with `LexDefKind` / `LexCommandKind` sealed enums dispatched by exhaustive `switch`.
 - refactor: unify the four byte-identical freezed data-class templates (`LexObject`/`LexRecord`/`LexInput`/`LexOutput`) into a single `renderFreezedDataClass`.
-- perf: `getExtensions` name lookup is O(1) via a precomputed set (was O(n²)); `LexUnion` resolves each ref name once instead of four times.
+- perf: `getExtensions` name lookup is O(1) via a precomputed set (was O(n²)); `LexUnion` resolves each ref name once instead of four times; `RepoCommitHandler` resolves each record type name once instead of six times.
+- refactor: unify `RepoCommitHandler`'s near-identical `_onCreate` / `_onUpdate` firehose event builders into a single parameterized `_getMutationEvent`.
 - refactor: fix the `_LexLexXrpc*` double-`Lex` type-name typos, deduplicate the record-accessor `rkey` literal handling and the `LexOutput` upload-ref predicate, remove dead `getDescription` helpers, and use `putIfAbsent` for map aggregation.
 - test: add unit tests for `Nsid` and `LexRef`.
 

--- a/packages/lex_gen/CHANGELOG.md
+++ b/packages/lex_gen/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Release Note
 
+## v0.4.1
+
+Internal readability/standardization/optimization refactor. Generated output is **byte-for-byte identical** to v0.4.0 (verified by hashing the raw generator output across `atproto`/`bluesky`/`bluesky_cli`), so no downstream regeneration is required.
+
+- refactor: introduce `Nsid` / `LexRef` value objects (`lib/src/model/`) that parse a lexicon id / ref once, replacing ~40 inline `split('.')` / `split('#')` sites across 8 files.
+- refactor: resolve a ref's related def in O(1) via a precomputed index instead of scanning every doc's every def per lookup (`getRelatedDocFromRef`).
+- refactor: replace the mutually-exclusive `isQuery`/`isProcedure`/`isSubscription`/`isRecord` (and command `isBlobProcedure`) boolean sets with `LexDefKind` / `LexCommandKind` sealed enums dispatched by exhaustive `switch`.
+- refactor: unify the four byte-identical freezed data-class templates (`LexObject`/`LexRecord`/`LexInput`/`LexOutput`) into a single `renderFreezedDataClass`.
+- perf: `getExtensions` name lookup is O(1) via a precomputed set (was O(n²)); `LexUnion` resolves each ref name once instead of four times.
+- refactor: fix the `_LexLexXrpc*` double-`Lex` type-name typos, deduplicate the record-accessor `rkey` literal handling and the `LexOutput` upload-ref predicate, remove dead `getDescription` helpers, and use `putIfAbsent` for map aggregation.
+- test: add unit tests for `Nsid` and `LexRef`.
+
 ## v0.4.0
 
 - fix: params-record refs are routed through the converter so a `$unknown` map picked up from a fetched object is no longer stored as a literal `$unknown` key on records written to the PDS (G-1).

--- a/packages/lex_gen/lib/src/commands/lex_command_generator.dart
+++ b/packages/lex_gen/lib/src/commands/lex_command_generator.dart
@@ -9,6 +9,7 @@ import 'dart:io';
 import 'package:lexicon/lexicon.dart';
 
 // Project imports:
+import '../config.dart';
 import '../model/lex_def_kind.dart';
 import 'rule.dart';
 import 'types/lex_command.dart';
@@ -16,8 +17,11 @@ import 'types/lex_parameter.dart';
 import 'types/lex_parent_command.dart';
 import 'types/lex_root_command.dart';
 
-void generateLexCommands(final List<LexiconDoc> docs) {
-  _cleanWorkspace();
+void generateLexCommands(
+  final LexCommandRuleConfig config,
+  final List<LexiconDoc> docs,
+) {
+  _cleanWorkspace(config);
 
   final result = <String, List<LexCommand>>{};
   for (final doc in docs) {
@@ -128,13 +132,18 @@ void generateLexCommands(final List<LexiconDoc> docs) {
   final parentCommands = <LexParentCommand>[];
   for (final entry in result.entries) {
     for (final command in entry.value) {
-      File(getAbsoluteFilePath(command.lexiconId.toString()))
+      File(getAbsoluteFilePath(config, command.lexiconId.toString()))
         ..createSync(recursive: true)
         ..writeAsStringSync(command.format());
     }
 
     final parentCommand = LexParentCommand(entry.key, entry.value);
-    File(getAbsoluteFilePathForParent(parentCommand.lexiconId.toString()))
+    File(
+        getAbsoluteFilePathForParent(
+          config,
+          parentCommand.lexiconId.toString(),
+        ),
+      )
       ..createSync(recursive: true)
       ..writeAsStringSync(parentCommand.format());
 
@@ -142,7 +151,7 @@ void generateLexCommands(final List<LexiconDoc> docs) {
   }
 
   final rootCommand = LexRootCommand(parentCommands);
-  File('${getHomeDir()}/lex_commands.dart')
+  File('${config.homeDir}/lex_commands.dart')
     ..createSync(recursive: true)
     ..writeAsStringSync(rootCommand.format());
 }
@@ -172,8 +181,8 @@ List<LexParameter> _getParameters(
   return parameters;
 }
 
-void _cleanWorkspace() {
-  final dir = Directory(getHomeDir());
+void _cleanWorkspace(final LexCommandRuleConfig config) {
+  final dir = Directory(config.homeDir);
   if (dir.existsSync()) dir.deleteSync(recursive: true);
 }
 

--- a/packages/lex_gen/lib/src/commands/lex_command_generator.dart
+++ b/packages/lex_gen/lib/src/commands/lex_command_generator.dart
@@ -9,6 +9,7 @@ import 'dart:io';
 import 'package:lexicon/lexicon.dart';
 
 // Project imports:
+import '../model/lex_def_kind.dart';
 import 'rule.dart';
 import 'types/lex_command.dart';
 import 'types/lex_parameter.dart';
@@ -34,7 +35,7 @@ void generateLexCommands(final List<LexiconDoc> docs) {
               query.parameters?.requiredProperties,
               query.parameters?.properties,
             ),
-            isQuery: true,
+            kind: LexCommandKind.query,
           ),
         );
       } else if (def.value is ULexUserTypeXrpcProcedure) {
@@ -51,7 +52,7 @@ void generateLexCommands(final List<LexiconDoc> docs) {
               doc.id,
               procedure.description,
               const [],
-              isProcedure: true,
+              kind: LexCommandKind.procedure,
             ),
           );
 
@@ -68,7 +69,7 @@ void generateLexCommands(final List<LexiconDoc> docs) {
               procedure.description,
               const [],
               encoding: input.encoding,
-              isBlobProcedure: true,
+              kind: LexCommandKind.blobProcedure,
             ),
           );
 
@@ -86,7 +87,7 @@ void generateLexCommands(final List<LexiconDoc> docs) {
               doc.id,
               procedure.description,
               const [],
-              isProcedure: true,
+              kind: LexCommandKind.procedure,
               isRawJsonBody: true,
             ),
           );
@@ -101,7 +102,7 @@ void generateLexCommands(final List<LexiconDoc> docs) {
             doc.id,
             procedure.description,
             _getParameters(object.requiredProperties, object.properties),
-            isProcedure: true,
+            kind: LexCommandKind.procedure,
           ),
         );
       } else if (def.value is ULexUserTypeXrpcSubscription) {
@@ -117,7 +118,7 @@ void generateLexCommands(final List<LexiconDoc> docs) {
             record.description,
             _getParameters(object.requiredProperties, object.properties),
             rkey: record.key,
-            isRecord: true,
+            kind: LexCommandKind.record,
           ),
         );
       }

--- a/packages/lex_gen/lib/src/commands/rule.dart
+++ b/packages/lex_gen/lib/src/commands/rule.dart
@@ -7,12 +7,6 @@ import '../config.dart';
 import '../model/nsid.dart';
 import '../utils.dart';
 
-LexCommandRuleConfig? _config;
-
-void setLexCommandRuleConfig(final LexCommandRuleConfig config) {
-  _config = config;
-}
-
 String getServiceId(final String lexiconId) {
   return Nsid(lexiconId).serviceId;
 }
@@ -57,21 +51,18 @@ String getParentCommandTypeName(final String lexiconId) {
   return '${name}Command';
 }
 
-String getAbsoluteFilePath(final String lexiconId) {
-  return '${getHomeDir()}/${getFilePath(lexiconId)}/${getFileName(lexiconId)}.dart';
+String getAbsoluteFilePath(
+  final LexCommandRuleConfig config,
+  final String lexiconId,
+) {
+  return '${config.homeDir}/${getFilePath(lexiconId)}/${getFileName(lexiconId)}.dart';
 }
 
-String getAbsoluteFilePathForParent(final String lexiconId) {
-  return '${getHomeDir()}/${getFilePathForParent(lexiconId)}/${getFileName(lexiconId)}.dart';
-}
-
-String getHomeDir() {
-  final config = _config;
-  if (config == null) {
-    throw StateError('Lex command rule config is not set');
-  }
-
-  return config.homeDir;
+String getAbsoluteFilePathForParent(
+  final LexCommandRuleConfig config,
+  final String lexiconId,
+) {
+  return '${config.homeDir}/${getFilePathForParent(lexiconId)}/${getFileName(lexiconId)}.dart';
 }
 
 String getFilePath(final String lexiconId) {

--- a/packages/lex_gen/lib/src/commands/rule.dart
+++ b/packages/lex_gen/lib/src/commands/rule.dart
@@ -4,6 +4,7 @@
 
 // Project imports:
 import '../config.dart';
+import '../model/nsid.dart';
 import '../utils.dart';
 
 LexCommandRuleConfig? _config;
@@ -13,21 +14,21 @@ void setLexCommandRuleConfig(final LexCommandRuleConfig config) {
 }
 
 String getServiceId(final String lexiconId) {
-  return lexiconId.split('.').sublist(0, 3).join('.');
+  return Nsid(lexiconId).serviceId;
 }
 
 String getServiceName(final String lexiconId) {
-  return getServiceId(lexiconId).split('.').join('-');
+  return getServiceId(lexiconId).replaceAll('.', '-');
 }
 
 String getCommandTypeName(final String lexiconId) {
-  final name = lexiconId.split('.').last;
+  final name = Nsid(lexiconId).method;
 
   return '${toFirstUpperCase(name)}Command';
 }
 
 String getCommandName(final String lexiconId) {
-  final name = lexiconId.split('.').last;
+  final name = Nsid(lexiconId).method;
 
   return _splitWords(name).map(toFirstLowerCase).join('-');
 }
@@ -51,7 +52,7 @@ List<String> _splitWords(final String name) {
 }
 
 String getParentCommandTypeName(final String lexiconId) {
-  final name = getServiceId(lexiconId).split('.').map(toFirstUpperCase).join();
+  final name = Nsid(lexiconId).segments.take(3).map(toFirstUpperCase).join();
 
   return '${name}Command';
 }
@@ -74,21 +75,21 @@ String getHomeDir() {
 }
 
 String getFilePath(final String lexiconId) {
-  return lexiconId.split('.').sublist(0, 3).join('/');
+  return Nsid(lexiconId).serviceIdDir;
 }
 
 String getFilePathForParent(final String lexiconId) {
-  return lexiconId.split('.').sublist(0, 2).join('/');
+  return Nsid(lexiconId).serviceDir;
 }
 
 String getFileName(final String lexiconId) {
-  return _splitWords(lexiconId.split('.').last).map(toFirstLowerCase).join('_');
+  return _splitWords(Nsid(lexiconId).method).map(toFirstLowerCase).join('_');
 }
 
 String getRelativePathForParent(final String lexiconId) {
-  return lexiconId.split('.').sublist(2, 3).join();
+  return Nsid(lexiconId).service;
 }
 
 String getRelativePathForRoot(final String lexiconId) {
-  return lexiconId.split('.').sublist(0, 2).join('/');
+  return Nsid(lexiconId).serviceDir;
 }

--- a/packages/lex_gen/lib/src/commands/types/lex_command.dart
+++ b/packages/lex_gen/lib/src/commands/types/lex_command.dart
@@ -275,23 +275,6 @@ $contentTypeOverride}
 
     final rkeyOverride = _getReferenceKeyOverride();
 
-    final deleteOpts = literalRkey == null
-        ? 'argParser..addOption("rkey", help: r"The record key.", mandatory: true,);'
-        : '';
-    final deleteInvocation = literalRkey == null
-        ? 'bsky $serviceName $commandName delete --rkey=<value>'
-        : 'bsky $serviceName $commandName delete';
-
-    final getRkeyOpt = literalRkey == null
-        ? '..addOption("rkey", help: r"The record key.", mandatory: true,)'
-        : '';
-    final getRkeyValue = literalRkey == null
-        ? "argResults!['rkey']"
-        : "'$literalRkey'";
-    final getInvocation = literalRkey == null
-        ? 'bsky $serviceName $commandName get --rkey=<value> [--repo=<value>] [--cid=<value>]'
-        : 'bsky $serviceName $commandName get [--repo=<value>] [--cid=<value>]';
-
     return '''$kHeaderHint
 
 import 'dart:async';
@@ -329,61 +312,83 @@ mixin $recordArgsMixin on Command<void> {
   }
 ${_getInputHelpers()}}
 
-final class _Create$typeName extends CreateRecordCommand with $recordArgsMixin {
-  _Create$typeName() {
+${_recordMutationClass(typeName: typeName, classPrefix: 'Create', baseClass: 'CreateRecordCommand', recordArgsMixin: recordArgsMixin, rkeyStmt: createRkeyStmt, name: 'create', descriptionVerb: 'Creates a new record', invocation: invocationForCreation, rkeyOverride: rkeyOverride, parameters: parameters)}
+
+${_recordMutationClass(typeName: typeName, classPrefix: 'Put', baseClass: 'PutRecordCommand', recordArgsMixin: recordArgsMixin, rkeyStmt: putRkeyStmt, name: 'put', descriptionVerb: 'Updates a record', invocation: invocationForUpdate, rkeyOverride: rkeyOverride, parameters: parameters)}
+
+${_deleteRecordClass(typeName, serviceName, commandName, literalRkey)}
+
+${_getRecordClass(typeName, serviceName, commandName, literalRkey)}
+
+${_listRecordClass(typeName, serviceName, commandName)}
+''';
+  }
+
+  /// Method id for the shared `com.atproto.repo` record read endpoints, emitted
+  /// into the generated `get`/`list` record subcommands.
+  static const _getRecordMethodId = 'com.atproto.repo.getRecord';
+  static const _listRecordsMethodId = 'com.atproto.repo.listRecords';
+
+  /// Renders a `create` or `put` record subcommand. The two differ only by the
+  /// [classPrefix]/[baseClass], their `rkey` option ([rkeyStmt]), [name],
+  /// [descriptionVerb] and [invocation]; everything else is shared.
+  String _recordMutationClass({
+    required final String typeName,
+    required final String classPrefix,
+    required final String baseClass,
+    required final String recordArgsMixin,
+    required final String rkeyStmt,
+    required final String name,
+    required final String descriptionVerb,
+    required final String invocation,
+    required final String rkeyOverride,
+    required final String parameters,
+  }) {
+    final id = lexiconId.toString();
+
+    return '''final class _$classPrefix$typeName extends $baseClass with $recordArgsMixin {
+  _$classPrefix$typeName() {
     _addRecordOptions();
-    $createRkeyStmt
+    $rkeyStmt
   }
 
   @override
-  final String name = "create";
+  final String name = "$name";
 
   @override
-  final String description = r"Creates a new record for ${lexiconId.toString()}.";
+  final String description = r"$descriptionVerb for $id.";
 
   @override
-  final String invocation = "$invocationForCreation";
+  final String invocation = "$invocation";
 
   $rkeyOverride
 
   @override
-  String get collection => "${lexiconId.toString()}";
+  String get collection => "$id";
 
   @override
   Map<String, dynamic> get record => {
-    r"\$type": "${lexiconId.toString()}",
+    r"\$type": "$id",
     $parameters
   };
-}
-
-final class _Put$typeName extends PutRecordCommand with $recordArgsMixin {
-  _Put$typeName() {
-    _addRecordOptions();
-    $putRkeyStmt
+}''';
   }
 
-  @override
-  final String name = "put";
+  String _deleteRecordClass(
+    final String typeName,
+    final String serviceName,
+    final String commandName,
+    final String? literalRkey,
+  ) {
+    final id = lexiconId.toString();
+    final deleteOpts = literalRkey == null
+        ? 'argParser..addOption("rkey", help: r"The record key.", mandatory: true,);'
+        : '';
+    final deleteInvocation = literalRkey == null
+        ? 'bsky $serviceName $commandName delete --rkey=<value>'
+        : 'bsky $serviceName $commandName delete';
 
-  @override
-  final String description = r"Updates a record for ${lexiconId.toString()}.";
-
-  @override
-  final String invocation = "$invocationForUpdate";
-
-  $rkeyOverride
-
-  @override
-  String get collection => "${lexiconId.toString()}";
-
-  @override
-  Map<String, dynamic> get record => {
-    r"\$type": "${lexiconId.toString()}",
-    $parameters
-  };
-}
-
-final class _Delete$typeName extends DeleteRecordCommand {
+    return '''final class _Delete$typeName extends DeleteRecordCommand {
   _Delete$typeName() {
     $deleteOpts
   }
@@ -392,7 +397,7 @@ final class _Delete$typeName extends DeleteRecordCommand {
   final String name = "delete";
 
   @override
-  final String description = r"Deletes a record for ${lexiconId.toString()}.";
+  final String description = r"Deletes a record for $id.";
 
   @override
   final String invocation = "$deleteInvocation";
@@ -400,10 +405,28 @@ final class _Delete$typeName extends DeleteRecordCommand {
   ${_getReferenceKeyOverride(nullable: false)}
 
   @override
-  String get collection => "${lexiconId.toString()}";
-}
+  String get collection => "$id";
+}''';
+  }
 
-final class _Get$typeName extends QueryCommand {
+  String _getRecordClass(
+    final String typeName,
+    final String serviceName,
+    final String commandName,
+    final String? literalRkey,
+  ) {
+    final id = lexiconId.toString();
+    final getRkeyOpt = literalRkey == null
+        ? '..addOption("rkey", help: r"The record key.", mandatory: true,)'
+        : '';
+    final getRkeyValue = literalRkey == null
+        ? "argResults!['rkey']"
+        : "'$literalRkey'";
+    final getInvocation = literalRkey == null
+        ? 'bsky $serviceName $commandName get --rkey=<value> [--repo=<value>] [--cid=<value>]'
+        : 'bsky $serviceName $commandName get [--repo=<value>] [--cid=<value>]';
+
+    return '''final class _Get$typeName extends QueryCommand {
   _Get$typeName() {
     argParser
       $getRkeyOpt
@@ -415,23 +438,31 @@ final class _Get$typeName extends QueryCommand {
   final String name = "get";
 
   @override
-  final String description = r"Gets a record for ${lexiconId.toString()}.";
+  final String description = r"Gets a record for $id.";
 
   @override
   final String invocation = "$getInvocation";
 
   @override
-  String get methodId => "com.atproto.repo.getRecord";
+  String get methodId => "$_getRecordMethodId";
 
   @override
   FutureOr<Map<String, dynamic>>? get parameters async => {
     'repo': argResults!['repo'] ?? await did,
-    'collection': "${lexiconId.toString()}",
+    'collection': "$id",
     'rkey': $getRkeyValue,
     if (argResults!['cid'] != null) 'cid': argResults!['cid'],};
-}
+}''';
+  }
 
-final class _List$typeName extends QueryCommand {
+  String _listRecordClass(
+    final String typeName,
+    final String serviceName,
+    final String commandName,
+  ) {
+    final id = lexiconId.toString();
+
+    return '''final class _List$typeName extends QueryCommand {
   _List$typeName() {
     argParser
       ..addOption("repo", help: r"The repo (handle or DID). Defaults to the authenticated user.",)
@@ -444,24 +475,23 @@ final class _List$typeName extends QueryCommand {
   final String name = "list";
 
   @override
-  final String description = r"Lists records for ${lexiconId.toString()}.";
+  final String description = r"Lists records for $id.";
 
   @override
   final String invocation = "bsky $serviceName $commandName list [--repo=<value>] [--limit=<value>] [--cursor=<value>] [--reverse]";
 
   @override
-  String get methodId => "com.atproto.repo.listRecords";
+  String get methodId => "$_listRecordsMethodId";
 
   @override
   FutureOr<Map<String, dynamic>>? get parameters async => {
     'repo': argResults!['repo'] ?? await did,
-    'collection': "${lexiconId.toString()}",
+    'collection': "$id",
     'limit': int.tryParse(argResults!['limit']) ?? usageException(r'Invalid integer value for option "limit".'),
     if (argResults!['cursor'] != null) 'cursor': argResults!['cursor'],
     'reverse': argResults!['reverse'],
   };
-}
-''';
+}''';
   }
 
   String _getDescription() {

--- a/packages/lex_gen/lib/src/commands/types/lex_command.dart
+++ b/packages/lex_gen/lib/src/commands/types/lex_command.dart
@@ -6,6 +6,7 @@
 import 'package:lexicon/lexicon.dart';
 
 // Project imports:
+import '../../model/lex_def_kind.dart';
 import '../../utils.dart';
 import '../rule.dart';
 import 'lex_parameter.dart';
@@ -20,11 +21,7 @@ final class LexCommand {
   /// The input encoding for blob procedures, e.g. `*/*`, `video/mp4`.
   final String? encoding;
 
-  final bool isQuery;
-  final bool isProcedure;
-  final bool isSubscription;
-  final bool isRecord;
-  final bool isBlobProcedure;
+  final LexCommandKind kind;
 
   /// Whether the procedure input schema is a ref or union, meaning
   /// the entire request body is passed as a single JSON string.
@@ -34,23 +31,19 @@ final class LexCommand {
     this.lexiconId,
     this.description,
     this.parameters, {
+    required this.kind,
     this.rkey,
     this.encoding,
-    this.isQuery = false,
-    this.isProcedure = false,
-    this.isSubscription = false,
-    this.isRecord = false,
-    this.isBlobProcedure = false,
     this.isRawJsonBody = false,
   });
 
   String format() {
-    if (isQuery) return _getQueryCommand();
-    if (isBlobProcedure) return _getBlobProcedureCommand();
-    if (isProcedure) return _getProcedureCommand();
-    if (isRecord) return _getRecordCommand();
-
-    throw UnimplementedError();
+    return switch (kind) {
+      LexCommandKind.query => _getQueryCommand(),
+      LexCommandKind.blobProcedure => _getBlobProcedureCommand(),
+      LexCommandKind.procedure => _getProcedureCommand(),
+      LexCommandKind.record => _getRecordCommand(),
+    };
   }
 
   String _getQueryCommand() {

--- a/packages/lex_gen/lib/src/gen.dart
+++ b/packages/lex_gen/lib/src/gen.dart
@@ -4,12 +4,11 @@
 
 // Project imports:
 import 'commands/lex_command_generator.dart';
-import 'commands/rule.dart' as command_rule;
 import 'config.dart';
+import 'services/gen_context.dart';
 import 'services/lex_service_generator.dart';
 import 'services/lex_tools_generator.dart';
 import 'services/lex_type_generator.dart';
-import 'services/rule.dart' as service_rule;
 import 'utils.dart';
 
 sealed class Gen {
@@ -29,13 +28,15 @@ final class ServiceGen implements Gen {
 
     final docs = config.docsProvider();
 
-    service_rule.setLexServiceRuleConfig(config.serviceRuleConfig);
-    service_rule.setLexiconDocs(docs);
+    final ctx = GenContext(
+      serviceRuleConfig: config.serviceRuleConfig,
+      docs: docs,
+    );
 
-    final types = generateLexTypes(config.services, config.packages, docs);
-    generateLexServices(config.services, config.packages, types, docs);
+    final types = generateLexTypes(ctx, config.services, config.packages, docs);
+    generateLexServices(ctx, config.services, config.packages, types, docs);
 
-    generateLexTools(docs);
+    generateLexTools(ctx, docs);
   }
 }
 
@@ -48,8 +49,6 @@ final class CommandGen implements Gen {
   void execute() {
     final docs = config.docsProvider();
 
-    command_rule.setLexCommandRuleConfig(config.commandRuleConfig);
-
-    generateLexCommands(docs);
+    generateLexCommands(config.commandRuleConfig, docs);
   }
 }

--- a/packages/lex_gen/lib/src/model/lex_def_kind.dart
+++ b/packages/lex_gen/lib/src/model/lex_def_kind.dart
@@ -1,0 +1,20 @@
+// Copyright (c) 2023-2026, Shinya Kato.
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// The four top-level Lexicon definition kinds the generator turns into an
+/// API surface.
+///
+/// These historically travelled as a set of mutually-exclusive `isQuery` /
+/// `isProcedure` / `isSubscription` / `isRecord` booleans dispatched through
+/// `if`/`else` chains. Modelling them as a single enum lets call sites
+/// `switch` exhaustively instead.
+enum LexDefKind { query, procedure, subscription, record }
+
+/// The command variants the CLI generator emits.
+///
+/// Mirrors [LexDefKind] but splits out `blobProcedure` (a procedure whose
+/// input is an uploaded blob rather than a JSON body) and drops
+/// `subscription`, which the command generator does not emit. Replaces the
+/// `isQuery` / `isProcedure` / `isBlobProcedure` / `isRecord` boolean set.
+enum LexCommandKind { query, procedure, blobProcedure, record }

--- a/packages/lex_gen/lib/src/model/lex_ref.dart
+++ b/packages/lex_gen/lib/src/model/lex_ref.dart
@@ -1,0 +1,54 @@
+// Copyright (c) 2023-2026, Shinya Kato.
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// Project imports:
+import 'nsid.dart';
+
+/// A parsed Lexicon reference (`ref`).
+///
+/// A raw ref appears in three shapes that the generator repeatedly re-decodes
+/// inline via `startsWith('#')` / `contains('#')` / `split('#')`:
+///
+/// * [LocalRef]   – `#draftEmbedGalleryItems` – a def within the same doc.
+/// * [ForeignRef] – `app.bsky.actor.defs#profileView` – a def in another doc.
+/// * [BareRef]    – `app.bsky.actor.profile` – a whole doc's main def.
+///
+/// [LexRef.parse] classifies the ref once so call sites can `switch` over the
+/// sealed hierarchy instead of duplicating the string surgery.
+sealed class LexRef {
+  const LexRef();
+
+  factory LexRef.parse(final String ref) {
+    if (ref.startsWith('#')) {
+      return LocalRef(ref.substring(1));
+    }
+    if (ref.contains('#')) {
+      final parts = ref.split('#');
+      return ForeignRef(Nsid(parts.first), parts.last);
+    }
+    return BareRef(Nsid(ref));
+  }
+}
+
+/// A ref to a def in the same document, e.g. `#profileView`.
+final class LocalRef extends LexRef {
+  const LocalRef(this.defName);
+
+  final String defName;
+}
+
+/// A ref to a def in another document, e.g. `app.bsky.actor.defs#profileView`.
+final class ForeignRef extends LexRef {
+  const ForeignRef(this.lexicon, this.defName);
+
+  final Nsid lexicon;
+  final String defName;
+}
+
+/// A ref to a whole document's main def, e.g. `app.bsky.actor.profile`.
+final class BareRef extends LexRef {
+  const BareRef(this.lexicon);
+
+  final Nsid lexicon;
+}

--- a/packages/lex_gen/lib/src/model/nsid.dart
+++ b/packages/lex_gen/lib/src/model/nsid.dart
@@ -1,0 +1,70 @@
+// Copyright (c) 2023-2026, Shinya Kato.
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// Project imports:
+import '../utils.dart';
+
+/// A parsed Lexicon namespace identifier (NSID).
+///
+/// The generator repeatedly decomposes a raw dotted id such as
+/// `app.bsky.actor.profile` into its authority, service, method and various
+/// path/name spellings. Historically each call site re-ran the same
+/// `split('.').sublist(...).join(...)` surgery inline. [Nsid] parses the id
+/// exactly once and exposes those spellings as named accessors so the
+/// intent is explicit and the string handling lives in one place.
+final class Nsid {
+  Nsid(this.raw) : segments = raw.split('.');
+
+  final String raw;
+
+  /// The dot-separated segments, e.g. `[app, bsky, actor, profile]`.
+  final List<String> segments;
+
+  /// The 2-part authority, e.g. `app.bsky`.
+  String get authority => segments.take(2).join('.');
+
+  /// The service segment (index 2), e.g. `actor`.
+  String get service => segments[2];
+
+  /// The last segment, e.g. `profile`.
+  String get method => segments.last;
+
+  /// Every segment joined by `/`, e.g. `app/bsky/actor/profile`.
+  String get fileDir => segments.join('/');
+
+  /// The authority joined by `/`, e.g. `app/bsky`.
+  String get serviceDir => segments.take(2).join('/');
+
+  /// The first three segments joined by `.`, e.g. `app.bsky.actor`.
+  String get serviceId => segments.take(3).join('.');
+
+  /// The first three segments joined by `/`, e.g. `app/bsky/actor`.
+  String get serviceIdDir => segments.take(3).join('/');
+
+  /// Every segment lower-cased and joined by `_`, e.g. `app_bsky_actor_profile`.
+  String get packageName => segments.join('_').toLowerCase();
+
+  /// Segments after the authority, capped at two, e.g.
+  /// `app.bsky.actor.profile` -> `[actor, profile]`, while a shorter id such
+  /// as `com.germnetwork.declaration` -> `[declaration]`.
+  List<String> nameSegments() {
+    final end = segments.length < 4 ? segments.length : 4;
+    return segments.sublist(2, end);
+  }
+
+  /// Segments after the authority, e.g.
+  /// `app.bsky.actor.profile` -> `[actor, profile]`.
+  List<String> segmentsAfterAuthority() => segments.sublist(2);
+
+  /// Segments after the authority joined by `/`, e.g.
+  /// `app.bsky.actor.profile` -> `actor/profile`.
+  String get dirAfterAuthority => segmentsAfterAuthority().join('/');
+
+  /// The PascalCase concatenation of every segment, e.g.
+  /// `AppBskyActorProfile`.
+  String pascalCase() => segments.map(toFirstUpperCase).join();
+
+  @override
+  String toString() => raw;
+}

--- a/packages/lex_gen/lib/src/services/fmt/lex_object_generator.dart
+++ b/packages/lex_gen/lib/src/services/fmt/lex_object_generator.dart
@@ -6,24 +6,34 @@
 import 'package:lexicon/lexicon.dart' as lex;
 
 // Project imports:
+import '../gen_context.dart';
 import '../object/lex_object.dart';
 import '../rule.dart' as rule;
 import 'lex_property_generator.dart';
 
 LexObject generateLexObject(
+  final GenContext ctx,
   final lex.NSID lexiconId,
   final String defName,
   final lex.LexObject object,
   final List<String> mainVariants,
-) => _LexObjectGenerator(lexiconId, defName, object, mainVariants).execute();
+) => _LexObjectGenerator(
+  ctx,
+  lexiconId,
+  defName,
+  object,
+  mainVariants,
+).execute();
 
 final class _LexObjectGenerator {
+  final GenContext ctx;
   final lex.NSID lexiconId;
   final String defName;
   final lex.LexObject object;
   final List<String> mainVariants;
 
   _LexObjectGenerator(
+    this.ctx,
     this.lexiconId,
     this.defName,
     this.object,
@@ -37,6 +47,7 @@ final class _LexObjectGenerator {
       name: rule.getLexObjectName(lexiconId.toString(), defName, mainVariants),
       description: object.description,
       properties: generateLexProperties(
+        ctx,
         lexiconId,
         defName,
         object.properties,

--- a/packages/lex_gen/lib/src/services/fmt/lex_packages_generator.dart
+++ b/packages/lex_gen/lib/src/services/fmt/lex_packages_generator.dart
@@ -47,7 +47,7 @@ List<LexPackage> generateLexPackagesForService(
   return lexPackages;
 }
 
-List<LexPackage> generateLexPackages(final List<LexType> types) {
+List<LexPackage> generateLexPackages(final List<GeneratableType> types) {
   final packages = <String, Set<String>>{};
   for (final type in types) {
     if (type.isShouldNotBeGenerated()) continue;

--- a/packages/lex_gen/lib/src/services/fmt/lex_packages_generator.dart
+++ b/packages/lex_gen/lib/src/services/fmt/lex_packages_generator.dart
@@ -4,12 +4,14 @@
 
 // Project imports:
 import '../../model/nsid.dart';
+import '../gen_context.dart';
 import '../object/lex_package.dart';
 import '../object/lex_service.dart';
 import '../object/lex_type.dart';
 import '../rule.dart' as rule;
 
 List<LexPackage> generateLexPackagesForService(
+  final GenContext ctx,
   final List<LexService> services,
 ) {
   final packages = <String, Set<String>>{};
@@ -20,6 +22,7 @@ List<LexPackage> generateLexPackagesForService(
         .putIfAbsent(key, () => <String>{})
         .add(
           rule.getLexObjectAbsolutePathForService(
+            ctx,
             service.lexiconId,
             service.getFileName(),
           ),
@@ -30,7 +33,7 @@ List<LexPackage> generateLexPackagesForService(
   for (final package in packages.entries) {
     final lexiconId = package.key;
 
-    final root = rule.getRootPackageName(lexiconId);
+    final root = rule.getRootPackageName(ctx, lexiconId);
     final name = rule.getPackageName(
       lexiconId.substring(0, lexiconId.length - 1),
     );
@@ -47,21 +50,30 @@ List<LexPackage> generateLexPackagesForService(
   return lexPackages;
 }
 
-List<LexPackage> generateLexPackages(final List<GeneratableType> types) {
+List<LexPackage> generateLexPackages(
+  final GenContext ctx,
+  final List<GeneratableType> types,
+) {
   final packages = <String, Set<String>>{};
   for (final type in types) {
     if (type.isShouldNotBeGenerated()) continue;
 
     packages
         .putIfAbsent(type.lexiconId, () => <String>{})
-        .add(rule.getLexObjectAbsolutePath(type.lexiconId, type.getFileName()));
+        .add(
+          rule.getLexObjectAbsolutePath(
+            ctx,
+            type.lexiconId,
+            type.getFileName(),
+          ),
+        );
   }
 
   final lexPackages = <LexPackage>[];
   for (final package in packages.entries) {
     final lexiconId = package.key;
 
-    final root = rule.getRootPackageName(lexiconId);
+    final root = rule.getRootPackageName(ctx, lexiconId);
     final name = rule.getPackageName(lexiconId);
 
     lexPackages.add(

--- a/packages/lex_gen/lib/src/services/fmt/lex_packages_generator.dart
+++ b/packages/lex_gen/lib/src/services/fmt/lex_packages_generator.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 // Project imports:
+import '../../model/nsid.dart';
 import '../object/lex_package.dart';
 import '../object/lex_service.dart';
 import '../object/lex_type.dart';
@@ -14,22 +15,15 @@ List<LexPackage> generateLexPackagesForService(
   final packages = <String, Set<String>>{};
 
   for (final service in services) {
-    final key = '${service.lexiconId.split('.').sublist(0, 2).join('.')}.';
-    if (packages.containsKey(key)) {
-      packages[key]!.add(
-        rule.getLexObjectAbsolutePathForService(
-          service.lexiconId,
-          service.getFileName(),
-        ),
-      );
-    } else {
-      packages[key] = <String>{
-        rule.getLexObjectAbsolutePathForService(
-          service.lexiconId,
-          service.getFileName(),
-        ),
-      };
-    }
+    final key = '${Nsid(service.lexiconId).authority}.';
+    packages
+        .putIfAbsent(key, () => <String>{})
+        .add(
+          rule.getLexObjectAbsolutePathForService(
+            service.lexiconId,
+            service.getFileName(),
+          ),
+        );
   }
 
   final lexPackages = <LexPackage>[];
@@ -58,15 +52,9 @@ List<LexPackage> generateLexPackages(final List<LexType> types) {
   for (final type in types) {
     if (type.isShouldNotBeGenerated()) continue;
 
-    if (packages.containsKey(type.lexiconId)) {
-      packages[type.lexiconId]!.add(
-        rule.getLexObjectAbsolutePath(type.lexiconId, type.getFileName()),
-      );
-    } else {
-      packages[type.lexiconId] = <String>{
-        rule.getLexObjectAbsolutePath(type.lexiconId, type.getFileName()),
-      };
-    }
+    packages
+        .putIfAbsent(type.lexiconId, () => <String>{})
+        .add(rule.getLexObjectAbsolutePath(type.lexiconId, type.getFileName()));
   }
 
   final lexPackages = <LexPackage>[];

--- a/packages/lex_gen/lib/src/services/fmt/lex_property_generator.dart
+++ b/packages/lex_gen/lib/src/services/fmt/lex_property_generator.dart
@@ -7,12 +7,14 @@ import 'package:lexicon/lexicon.dart' as lex;
 
 // Project imports:
 import '../../dart_type.dart';
+import '../gen_context.dart';
 import '../object/lex_property.dart';
 import '../rule.dart' as rule;
 import 'lex_known_values_generator.dart';
 import 'lex_union_generator.dart';
 
 List<LexProperty> generateLexPropertiesFromLexXrpcParameters(
+  final GenContext ctx,
   final lex.NSID lexiconId,
   final String defName,
   final Map<String, lex.LexXrpcParametersProperty>? properties,
@@ -30,6 +32,7 @@ List<LexProperty> generateLexPropertiesFromLexXrpcParameters(
   );
 
   return generateLexProperties(
+    ctx,
     lexiconId,
     defName,
     $properties,
@@ -40,6 +43,7 @@ List<LexProperty> generateLexPropertiesFromLexXrpcParameters(
 }
 
 List<LexProperty> generateLexProperties(
+  final GenContext ctx,
   final lex.NSID lexiconId,
   final String defName,
   final Map<String, lex.LexObjectProperty>? properties,
@@ -57,6 +61,7 @@ List<LexProperty> generateLexProperties(
   final result = <LexProperty>[];
   for (final property in properties.entries) {
     final type = _getDartType(
+      ctx,
       property,
       lexiconId,
       defName,
@@ -137,6 +142,7 @@ String _escapeDartString(final String value) {
 }
 
 DartType _getDartType(
+  final GenContext ctx,
   final MapEntry<String, lex.LexObjectProperty> property,
   final lex.NSID lexiconId,
   final String defName,
@@ -209,6 +215,7 @@ DartType _getDartType(
 
         case lex.ULexArrayRefVariant refVariant:
           final type = _getLexRefVariantType(
+            ctx,
             refVariant.data,
             lexiconId,
             defName,
@@ -234,6 +241,7 @@ DartType _getDartType(
 
     case lex.ULexObjectPropertyRefVariant refVariant:
       return _getLexRefVariantType(
+        ctx,
         refVariant.data,
         lexiconId,
         defName,
@@ -323,6 +331,7 @@ DartType _getIpldType(final lex.LexIpld ipld) {
 }
 
 DartType _getLexRefVariantType(
+  final GenContext ctx,
   final lex.LexRefVariant ref,
   final lex.NSID lexiconId,
   final String defName,
@@ -336,6 +345,7 @@ DartType _getLexRefVariantType(
       bool isUnion = false;
 
       final relatedDoc = rule.getRelatedDocFromRef(
+        ctx,
         ref.data.ref,
         lexiconId: lexiconId.toString(),
       );
@@ -370,6 +380,7 @@ DartType _getLexRefVariantType(
         fieldName: isUnion ? fieldName : '',
         ref: ref.data.ref!,
         packagePath: rule.getLexObjectPackagePathFromRef(
+          ctx,
           lexiconId.toString(),
           ref.data.ref!,
           isUnion: isUnion,

--- a/packages/lex_gen/lib/src/services/fmt/lex_record_generator.dart
+++ b/packages/lex_gen/lib/src/services/fmt/lex_record_generator.dart
@@ -6,24 +6,34 @@
 import 'package:lexicon/lexicon.dart' as lex;
 
 // Project imports:
+import '../gen_context.dart';
 import '../object/lex_record.dart';
 import '../rule.dart' as rule;
 import 'lex_property_generator.dart';
 
 LexRecord generateLexRecord(
+  final GenContext ctx,
   final lex.NSID lexiconId,
   final String defName,
   final lex.LexRecord record,
   final List<String> mainVariants,
-) => _LexRecordGenerator(lexiconId, defName, record, mainVariants).execute();
+) => _LexRecordGenerator(
+  ctx,
+  lexiconId,
+  defName,
+  record,
+  mainVariants,
+).execute();
 
 final class _LexRecordGenerator {
+  final GenContext ctx;
   final lex.NSID lexiconId;
   final String defName;
   final lex.LexRecord record;
   final List<String> mainVariants;
 
   _LexRecordGenerator(
+    this.ctx,
     this.lexiconId,
     this.defName,
     this.record,
@@ -37,6 +47,7 @@ final class _LexRecordGenerator {
       name: rule.getLexObjectName(lexiconId.toString(), defName, mainVariants),
       description: record.description,
       properties: generateLexProperties(
+        ctx,
         lexiconId,
         defName,
         record.record.properties,

--- a/packages/lex_gen/lib/src/services/fmt/lex_xrpc_procedure_generator.dart
+++ b/packages/lex_gen/lib/src/services/fmt/lex_xrpc_procedure_generator.dart
@@ -17,7 +17,7 @@ import 'lex_property_generator.dart';
   final lex.LexXrpcProcedure procedure,
   final List<String> mainVariants,
 ) {
-  return _LexLexXrpcProcedureGenerator(
+  return _LexXrpcProcedureGenerator(
     lexiconId,
     defName,
     procedure,
@@ -25,13 +25,13 @@ import 'lex_property_generator.dart';
   ).execute();
 }
 
-final class _LexLexXrpcProcedureGenerator {
+final class _LexXrpcProcedureGenerator {
   final lex.NSID lexiconId;
   final String defName;
   final lex.LexXrpcProcedure procedure;
   final List<String> mainVariants;
 
-  _LexLexXrpcProcedureGenerator(
+  _LexXrpcProcedureGenerator(
     this.lexiconId,
     this.defName,
     this.procedure,

--- a/packages/lex_gen/lib/src/services/fmt/lex_xrpc_procedure_generator.dart
+++ b/packages/lex_gen/lib/src/services/fmt/lex_xrpc_procedure_generator.dart
@@ -6,18 +6,21 @@
 import 'package:lexicon/lexicon.dart' as lex;
 
 // Project imports:
+import '../gen_context.dart';
 import '../object/lex_input.dart';
 import '../object/lex_output.dart';
 import '../rule.dart' as rule;
 import 'lex_property_generator.dart';
 
 (LexInput?, LexOutput?)? generateLexXrpcProcedure(
+  final GenContext ctx,
   final lex.NSID lexiconId,
   final String defName,
   final lex.LexXrpcProcedure procedure,
   final List<String> mainVariants,
 ) {
   return _LexXrpcProcedureGenerator(
+    ctx,
     lexiconId,
     defName,
     procedure,
@@ -26,12 +29,14 @@ import 'lex_property_generator.dart';
 }
 
 final class _LexXrpcProcedureGenerator {
+  final GenContext ctx;
   final lex.NSID lexiconId;
   final String defName;
   final lex.LexXrpcProcedure procedure;
   final List<String> mainVariants;
 
   _LexXrpcProcedureGenerator(
+    this.ctx,
     this.lexiconId,
     this.defName,
     this.procedure,
@@ -61,6 +66,7 @@ final class _LexXrpcProcedureGenerator {
     final object = procedure.input?.schema?.whenOrNull(object: (e) => e);
     if (object != null) {
       final properties = generateLexProperties(
+        ctx,
         lexiconId,
         defName,
         object.properties,
@@ -105,6 +111,7 @@ final class _LexXrpcProcedureGenerator {
 
     if (object != null) {
       final properties = generateLexProperties(
+        ctx,
         lexiconId,
         defName,
         object.properties,

--- a/packages/lex_gen/lib/src/services/fmt/lex_xrpc_query_generator.dart
+++ b/packages/lex_gen/lib/src/services/fmt/lex_xrpc_query_generator.dart
@@ -17,7 +17,7 @@ import 'lex_property_generator.dart';
   final lex.LexXrpcQuery query,
   final List<String> mainVariants,
 ) {
-  return _LexLexXrpcQueryGenerator(
+  return _LexXrpcQueryGenerator(
     lexiconId,
     defName,
     query,
@@ -25,13 +25,13 @@ import 'lex_property_generator.dart';
   ).execute();
 }
 
-final class _LexLexXrpcQueryGenerator {
+final class _LexXrpcQueryGenerator {
   final lex.NSID lexiconId;
   final String defName;
   final lex.LexXrpcQuery query;
   final List<String> mainVariants;
 
-  _LexLexXrpcQueryGenerator(
+  _LexXrpcQueryGenerator(
     this.lexiconId,
     this.defName,
     this.query,

--- a/packages/lex_gen/lib/src/services/fmt/lex_xrpc_query_generator.dart
+++ b/packages/lex_gen/lib/src/services/fmt/lex_xrpc_query_generator.dart
@@ -6,18 +6,21 @@
 import 'package:lexicon/lexicon.dart' as lex;
 
 // Project imports:
+import '../gen_context.dart';
 import '../object/lex_input.dart';
 import '../object/lex_output.dart';
 import '../rule.dart' as rule;
 import 'lex_property_generator.dart';
 
 (LexInput?, LexOutput?)? generateLexXrpcQuery(
+  final GenContext ctx,
   final lex.NSID lexiconId,
   final String defName,
   final lex.LexXrpcQuery query,
   final List<String> mainVariants,
 ) {
   return _LexXrpcQueryGenerator(
+    ctx,
     lexiconId,
     defName,
     query,
@@ -26,12 +29,14 @@ import 'lex_property_generator.dart';
 }
 
 final class _LexXrpcQueryGenerator {
+  final GenContext ctx;
   final lex.NSID lexiconId;
   final String defName;
   final lex.LexXrpcQuery query;
   final List<String> mainVariants;
 
   _LexXrpcQueryGenerator(
+    this.ctx,
     this.lexiconId,
     this.defName,
     this.query,
@@ -49,6 +54,7 @@ final class _LexXrpcQueryGenerator {
     final parameters = query.parameters!;
 
     final properties = generateLexPropertiesFromLexXrpcParameters(
+      ctx,
       lexiconId,
       defName,
       parameters.properties,
@@ -84,6 +90,7 @@ final class _LexXrpcQueryGenerator {
     final object = output?.schema?.whenOrNull(object: (e) => e);
     if (object != null) {
       final properties = generateLexProperties(
+        ctx,
         lexiconId,
         defName,
         object.properties,

--- a/packages/lex_gen/lib/src/services/fmt/lex_xrpc_subscription_generator.dart
+++ b/packages/lex_gen/lib/src/services/fmt/lex_xrpc_subscription_generator.dart
@@ -6,6 +6,7 @@
 import 'package:lexicon/lexicon.dart' as lex;
 
 // Project imports:
+import '../gen_context.dart';
 import '../object/lex_input.dart';
 import '../object/lex_message.dart';
 import '../rule.dart' as rule;
@@ -13,12 +14,14 @@ import 'lex_property_generator.dart';
 import 'lex_union_generator.dart';
 
 (LexInput?, LexMessage?)? generateLexXrpcSubscription(
+  final GenContext ctx,
   final lex.NSID lexiconId,
   final String defName,
   final lex.LexXrpcSubscription subscription,
   final List<String> mainVariants,
 ) {
   return _LexXrpcSubscriptionGenerator(
+    ctx,
     lexiconId,
     defName,
     subscription,
@@ -27,12 +30,14 @@ import 'lex_union_generator.dart';
 }
 
 final class _LexXrpcSubscriptionGenerator {
+  final GenContext ctx;
   final lex.NSID lexiconId;
   final String defName;
   final lex.LexXrpcSubscription subscription;
   final List<String> mainVariants;
 
   _LexXrpcSubscriptionGenerator(
+    this.ctx,
     this.lexiconId,
     this.defName,
     this.subscription,
@@ -50,6 +55,7 @@ final class _LexXrpcSubscriptionGenerator {
     final parameters = subscription.parameters!;
 
     final properties = generateLexPropertiesFromLexXrpcParameters(
+      ctx,
       lexiconId,
       defName,
       parameters.properties,

--- a/packages/lex_gen/lib/src/services/fmt/lex_xrpc_subscription_generator.dart
+++ b/packages/lex_gen/lib/src/services/fmt/lex_xrpc_subscription_generator.dart
@@ -18,7 +18,7 @@ import 'lex_union_generator.dart';
   final lex.LexXrpcSubscription subscription,
   final List<String> mainVariants,
 ) {
-  return _LexLexXrpcSubscriptionGenerator(
+  return _LexXrpcSubscriptionGenerator(
     lexiconId,
     defName,
     subscription,
@@ -26,13 +26,13 @@ import 'lex_union_generator.dart';
   ).execute();
 }
 
-final class _LexLexXrpcSubscriptionGenerator {
+final class _LexXrpcSubscriptionGenerator {
   final lex.NSID lexiconId;
   final String defName;
   final lex.LexXrpcSubscription subscription;
   final List<String> mainVariants;
 
-  _LexLexXrpcSubscriptionGenerator(
+  _LexXrpcSubscriptionGenerator(
     this.lexiconId,
     this.defName,
     this.subscription,

--- a/packages/lex_gen/lib/src/services/gen_context.dart
+++ b/packages/lex_gen/lib/src/services/gen_context.dart
@@ -1,0 +1,53 @@
+// Copyright (c) 2023-2026, Shinya Kato.
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// Package imports:
+import 'package:lexicon/lexicon.dart';
+
+// Project imports:
+import '../config.dart';
+
+/// The per-generation dependencies for the service generator.
+///
+/// Replaces the module-level mutable state that `rule.dart` used to hold
+/// (`_config` / `_defsByRef` set via top-level setters). An instance is built
+/// once at the start of a run and threaded explicitly through the generators
+/// and the `rule.*` helpers that need it, so nothing depends on hidden global
+/// state or setter-call ordering.
+final class GenContext {
+  GenContext({
+    required this.serviceRuleConfig,
+    required final List<LexiconDoc> docs,
+  }) : _defsByRef = _indexDefs(docs);
+
+  final LexServiceRuleConfig serviceRuleConfig;
+
+  /// Every def keyed by `<lexiconId>#<defName>`, so a ref resolves in O(1).
+  final Map<String, LexUserType> _defsByRef;
+
+  LexiconNamespaceRule namespaceRule(final String lexiconId) {
+    for (final rule in serviceRuleConfig.namespaceRules) {
+      if (rule.matches(lexiconId)) {
+        return rule;
+      }
+    }
+
+    throw ArgumentError('Unsupported lexicon ID: $lexiconId');
+  }
+
+  LexUserType? defByRef(final String lexiconId, final String defName) =>
+      _defsByRef['$lexiconId#$defName'];
+
+  static Map<String, LexUserType> _indexDefs(final List<LexiconDoc> docs) {
+    final index = <String, LexUserType>{};
+    for (final doc in docs) {
+      final lexiconId = doc.id.toString();
+      for (final def in doc.defs.entries) {
+        index['$lexiconId#${def.key}'] = def.value;
+      }
+    }
+
+    return Map.unmodifiable(index);
+  }
+}

--- a/packages/lex_gen/lib/src/services/lex_service_generator.dart
+++ b/packages/lex_gen/lib/src/services/lex_service_generator.dart
@@ -9,6 +9,8 @@ import 'dart:io';
 import 'package:lexicon/lexicon.dart';
 
 // Project imports:
+import '../model/lex_def_kind.dart';
+import '../model/nsid.dart';
 import '../utils.dart';
 import 'fmt/lex_packages_generator.dart';
 import 'object/lex_package.dart';
@@ -70,10 +72,7 @@ final class _LexServiceGenerator {
             inputType: inputType,
             returnType: returnType,
             rkey: api is LexRecord ? api.key : null,
-            isQuery: _isQuery(doc),
-            isProcedure: _isProcedure(doc),
-            isSubscription: _isSubscription(doc),
-            isRecord: _isRecord(doc),
+            kind: _kindOf(doc),
           ),
         );
       }
@@ -98,8 +97,7 @@ final class _LexServiceGenerator {
 
   List<LexiconDoc> _filterLexicons(final List<LexiconDoc> docs) {
     return docs.where((lexicon) {
-      final id = lexicon.id.toString();
-      final service = id.split('.').sublist(0, 2).join('.');
+      final service = Nsid(lexicon.id.toString()).authority;
 
       return services.contains(service);
     }).toList();
@@ -114,13 +112,9 @@ final class _LexServiceGenerator {
       if (!_isApi(doc)) continue;
       if (rule.isDeprecated(doc.description)) continue;
 
-      final key = doc.id.toString().split('.').sublist(0, 3).join('.');
+      final key = Nsid(doc.id.toString()).serviceId;
 
-      if (result.containsKey(key)) {
-        result[key]!.add(doc);
-      } else {
-        result[key] = [doc];
-      }
+      result.putIfAbsent(key, () => []).add(doc);
     }
 
     return result;
@@ -131,6 +125,16 @@ final class _LexServiceGenerator {
         _isProcedure(doc) ||
         _isSubscription(doc) ||
         _isRecord(doc);
+  }
+
+  /// Resolves the API kind of [doc], keeping the historical dispatch priority
+  /// (query, then procedure, then subscription, then record) so that a doc
+  /// carrying more than one API def resolves exactly as the old boolean chain.
+  LexDefKind _kindOf(final LexiconDoc doc) {
+    if (_isQuery(doc)) return LexDefKind.query;
+    if (_isProcedure(doc)) return LexDefKind.procedure;
+    if (_isSubscription(doc)) return LexDefKind.subscription;
+    return LexDefKind.record;
   }
 
   bool _isQuery(final LexiconDoc doc) {

--- a/packages/lex_gen/lib/src/services/lex_service_generator.dart
+++ b/packages/lex_gen/lib/src/services/lex_service_generator.dart
@@ -13,27 +13,31 @@ import '../model/lex_def_kind.dart';
 import '../model/nsid.dart';
 import '../utils.dart';
 import 'fmt/lex_packages_generator.dart';
+import 'gen_context.dart';
 import 'object/lex_package.dart';
 import 'object/lex_service.dart';
 import 'object/lex_type.dart';
 import 'rule.dart' as rule;
 
 void generateLexServices(
+  final GenContext ctx,
   final List<String> services,
   final List<String> packages,
   final List<GeneratableType> types,
   final List<LexiconDoc> docs,
 ) {
-  return _LexServiceGenerator(services, packages, types, docs).execute();
+  return _LexServiceGenerator(ctx, services, packages, types, docs).execute();
 }
 
 final class _LexServiceGenerator {
+  final GenContext ctx;
   final List<String> services;
   final List<String> packages;
   final List<GeneratableType> types;
   final List<LexiconDoc> docs;
 
   const _LexServiceGenerator(
+    this.ctx,
     this.services,
     this.packages,
     this.types,
@@ -87,9 +91,9 @@ final class _LexServiceGenerator {
     }
 
     for (final service in services) {
-      File(service.getFilePath())
+      File(service.getFilePath(ctx))
         ..createSync(recursive: true)
-        ..writeAsStringSync(service.format());
+        ..writeAsStringSync(service.format(ctx));
     }
 
     _generateLexPackages(services);
@@ -230,7 +234,7 @@ final class _LexServiceGenerator {
   }
 
   void _generateLexPackages(final List<LexService> services) {
-    final packages = generateLexPackagesForService(services);
+    final packages = generateLexPackagesForService(ctx, services);
     final basePackages = _getBasePackages(packages);
 
     for (final package in packages) {

--- a/packages/lex_gen/lib/src/services/lex_service_generator.dart
+++ b/packages/lex_gen/lib/src/services/lex_service_generator.dart
@@ -21,7 +21,7 @@ import 'rule.dart' as rule;
 void generateLexServices(
   final List<String> services,
   final List<String> packages,
-  final List<LexType> types,
+  final List<GeneratableType> types,
   final List<LexiconDoc> docs,
 ) {
   return _LexServiceGenerator(services, packages, types, docs).execute();
@@ -30,7 +30,7 @@ void generateLexServices(
 final class _LexServiceGenerator {
   final List<String> services;
   final List<String> packages;
-  final List<LexType> types;
+  final List<GeneratableType> types;
   final List<LexiconDoc> docs;
 
   const _LexServiceGenerator(
@@ -163,7 +163,7 @@ final class _LexServiceGenerator {
     return false;
   }
 
-  LexType? _getRelatedType(
+  GeneratableType? _getRelatedType(
     final String lexiconId,
     final List<LexTypeState> states, {
     String? refDefName,

--- a/packages/lex_gen/lib/src/services/lex_tools_generator.dart
+++ b/packages/lex_gen/lib/src/services/lex_tools_generator.dart
@@ -9,22 +9,24 @@ import 'dart:io';
 import 'package:lexicon/lexicon.dart';
 
 // Project imports:
+import 'gen_context.dart';
 import 'object/at_uri_extension.dart';
 import 'object/repo_commit_handler.dart';
 import 'rule.dart';
 
-void generateLexTools(final List<LexiconDoc> docs) {
-  return _LexToolsGenerator(docs).execute();
+void generateLexTools(final GenContext ctx, final List<LexiconDoc> docs) {
+  return _LexToolsGenerator(ctx, docs).execute();
 }
 
 final class _LexToolsGenerator {
+  final GenContext ctx;
   final List<LexiconDoc> docs;
 
-  const _LexToolsGenerator(this.docs);
+  const _LexToolsGenerator(this.ctx, this.docs);
 
   void execute() {
     final recordLexiconIds = _getRecordLexiconIds();
-    final homeDir = getHomeDir('app.bsky.');
+    final homeDir = getHomeDir(ctx, 'app.bsky.');
 
     File('$homeDir/at_uri_extension.dart')
       ..createSync(recursive: true)

--- a/packages/lex_gen/lib/src/services/lex_type_generator.dart
+++ b/packages/lex_gen/lib/src/services/lex_type_generator.dart
@@ -21,7 +21,7 @@ import 'fmt/lex_xrpc_subscription_generator.dart';
 import 'object/lex_package.dart';
 import 'object/lex_type.dart';
 
-List<LexType> generateLexTypes(
+List<GeneratableType> generateLexTypes(
   final List<String> services,
   final List<String> packages,
   final List<lex.LexiconDoc> docs,
@@ -36,10 +36,10 @@ final class _LexTypeGenerator {
 
   const _LexTypeGenerator(this.services, this.packages, this.docs);
 
-  List<LexType> execute() {
+  List<GeneratableType> execute() {
     _cleanWorkspace();
 
-    final types = <LexType>[];
+    final types = <GeneratableType>[];
     final filteredLexicons = _filterLexicons(docs, services);
 
     final mainVariants = _checkMainVariants(filteredLexicons);
@@ -178,7 +178,7 @@ final class _LexTypeGenerator {
     }).toList();
   }
 
-  void _generateLexPackages(final List<LexType> type) {
+  void _generateLexPackages(final List<GeneratableType> type) {
     final packages = generateLexPackages(type);
     final basePackages = _getBasePackages(packages);
 
@@ -227,10 +227,12 @@ final class _LexTypeGenerator {
     return mainVariants.toList();
   }
 
-  void _aggregateTypes(final List<LexType> types, final LexType? type) {
+  void _aggregateTypes(final List<GeneratableType> types, final LexType? type) {
     if (type == null) return;
 
-    if (type.state != LexTypeState.message) {
+    // Only generatable types are emitted; the sole non-generatable type is the
+    // subscription-message container, which is surfaced via its nested union.
+    if (type is GeneratableType) {
       types.add(type);
     }
 

--- a/packages/lex_gen/lib/src/services/lex_type_generator.dart
+++ b/packages/lex_gen/lib/src/services/lex_type_generator.dart
@@ -11,6 +11,7 @@ import 'package:lexicon/lexicon.dart' as lex;
 // Project imports:
 import '../model/nsid.dart';
 import 'fmt/lex_known_values_generator.dart';
+import 'gen_context.dart';
 import 'fmt/lex_object_generator.dart';
 import 'fmt/lex_packages_generator.dart';
 import 'fmt/lex_record_generator.dart';
@@ -22,19 +23,21 @@ import 'object/lex_package.dart';
 import 'object/lex_type.dart';
 
 List<GeneratableType> generateLexTypes(
+  final GenContext ctx,
   final List<String> services,
   final List<String> packages,
   final List<lex.LexiconDoc> docs,
 ) {
-  return _LexTypeGenerator(services, packages, docs).execute();
+  return _LexTypeGenerator(ctx, services, packages, docs).execute();
 }
 
 final class _LexTypeGenerator {
+  final GenContext ctx;
   final List<String> services;
   final List<String> packages;
   final List<lex.LexiconDoc> docs;
 
-  const _LexTypeGenerator(this.services, this.packages, this.docs);
+  const _LexTypeGenerator(this.ctx, this.services, this.packages, this.docs);
 
   List<GeneratableType> execute() {
     _cleanWorkspace();
@@ -52,6 +55,7 @@ final class _LexTypeGenerator {
           _aggregateTypes(
             types,
             generateLexObject(
+              ctx,
               doc.id,
               def.key,
               def.value.data as lex.LexObject,
@@ -75,6 +79,7 @@ final class _LexTypeGenerator {
           _aggregateTypes(
             types,
             generateLexRecord(
+              ctx,
               doc.id,
               def.key,
               def.value.data as lex.LexRecord,
@@ -96,6 +101,7 @@ final class _LexTypeGenerator {
           );
         } else if (def.value is lex.ULexUserTypeXrpcQuery) {
           final type = generateLexXrpcQuery(
+            ctx,
             doc.id,
             def.key,
             def.value.data as lex.LexXrpcQuery,
@@ -108,6 +114,7 @@ final class _LexTypeGenerator {
           _aggregateTypes(types, type.$2);
         } else if (def.value is lex.ULexUserTypeXrpcProcedure) {
           final type = generateLexXrpcProcedure(
+            ctx,
             doc.id,
             def.key,
             def.value.data as lex.LexXrpcProcedure,
@@ -120,6 +127,7 @@ final class _LexTypeGenerator {
           _aggregateTypes(types, type.$2);
         } else if (def.value is lex.ULexUserTypeXrpcSubscription) {
           final type = generateLexXrpcSubscription(
+            ctx,
             doc.id,
             def.key,
             def.value.data as lex.LexXrpcSubscription,
@@ -137,9 +145,9 @@ final class _LexTypeGenerator {
     for (final type in types) {
       if (type.isShouldNotBeGenerated()) continue;
 
-      File(type.getFilePath())
+      File(type.getFilePath(ctx))
         ..createSync(recursive: true)
-        ..writeAsStringSync(type.format());
+        ..writeAsStringSync(type.format(ctx));
     }
 
     _generateLexPackages(types);
@@ -179,7 +187,7 @@ final class _LexTypeGenerator {
   }
 
   void _generateLexPackages(final List<GeneratableType> type) {
-    final packages = generateLexPackages(type);
+    final packages = generateLexPackages(ctx, type);
     final basePackages = _getBasePackages(packages);
 
     for (final package in packages) {

--- a/packages/lex_gen/lib/src/services/lex_type_generator.dart
+++ b/packages/lex_gen/lib/src/services/lex_type_generator.dart
@@ -9,6 +9,7 @@ import 'dart:io';
 import 'package:lexicon/lexicon.dart' as lex;
 
 // Project imports:
+import '../model/nsid.dart';
 import 'fmt/lex_known_values_generator.dart';
 import 'fmt/lex_object_generator.dart';
 import 'fmt/lex_packages_generator.dart';
@@ -171,8 +172,7 @@ final class _LexTypeGenerator {
     final List<String> services,
   ) {
     return lexicons.where((lexicon) {
-      final id = lexicon.id.toString();
-      final service = id.split('.').sublist(0, 2).join('.');
+      final service = Nsid(lexicon.id.toString()).authority;
 
       return services.contains(service);
     }).toList();

--- a/packages/lex_gen/lib/src/services/object/lex_input.dart
+++ b/packages/lex_gen/lib/src/services/object/lex_input.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 // Project imports:
+import '../gen_context.dart';
 import 'lex_property.dart';
 import 'lex_type.dart';
 import 'utils.dart';
@@ -72,7 +73,7 @@ final class LexInput extends GeneratableType {
   }
 
   @override
-  String format() {
+  String format(final GenContext ctx) {
     return renderFreezedDataClass(
       name: name,
       suffix: 'Input',

--- a/packages/lex_gen/lib/src/services/object/lex_input.dart
+++ b/packages/lex_gen/lib/src/services/object/lex_input.dart
@@ -3,8 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 // Project imports:
-import '../../utils.dart';
-import '../rule.dart' as rule;
 import 'lex_property.dart';
 import 'lex_type.dart';
 import 'utils.dart';
@@ -37,10 +35,6 @@ final class LexInput extends LexType {
     this.ref,
     this.encoding,
   });
-
-  String? getDescription() {
-    return description != null ? '/// $description' : '';
-  }
 
   @override
   String? getRef() {
@@ -79,60 +73,12 @@ final class LexInput extends LexType {
 
   @override
   String format() {
-    final properties = StringBuffer();
-    for (final property in this.properties) {
-      if (rule.isDeprecated(property.description)) {
-        continue;
-      }
-
-      properties.writeln(property.format());
-    }
-
-    final packages = StringBuffer();
-    for (final packagePath
-        in this.properties
-            .where((e) => e.type.packagePath != null)
-            .map((e) => e.type.packagePath)
-            .toSet()
-            .toList()) {
-      packages.writeln("import '$packagePath';");
-    }
-
-    final typeName = getTypeName();
-    final knownProps = getKnownProps(this.properties);
-    final extensions = getExtensions(name, this.properties, suffix: 'Input');
-    final converter = getObjectConverter(name, suffix: 'Input');
-
-    return '''$kHeaderHint
-
-import 'package:freezed_annotation/freezed_annotation.dart';
-import 'package:atproto_core/atproto_core.dart';
-import 'package:atproto_core/internals.dart';
-
-${packages.toString()}
-
-part 'input.freezed.dart';
-part 'input.g.dart';
-
-$kHeader
-
-${getDescription()}
-@freezed
-abstract class $typeName with _\$$typeName {
-  $knownProps
-
-  @JsonSerializable(includeIfNull: false)
-  const factory $typeName({
-    ${properties.toString()}
-    Map<String, dynamic>? \$unknown,
-  }) = _$typeName;
-
-  factory $typeName.fromJson(Map<String, Object?> json) => _\$${typeName}FromJson(json);
-}
-
-$extensions
-
-$converter
-''';
+    return renderFreezedDataClass(
+      name: name,
+      suffix: 'Input',
+      partBaseName: 'input',
+      description: description,
+      properties: properties,
+    );
   }
 }

--- a/packages/lex_gen/lib/src/services/object/lex_input.dart
+++ b/packages/lex_gen/lib/src/services/object/lex_input.dart
@@ -7,7 +7,7 @@ import 'lex_property.dart';
 import 'lex_type.dart';
 import 'utils.dart';
 
-final class LexInput extends LexType {
+final class LexInput extends GeneratableType {
   @override
   final String lexiconId;
   @override

--- a/packages/lex_gen/lib/src/services/object/lex_known_values.dart
+++ b/packages/lex_gen/lib/src/services/object/lex_known_values.dart
@@ -7,7 +7,7 @@ import '../../utils.dart';
 import '../rule.dart' as rule;
 import 'lex_type.dart';
 
-final class LexKnownValues extends LexType {
+final class LexKnownValues extends GeneratableType {
   @override
   final String lexiconId;
   @override

--- a/packages/lex_gen/lib/src/services/object/lex_known_values.dart
+++ b/packages/lex_gen/lib/src/services/object/lex_known_values.dart
@@ -4,6 +4,7 @@
 
 // Project imports:
 import '../../utils.dart';
+import '../gen_context.dart';
 import '../rule.dart' as rule;
 import 'lex_type.dart';
 
@@ -29,8 +30,14 @@ final class LexKnownValues extends GeneratableType {
   });
 
   @override
-  String getFilePath() {
-    return rule.getFilePath(lexiconId, defName, state, fieldName: fieldName);
+  String getFilePath(final GenContext ctx) {
+    return rule.getFilePath(
+      ctx,
+      lexiconId,
+      defName,
+      state,
+      fieldName: fieldName,
+    );
   }
 
   @override
@@ -51,7 +58,7 @@ final class LexKnownValues extends GeneratableType {
   }
 
   @override
-  String format() {
+  String format(final GenContext ctx) {
     final elements = values
         .map((e) {
           final buffer = StringBuffer();

--- a/packages/lex_gen/lib/src/services/object/lex_message.dart
+++ b/packages/lex_gen/lib/src/services/object/lex_message.dart
@@ -6,37 +6,24 @@
 import 'lex_type.dart';
 import 'lex_union.dart';
 
+/// A subscription message container. It is never generated to a file on its
+/// own — it only carries a [LexUnion] that is surfaced via [getNestedTypes] —
+/// so it is a plain [LexType] rather than a [GeneratableType].
 final class LexMessage extends LexType {
-  @override
-  String get lexiconId =>
-      throw UnsupportedError('not allowed for subscription message');
-  @override
-  String get defName =>
-      throw UnsupportedError('not allowed for subscription message');
+  const LexMessage({required this.union});
 
   final LexUnion union;
 
   @override
-  List<LexType> getNestedTypes() {
+  LexTypeState get state => LexTypeState.message;
+
+  @override
+  List<GeneratableType> getNestedTypes() {
     return [union];
   }
 
   @override
   bool isShouldNotBeGenerated() {
     return true;
-  }
-
-  @override
-  LexTypeState get state => LexTypeState.message;
-
-  const LexMessage({required this.union});
-
-  @override
-  String getTypeName() =>
-      throw UnsupportedError('not allowed for subscription message');
-
-  @override
-  String format() {
-    throw UnsupportedError('format() not allowed for subscription message');
   }
 }

--- a/packages/lex_gen/lib/src/services/object/lex_object.dart
+++ b/packages/lex_gen/lib/src/services/object/lex_object.dart
@@ -4,6 +4,7 @@
 
 // Project imports:
 import '../../model/nsid.dart';
+import '../gen_context.dart';
 import '../rule.dart' as rule;
 import 'lex_property.dart';
 import 'lex_type.dart';
@@ -41,7 +42,7 @@ final class LexObject extends GeneratableType {
   }
 
   @override
-  String format() {
+  String format(final GenContext ctx) {
     final id = rule.getLexObjectTypeId(lexiconId, defName);
 
     return renderFreezedDataClass(

--- a/packages/lex_gen/lib/src/services/object/lex_object.dart
+++ b/packages/lex_gen/lib/src/services/object/lex_object.dart
@@ -9,7 +9,7 @@ import 'lex_property.dart';
 import 'lex_type.dart';
 import 'utils.dart';
 
-final class LexObject extends LexType {
+final class LexObject extends GeneratableType {
   @override
   final String lexiconId;
   @override

--- a/packages/lex_gen/lib/src/services/object/lex_object.dart
+++ b/packages/lex_gen/lib/src/services/object/lex_object.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 // Project imports:
-import '../../utils.dart';
+import '../../model/nsid.dart';
 import '../rule.dart' as rule;
 import 'lex_property.dart';
 import 'lex_type.dart';
@@ -30,10 +30,6 @@ final class LexObject extends LexType {
     required this.properties,
   });
 
-  String getDescription() {
-    return description != null ? '/// $description' : '';
-  }
-
   @override
   List<LexProperty> getProperties() {
     return properties;
@@ -47,72 +43,22 @@ final class LexObject extends LexType {
   @override
   String format() {
     final id = rule.getLexObjectTypeId(lexiconId, defName);
-    final fileName = rule.getLexObjectFileName(defName);
 
-    final properties = StringBuffer();
-    for (final property in this.properties) {
-      if (rule.isDeprecated(property.description)) {
-        continue;
-      }
-
-      properties.writeln(property.format());
-    }
-
-    final packages = StringBuffer();
-    for (final packagePath
-        in this.properties
-            .where((e) => e.type.packagePath != null)
-            .map((e) => e.type.packagePath)
-            .toSet()
-            .toList()) {
-      packages.writeln("import '$packagePath';");
-    }
-
-    final knownProps = getKnownProps(this.properties);
-    final validateMethod = _getValidateMethod(id);
-    final extensions = getExtensions(name, this.properties);
-    final converter = getObjectConverter(name);
-
-    return '''$kHeaderHint
-
-import 'package:freezed_annotation/freezed_annotation.dart';
-import 'package:atproto_core/atproto_core.dart';
-import 'package:atproto_core/internals.dart';
-
-${packages.toString()}
-
-part '$fileName.freezed.dart';
-part '$fileName.g.dart';
-
-$kHeader
-
-${getDescription()}
-@freezed
-abstract class $name with _\$$name {
-  $knownProps
-
-  @JsonSerializable(includeIfNull: false)
-  const factory $name({
-    @Default('$id') String \$type,
-    ${properties.toString()}
-    Map<String, dynamic>? \$unknown,
-  }) = _$name;
-
-  factory $name.fromJson(Map<String, Object?> json) => _\$${name}FromJson(json);
-
-  $validateMethod
-}
-
-$extensions
-
-$converter
-''';
+    return renderFreezedDataClass(
+      name: name,
+      suffix: '',
+      partBaseName: rule.getLexObjectFileName(defName),
+      description: description,
+      properties: properties,
+      typeDefaultId: id,
+      validateMethod: _getValidateMethod(id),
+    );
   }
 
   String _getValidateMethod(final String id) {
     final buffer = StringBuffer();
     buffer.writeln('static bool validate(final Map<String, dynamic> object) {');
-    if (lexiconId.split('.').last.startsWith('subscribe')) {
+    if (Nsid(lexiconId).method.startsWith('subscribe')) {
       buffer.writeln("  if (!object.containsKey('t')) return false;");
       buffer.writeln("  return object['t'] == '#$defName'");
     } else {

--- a/packages/lex_gen/lib/src/services/object/lex_output.dart
+++ b/packages/lex_gen/lib/src/services/object/lex_output.dart
@@ -7,7 +7,7 @@ import 'lex_property.dart';
 import 'lex_type.dart';
 import 'utils.dart';
 
-final class LexOutput extends LexType {
+final class LexOutput extends GeneratableType {
   @override
   final String lexiconId;
   @override

--- a/packages/lex_gen/lib/src/services/object/lex_output.dart
+++ b/packages/lex_gen/lib/src/services/object/lex_output.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 // Project imports:
+import '../gen_context.dart';
 import 'lex_property.dart';
 import 'lex_type.dart';
 import 'utils.dart';
@@ -80,7 +81,7 @@ final class LexOutput extends GeneratableType {
   }
 
   @override
-  String format() {
+  String format(final GenContext ctx) {
     return renderFreezedDataClass(
       name: name,
       suffix: 'Output',

--- a/packages/lex_gen/lib/src/services/object/lex_output.dart
+++ b/packages/lex_gen/lib/src/services/object/lex_output.dart
@@ -3,8 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 // Project imports:
-import '../../utils.dart';
-import '../rule.dart' as rule;
 import 'lex_property.dart';
 import 'lex_type.dart';
 import 'utils.dart';
@@ -36,20 +34,17 @@ final class LexOutput extends LexType {
     this.bytes = false,
   });
 
-  String? getDescription() {
-    return description != null ? '/// $description' : '';
-  }
+  /// A single-ref output on an `upload*` endpoint, which is served by the
+  /// referenced type directly rather than a generated wrapper (duct-tape rule).
+  bool get _isUploadRef =>
+      properties.length == 1 &&
+      properties.first.type.isRef &&
+      lexiconId.contains('upload');
 
   @override
   String? getRef() {
     if (ref != null) return ref;
-
-    if (properties.length == 1 &&
-        properties.first.type.isRef &&
-        lexiconId.contains('upload')) {
-      // Duct tape solution
-      return properties.first.type.ref;
-    }
+    if (_isUploadRef) return properties.first.type.ref;
 
     return null;
   }
@@ -58,13 +53,7 @@ final class LexOutput extends LexType {
   bool isShouldNotBeGenerated() {
     if (getRef() != null) return true;
     if (isBytes()) return true;
-
-    if (properties.length == 1 &&
-        properties.first.type.isRef &&
-        lexiconId.contains('upload')) {
-      // Duct tape solution
-      return true;
-    }
+    if (_isUploadRef) return true;
 
     return false;
   }
@@ -92,59 +81,12 @@ final class LexOutput extends LexType {
 
   @override
   String format() {
-    final properties = StringBuffer();
-    for (final property in this.properties) {
-      if (rule.isDeprecated(property.description)) {
-        continue;
-      }
-
-      properties.writeln(property.format());
-    }
-
-    final packages = StringBuffer();
-    for (final packagePath
-        in this.properties
-            .where((e) => e.type.packagePath != null)
-            .map((e) => e.type.packagePath)
-            .toSet()
-            .toList()) {
-      packages.writeln("import '$packagePath';");
-    }
-
-    final knownProps = getKnownProps(this.properties);
-    final extensions = getExtensions(name, this.properties, suffix: 'Output');
-    final converter = getObjectConverter(name, suffix: 'Output');
-
-    return '''$kHeaderHint
-
-import 'package:freezed_annotation/freezed_annotation.dart';
-import 'package:atproto_core/atproto_core.dart';
-import 'package:atproto_core/internals.dart';
-
-${packages.toString()}
-
-part 'output.freezed.dart';
-part 'output.g.dart';
-
-$kHeader
-
-${getDescription()}
-@freezed
-abstract class ${name}Output with _\$${name}Output {
-  $knownProps
-
-  @JsonSerializable(includeIfNull: false)
-  const factory ${name}Output({
-    ${properties.toString()}
-    Map<String, dynamic>? \$unknown,
-  }) = _${name}Output;
-
-  factory ${name}Output.fromJson(Map<String, Object?> json) => _\$${name}OutputFromJson(json);
-}
-
-$extensions
-
-$converter
-''';
+    return renderFreezedDataClass(
+      name: name,
+      suffix: 'Output',
+      partBaseName: 'output',
+      description: description,
+      properties: properties,
+    );
   }
 }

--- a/packages/lex_gen/lib/src/services/object/lex_record.dart
+++ b/packages/lex_gen/lib/src/services/object/lex_record.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 // Project imports:
+import '../gen_context.dart';
 import '../rule.dart' as rule;
 import 'lex_property.dart';
 import 'lex_type.dart';
@@ -40,7 +41,7 @@ final class LexRecord extends GeneratableType {
   }
 
   @override
-  String format() {
+  String format(final GenContext ctx) {
     final id = rule.getLexObjectTypeId(lexiconId, defName);
 
     return renderFreezedDataClass(

--- a/packages/lex_gen/lib/src/services/object/lex_record.dart
+++ b/packages/lex_gen/lib/src/services/object/lex_record.dart
@@ -3,7 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 // Project imports:
-import '../../utils.dart';
 import '../rule.dart' as rule;
 import 'lex_property.dart';
 import 'lex_type.dart';
@@ -42,72 +41,17 @@ final class LexRecord extends LexType {
 
   @override
   String format() {
-    final properties = StringBuffer();
-    for (final property in this.properties) {
-      if (rule.isDeprecated(property.description)) {
-        continue;
-      }
-
-      properties.writeln(property.format());
-    }
-
     final id = rule.getLexObjectTypeId(lexiconId, defName);
 
-    final packages = StringBuffer();
-    for (final packagePath
-        in this.properties
-            .where((e) => e.type.packagePath != null)
-            .map((e) => e.type.packagePath)
-            .toSet()
-            .toList()) {
-      packages.writeln("import '$packagePath';");
-    }
-
-    final knownProps = getKnownProps(this.properties);
-    final validateMethod = _getValidateMethod(id);
-    final extensions = getExtensions(name, this.properties, suffix: 'Record');
-    final converter = getObjectConverter(name, suffix: 'Record');
-
-    return '''$kHeaderHint
-
-import 'package:freezed_annotation/freezed_annotation.dart';
-import 'package:atproto_core/atproto_core.dart';
-import 'package:atproto_core/internals.dart';
-
-${packages.toString()}
-
-part 'main.freezed.dart';
-part 'main.g.dart';
-
-$kHeader
-
-${_getDescription()}
-@freezed
-abstract class ${name}Record with _\$${name}Record {
-  $knownProps
-
-  @JsonSerializable(includeIfNull: false)
-  const factory ${name}Record({
-    @Default('$id') String \$type,
-    ${properties.toString()}
-    Map<String, dynamic>? \$unknown,
-  }) = _${name}Record;
-
-  factory ${name}Record.fromJson(Map<String, Object?> json) => _\$${name}RecordFromJson(json);
-
-  $validateMethod
-}
-
-$extensions
-
-$converter
-''';
-  }
-
-  String _getDescription() {
-    if (description == null) return '';
-
-    return '/// $description';
+    return renderFreezedDataClass(
+      name: name,
+      suffix: 'Record',
+      partBaseName: 'main',
+      description: description,
+      properties: properties,
+      typeDefaultId: id,
+      validateMethod: _getValidateMethod(id),
+    );
   }
 
   String _getValidateMethod(final String id) {

--- a/packages/lex_gen/lib/src/services/object/lex_record.dart
+++ b/packages/lex_gen/lib/src/services/object/lex_record.dart
@@ -8,7 +8,7 @@ import 'lex_property.dart';
 import 'lex_type.dart';
 import 'utils.dart';
 
-final class LexRecord extends LexType {
+final class LexRecord extends GeneratableType {
   @override
   final String lexiconId;
   @override

--- a/packages/lex_gen/lib/src/services/object/lex_service.dart
+++ b/packages/lex_gen/lib/src/services/object/lex_service.dart
@@ -3,6 +3,8 @@
 // BSD-style license that can be found in the LICENSE file.
 
 // Project imports:
+import '../../model/lex_def_kind.dart';
+import '../../model/nsid.dart';
 import '../../utils.dart';
 import '../rule.dart' as rule;
 import 'lex_parameter.dart';
@@ -60,7 +62,7 @@ final class LexService {
           if (ref != null) {
             final lexiconId = ref.split('#').first;
 
-            final relativePath = lexiconId.split('.').sublist(2).join('/');
+            final relativePath = Nsid(lexiconId).dirAfterAuthority;
             final fileName = rule.getFileNameForUnion(
               lexiconId,
               parameter.type.defName,
@@ -69,10 +71,9 @@ final class LexService {
 
             importPaths.add("import '$relativePath/$fileName.dart';");
           } else {
-            final relativePath = parameter.type.lexiconId!
-                .split('.')
-                .sublist(2)
-                .join('/');
+            final relativePath = Nsid(
+              parameter.type.lexiconId!,
+            ).dirAfterAuthority;
             final fileName = rule.getFileNameForUnion(
               parameter.type.lexiconId!,
               parameter.type.defName,
@@ -82,10 +83,9 @@ final class LexService {
             importPaths.add("import '$relativePath/$fileName.dart';");
           }
         } else if (parameter.type.isKnownValues) {
-          final relativePath = parameter.type.knownValues!.lexiconId
-              .split('.')
-              .sublist(2)
-              .join('/');
+          final relativePath = Nsid(
+            parameter.type.knownValues!.lexiconId,
+          ).dirAfterAuthority;
           final fileName = parameter.type.knownValues!.getFileName();
 
           importPaths.add("import '$relativePath/$fileName.dart';");
@@ -104,7 +104,7 @@ final class LexService {
       if (api.returnType != null &&
           !(api.returnType?.isShouldNotBeGenerated() ?? true)) {
         final lexiconId = api.returnType!.lexiconId;
-        final fileDir = lexiconId.split('.').sublist(2).join('/');
+        final fileDir = Nsid(lexiconId).dirAfterAuthority;
         final fileName = api.returnType!.getFileName();
 
         importPaths.add("import '$fileDir/$fileName.dart';");
@@ -183,6 +183,18 @@ $recordAccessors
 ''';
   }
 
+  /// Renders the `rkey` parameter line for a record accessor. A record that
+  /// pins a literal rkey (`literal:foo`) turns it into a defaulted parameter;
+  /// otherwise [fallback] (required or nullable) is used verbatim.
+  String _rkeyParam(final LexApi api, final String fallback) {
+    final rkey = api.rkey;
+    if (rkey?.startsWith('literal') ?? false) {
+      return "    String rkey = '${rkey!.split('literal:').last}',";
+    }
+
+    return fallback;
+  }
+
   String _getRecordAccessors(final List<LexApi> recordApis) {
     if (recordApis.isEmpty) return '';
 
@@ -192,12 +204,7 @@ $recordAccessors
       final name = rule.getRecordTypeName(api.lexiconId);
       final id = rule.getNamespaceIdForApi(api.lexiconId);
 
-      final parameters = api.inputType == null
-          ? const <LexParameter>[]
-          : api.inputType!
-                .getProperties()
-                .map((e) => e.toLexParameter())
-                .toList();
+      final parameters = api._parameters;
 
       buffer.writeln('final class ${name}RecordAccessor {');
       buffer.writeln('  final ServiceContext ctx;');
@@ -206,12 +213,7 @@ $recordAccessors
       buffer.writeln();
       buffer.writeln('  Future<XRPCResponse<RepoGetRecordOutput>> get({');
       buffer.writeln('    required String repo,');
-      if (api.rkey?.startsWith('literal') ?? false) {
-        final key = api.rkey!.split('literal:').last;
-        buffer.writeln("    String rkey = '$key',");
-      } else {
-        buffer.writeln('    required String rkey,');
-      }
+      buffer.writeln(_rkeyParam(api, '    required String rkey,'));
       buffer.writeln('    String? cid,');
       buffer.writeln('    Map<String, String>? \$headers,');
       buffer.writeln('    Map<String, String>? \$unknown,');
@@ -249,12 +251,7 @@ $recordAccessors
           parameter.getParams(ignoreRequired: parameter.name == 'createdAt'),
         );
       }
-      if (api.rkey?.startsWith('literal') ?? false) {
-        final key = api.rkey!.split('literal:').last;
-        buffer.writeln("    String rkey = '$key',");
-      } else {
-        buffer.writeln('    String? rkey,');
-      }
+      buffer.writeln(_rkeyParam(api, '    String? rkey,'));
       buffer.writeln('    bool? validate,');
       buffer.writeln('    String? swapCommit,');
       buffer.writeln('    Map<String, String>? \$headers,');
@@ -282,12 +279,7 @@ $recordAccessors
           parameter.getParams(ignoreRequired: parameter.name == 'createdAt'),
         );
       }
-      if (api.rkey?.startsWith('literal') ?? false) {
-        final key = api.rkey!.split('literal:').last;
-        buffer.writeln("    String rkey = '$key',");
-      } else {
-        buffer.writeln('    required String rkey,');
-      }
+      buffer.writeln(_rkeyParam(api, '    required String rkey,'));
       buffer.writeln('    bool? validate,');
       buffer.writeln('    String? swapRecord,');
       buffer.writeln('    String? swapCommit,');
@@ -312,12 +304,7 @@ $recordAccessors
       buffer.writeln('  );');
       buffer.writeln('');
       buffer.writeln('  Future<XRPCResponse<RepoDeleteRecordOutput>> delete({');
-      if (api.rkey?.startsWith('literal') ?? false) {
-        final key = api.rkey!.split('literal:').last;
-        buffer.writeln("    String rkey = '$key',");
-      } else {
-        buffer.writeln('    required String rkey,');
-      }
+      buffer.writeln(_rkeyParam(api, '    required String rkey,'));
       buffer.writeln('    String? swapRecord,');
       buffer.writeln('    String? swapCommit,');
       buffer.writeln('    Map<String, String>? \$headers,');
@@ -374,58 +361,45 @@ final class LexApi {
 
   final String? rkey;
 
-  final bool isQuery;
-  final bool isProcedure;
-  final bool isSubscription;
-  final bool isRecord;
+  final LexDefKind kind;
 
   const LexApi({
     required this.lexiconId,
     required this.name,
+    required this.kind,
     this.description,
     this.inputType,
     this.returnType,
     this.rkey,
-    this.isQuery = false,
-    this.isProcedure = false,
-    this.isSubscription = false,
-    this.isRecord = false,
   });
 
+  bool get isRecord => kind == LexDefKind.record;
+
+  /// The API's input parameters, derived from its input/record type.
+  List<LexParameter> get _parameters => inputType == null
+      ? const <LexParameter>[]
+      : inputType!.getProperties().map((e) => e.toLexParameter()).toList();
+
   String toFunction() {
-    final parameters = inputType == null
-        ? const <LexParameter>[]
-        : inputType!.getProperties().map((e) => e.toLexParameter()).toList();
+    final parameters = _parameters;
 
-    if (isQuery) {
-      return _getQueryFunction(parameters);
-    } else if (isProcedure) {
-      return _getProcedureFunction(parameters);
-    } else if (isSubscription) {
-      return _getSubscriptionFunction(parameters);
-    } else if (isRecord) {
-      return '';
-    }
-
-    throw UnsupportedError('Unsupported API format');
+    return switch (kind) {
+      LexDefKind.query => _getQueryFunction(parameters),
+      LexDefKind.procedure => _getProcedureFunction(parameters),
+      LexDefKind.subscription => _getSubscriptionFunction(parameters),
+      LexDefKind.record => '',
+    };
   }
 
   String toMethod() {
-    final parameters = inputType == null
-        ? const <LexParameter>[]
-        : inputType!.getProperties().map((e) => e.toLexParameter()).toList();
+    final parameters = _parameters;
 
-    if (isQuery) {
-      return _getQueryMethod(parameters);
-    } else if (isProcedure) {
-      return _getProcedureMethod(parameters);
-    } else if (isSubscription) {
-      return _getSubscriptionMethod(parameters);
-    } else if (isRecord) {
-      return _getRecordMethod(parameters);
-    }
-
-    throw UnsupportedError('Unsupported API format');
+    return switch (kind) {
+      LexDefKind.query => _getQueryMethod(parameters),
+      LexDefKind.procedure => _getProcedureMethod(parameters),
+      LexDefKind.subscription => _getSubscriptionMethod(parameters),
+      LexDefKind.record => _getRecordMethod(parameters),
+    };
   }
 
   String _getQueryFunction(final List<LexParameter> parameters) {

--- a/packages/lex_gen/lib/src/services/object/lex_service.dart
+++ b/packages/lex_gen/lib/src/services/object/lex_service.dart
@@ -356,8 +356,8 @@ final class LexApi {
 
   final String name;
   final String? description;
-  final LexType? inputType;
-  final LexType? returnType;
+  final GeneratableType? inputType;
+  final GeneratableType? returnType;
 
   final String? rkey;
 

--- a/packages/lex_gen/lib/src/services/object/lex_service.dart
+++ b/packages/lex_gen/lib/src/services/object/lex_service.dart
@@ -6,6 +6,7 @@
 import '../../model/lex_def_kind.dart';
 import '../../model/nsid.dart';
 import '../../utils.dart';
+import '../gen_context.dart';
 import '../rule.dart' as rule;
 import 'lex_parameter.dart';
 import 'lex_type.dart';
@@ -26,8 +27,8 @@ final class LexService {
     return '${name.toLowerCase()}_service';
   }
 
-  String getFilePath() {
-    final homeDir = rule.getHomeDir(lexiconId);
+  String getFilePath(final GenContext ctx) {
+    final homeDir = rule.getHomeDir(ctx, lexiconId);
     final fileDir = rule.getFileDirForService(lexiconId);
 
     return '$homeDir/$fileDir/${getFileName()}.dart';
@@ -41,7 +42,7 @@ final class LexService {
     return false;
   }
 
-  String _getPackagePaths() {
+  String _getPackagePaths(final GenContext ctx) {
     final importPaths = <String>[];
     for (final api in apis) {
       final parameters = api.inputType == null
@@ -93,6 +94,7 @@ final class LexService {
           if (parameter.type.ref == null) continue;
 
           final packagePath = rule.getLexObjectPackagePathFromRefForService(
+            ctx,
             parameter.type.lexiconId!,
             parameter.type.ref!,
           );
@@ -120,8 +122,8 @@ final class LexService {
     return importPaths.toSet().join('\n');
   }
 
-  String format() {
-    final packagePaths = _getPackagePaths();
+  String format(final GenContext ctx) {
+    final packagePaths = _getPackagePaths(ctx);
 
     final functions = apis.map((e) => e.toFunction()).join();
     final methods = apis.map((e) => e.toMethod()).join();

--- a/packages/lex_gen/lib/src/services/object/lex_type.dart
+++ b/packages/lex_gen/lib/src/services/object/lex_type.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 // Project imports:
+import '../gen_context.dart';
 import '../rule.dart' as rule;
 import 'lex_property.dart';
 
@@ -70,8 +71,8 @@ abstract class GeneratableType extends LexType {
     return 'application/json';
   }
 
-  String getFilePath() {
-    return rule.getFilePath(lexiconId, defName, state);
+  String getFilePath(final GenContext ctx) {
+    return rule.getFilePath(ctx, lexiconId, defName, state);
   }
 
   String getFileName() {
@@ -80,5 +81,5 @@ abstract class GeneratableType extends LexType {
 
   String getTypeName();
 
-  String format();
+  String format(final GenContext ctx);
 }

--- a/packages/lex_gen/lib/src/services/object/lex_type.dart
+++ b/packages/lex_gen/lib/src/services/object/lex_type.dart
@@ -17,12 +17,23 @@ enum LexTypeState {
   union,
 }
 
+/// Base type for everything the generator tracks, including containers that
+/// are never emitted to a file on their own (e.g. [LexMessage]).
+///
+/// Only [GeneratableType]s carry a lexicon id / file / `format()`; keeping
+/// those off this base lets non-generatable containers implement just what
+/// they can honor, instead of throwing `UnsupportedError` from inherited
+/// members.
 abstract class LexType {
-  LexTypeState get state;
-  String get lexiconId;
-  String get defName;
+  const LexType();
 
-  List<LexType> getNestedTypes() {
+  LexTypeState get state;
+
+  List<LexProperty> getProperties() {
+    return const [];
+  }
+
+  List<GeneratableType> getNestedTypes() {
     final properties = getProperties();
 
     return [
@@ -35,15 +46,17 @@ abstract class LexType {
     ];
   }
 
-  const LexType();
-
-  List<LexProperty> getProperties() {
-    return const [];
-  }
-
   bool isShouldNotBeGenerated() {
     return false;
   }
+}
+
+/// A [LexType] that is emitted to its own generated source file.
+abstract class GeneratableType extends LexType {
+  const GeneratableType();
+
+  String get lexiconId;
+  String get defName;
 
   String? getRef() {
     return null;

--- a/packages/lex_gen/lib/src/services/object/lex_union.dart
+++ b/packages/lex_gen/lib/src/services/object/lex_union.dart
@@ -1,5 +1,6 @@
 // Project imports:
 import '../../utils.dart';
+import '../gen_context.dart';
 import '../rule.dart' as rule;
 import 'lex_type.dart';
 
@@ -28,8 +29,8 @@ final class LexUnion extends GeneratableType {
   });
 
   @override
-  String getFilePath() {
-    return rule.getFilePathForUnion(lexiconId, defName, fieldName);
+  String getFilePath(final GenContext ctx) {
+    return rule.getFilePathForUnion(ctx, lexiconId, defName, fieldName);
   }
 
   @override
@@ -43,7 +44,7 @@ final class LexUnion extends GeneratableType {
   }
 
   @override
-  String format() {
+  String format(final GenContext ctx) {
     final fileName = rule.getFileNameForUnion(lexiconId, defName, fieldName);
     // Resolve each ref's object name once and reuse it across every section
     // below, instead of re-resolving it four times per ref.
@@ -51,7 +52,7 @@ final class LexUnion extends GeneratableType {
       for (final ref in refs)
         rule.getLexObjectNameFromRef(lexiconId, ref, mainVariants),
     ];
-    final packagePaths = _getPackagePaths();
+    final packagePaths = _getPackagePaths(ctx);
     final factories = _getUnionFactories(objectNames);
     final extensions = _getExtensions(objectNames);
     final fromJson = _getFromJson(objectNames);
@@ -108,11 +109,11 @@ final class ${name}Converter implements JsonConverter<$name, Map<String, dynamic
 ''';
   }
 
-  String _getPackagePaths() {
+  String _getPackagePaths(final GenContext ctx) {
     final buffer = StringBuffer();
 
     for (final ref in refs) {
-      final path = rule.getLexObjectPackagePathFromRef(lexiconId, ref);
+      final path = rule.getLexObjectPackagePathFromRef(ctx, lexiconId, ref);
       buffer.writeln("import '$path';");
     }
 

--- a/packages/lex_gen/lib/src/services/object/lex_union.dart
+++ b/packages/lex_gen/lib/src/services/object/lex_union.dart
@@ -3,7 +3,7 @@ import '../../utils.dart';
 import '../rule.dart' as rule;
 import 'lex_type.dart';
 
-final class LexUnion extends LexType {
+final class LexUnion extends GeneratableType {
   @override
   final String lexiconId;
   @override

--- a/packages/lex_gen/lib/src/services/object/lex_union.dart
+++ b/packages/lex_gen/lib/src/services/object/lex_union.dart
@@ -45,11 +45,17 @@ final class LexUnion extends LexType {
   @override
   String format() {
     final fileName = rule.getFileNameForUnion(lexiconId, defName, fieldName);
+    // Resolve each ref's object name once and reuse it across every section
+    // below, instead of re-resolving it four times per ref.
+    final objectNames = [
+      for (final ref in refs)
+        rule.getLexObjectNameFromRef(lexiconId, ref, mainVariants),
+    ];
     final packagePaths = _getPackagePaths();
-    final factories = _getUnionFactories();
-    final extensions = _getExtensions();
-    final fromJson = _getFromJson();
-    final toJson = _getToJson();
+    final factories = _getUnionFactories(objectNames);
+    final extensions = _getExtensions(objectNames);
+    final fromJson = _getFromJson(objectNames);
+    final toJson = _getToJson(objectNames);
 
     return '''$kHeaderHint
 
@@ -113,16 +119,10 @@ final class ${name}Converter implements JsonConverter<$name, Map<String, dynamic
     return buffer.toString();
   }
 
-  String _getUnionFactories() {
+  String _getUnionFactories(final List<String> objectNames) {
     final buffer = StringBuffer();
 
-    for (final ref in refs) {
-      final objectName = rule.getLexObjectNameFromRef(
-        lexiconId,
-        ref,
-        mainVariants,
-      );
-
+    for (final objectName in objectNames) {
       buffer.writeln('const factory $name.${toFirstLowerCase(objectName)}({');
       buffer.writeln('  required $objectName data,');
       buffer.writeln('}) = $name$objectName;');
@@ -131,16 +131,10 @@ final class ${name}Converter implements JsonConverter<$name, Map<String, dynamic
     return buffer.toString();
   }
 
-  String _getExtensions() {
+  String _getExtensions(final List<String> objectNames) {
     final buffer = StringBuffer();
 
-    for (final ref in refs) {
-      final objectName = rule.getLexObjectNameFromRef(
-        lexiconId,
-        ref,
-        mainVariants,
-      );
-
+    for (final objectName in objectNames) {
       buffer.writeln('bool get is$objectName => isA<$name$objectName>(this);');
       buffer.writeln('bool get isNot$objectName => !is$objectName;');
 
@@ -161,16 +155,10 @@ final class ${name}Converter implements JsonConverter<$name, Map<String, dynamic
     return buffer.toString();
   }
 
-  String _getFromJson() {
+  String _getFromJson(final List<String> objectNames) {
     final buffer = StringBuffer();
 
-    for (final ref in refs) {
-      final objectName = rule.getLexObjectNameFromRef(
-        lexiconId,
-        ref,
-        mainVariants,
-      );
-
+    for (final objectName in objectNames) {
       buffer.writeln('if ($objectName.validate(json)) {');
       buffer.writeln('  return $name.${toFirstLowerCase(objectName)}(');
       buffer.writeln(
@@ -183,16 +171,10 @@ final class ${name}Converter implements JsonConverter<$name, Map<String, dynamic
     return buffer.toString();
   }
 
-  String _getToJson() {
+  String _getToJson(final List<String> objectNames) {
     final buffer = StringBuffer();
 
-    for (final ref in refs) {
-      final objectName = rule.getLexObjectNameFromRef(
-        lexiconId,
-        ref,
-        mainVariants,
-      );
-
+    for (final objectName in objectNames) {
       buffer.writeln(
         '${toFirstLowerCase(objectName)}: (data) => '
         'const ${objectName}Converter().toJson(data),',

--- a/packages/lex_gen/lib/src/services/object/repo_commit_handler.dart
+++ b/packages/lex_gen/lib/src/services/object/repo_commit_handler.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 // Project imports:
+import '../../model/nsid.dart';
 import '../../utils.dart';
 import '../rule.dart';
 
@@ -254,10 +255,10 @@ final class RepoCommitDelete {
 
     for (final lexiconId in lexiconIds) {
       if (_atprotoPrefixes.any(lexiconId.startsWith)) {
-        final libName = lexiconId.split('.').join('_');
+        final libName = Nsid(lexiconId).segments.join('_');
         imports.writeln("import 'package:atproto/$libName.dart';");
       } else {
-        final path = lexiconId.split('.').join('/');
+        final path = Nsid(lexiconId).fileDir;
         imports.writeln("import '$path/main.dart';");
       }
     }

--- a/packages/lex_gen/lib/src/services/object/repo_commit_handler.dart
+++ b/packages/lex_gen/lib/src/services/object/repo_commit_handler.dart
@@ -15,13 +15,25 @@ final class RepoCommitHandler {
   String format() {
     final imports = _getImports();
 
-    final fields = _getFields();
-    final constructorArgs = _getConstructorArgs();
-    final constructorArgsSetter = _getConstructorArgsSetter();
+    // Resolve every record's type name once and reuse it across all sections
+    // below, instead of re-deriving it in each builder (was six passes).
+    final typeNames = [for (final id in lexiconIds) getRecordTypeName(id)];
 
-    final onCreateEvent = _getOnCreateEvent();
-    final onUpdateEvent = _getOnUpdateEvent();
-    final onDeleteEvent = _getOnDeleteEvent();
+    final fields = _getFields(typeNames);
+    final constructorArgs = _getConstructorArgs(typeNames);
+    final constructorArgsSetter = _getConstructorArgsSetter(typeNames);
+
+    final onCreateEvent = _getMutationEvent(
+      typeNames,
+      verb: 'Create',
+      withCreatedAt: false,
+    );
+    final onUpdateEvent = _getMutationEvent(
+      typeNames,
+      verb: 'Update',
+      withCreatedAt: true,
+    );
+    final onDeleteEvent = _getOnDeleteEvent(typeNames);
 
     return '''$kHeaderHint
 
@@ -266,12 +278,10 @@ final class RepoCommitDelete {
     return imports.toString();
   }
 
-  String _getFields() {
+  String _getFields(final List<String> typeNames) {
     final buffer = StringBuffer();
 
-    for (final lexiconId in lexiconIds) {
-      final typeName = getRecordTypeName(lexiconId);
-
+    for (final typeName in typeNames) {
       buffer.writeln(
         'final RepoCommitOnCreate<${typeName}Record>? _onCreate$typeName;',
       );
@@ -284,12 +294,10 @@ final class RepoCommitDelete {
     return buffer.toString();
   }
 
-  String _getConstructorArgs() {
+  String _getConstructorArgs(final List<String> typeNames) {
     final buffer = StringBuffer();
 
-    for (final lexiconId in lexiconIds) {
-      final typeName = getRecordTypeName(lexiconId);
-
+    for (final typeName in typeNames) {
       buffer.writeln(
         'final RepoCommitOnCreate<${typeName}Record>? onCreate$typeName,',
       );
@@ -302,12 +310,10 @@ final class RepoCommitDelete {
     return buffer.toString();
   }
 
-  String _getConstructorArgsSetter() {
+  String _getConstructorArgsSetter(final List<String> typeNames) {
     final buffer = StringBuffer();
 
-    for (final lexiconId in lexiconIds) {
-      final typeName = getRecordTypeName(lexiconId);
-
+    for (final typeName in typeNames) {
       buffer.writeln('_onCreate$typeName = onCreate$typeName,');
       buffer.writeln('_onUpdate$typeName = onUpdate$typeName,');
       buffer.writeln('_onDelete$typeName = onDelete$typeName,');
@@ -316,21 +322,27 @@ final class RepoCommitDelete {
     return buffer.toString();
   }
 
-  String _getOnCreateEvent() {
+  /// Renders the `_onCreate` / `_onUpdate` firehose handler, which differ only
+  /// by the `Create`/`Update` [verb] and whether an `Update`'s `createdAt` is
+  /// carried through ([withCreatedAt]).
+  String _getMutationEvent(
+    final List<String> typeNames, {
+    required final String verb,
+    required final bool withCreatedAt,
+  }) {
+    final createdAtLine = withCreatedAt ? '\n      createdAt: data.time,' : '';
     final handlers = StringBuffer();
 
-    for (final lexiconId in lexiconIds) {
-      final typeName = getRecordTypeName(lexiconId);
-
+    for (final typeName in typeNames) {
       handlers.write(
         '''if (uri.is$typeName && ${typeName}Record.validate(record)) {
-  await _onCreate$typeName?.call(
-    RepoCommitCreate<${typeName}Record>(
+  await _on$verb$typeName?.call(
+    RepoCommit$verb<${typeName}Record>(
       record: const ${typeName}RecordConverter().fromJson(record),
       uri: uri,
       cid: op.cid,
       author: data.repo,
-      cursor: data.seq,
+      cursor: data.seq,$createdAtLine
     ),
   );
   return;
@@ -339,75 +351,29 @@ final class RepoCommitDelete {
       );
     }
 
-    return '''Future<void> _onCreate(final Commit data, final RepoOp op) async {
+    return '''Future<void> _on$verb(final Commit data, final RepoOp op) async {
   final uri = _getUri(data, op);
   final record = _getRecord(data, op);
 
   $handlers
 
-  await _onCreateUnknown?.call(
-    RepoCommitCreate<Map<String, dynamic>>(
+  await _on${verb}Unknown?.call(
+    RepoCommit$verb<Map<String, dynamic>>(
       record: record,
       uri: uri,
       cid: op.cid,
       author: data.repo,
-      cursor: data.seq,
+      cursor: data.seq,$createdAtLine
     ),
   );
 }
 ''';
   }
 
-  String _getOnUpdateEvent() {
+  String _getOnDeleteEvent(final List<String> typeNames) {
     final handlers = StringBuffer();
 
-    for (final lexiconId in lexiconIds) {
-      final typeName = getRecordTypeName(lexiconId);
-
-      handlers.write(
-        '''if (uri.is$typeName && ${typeName}Record.validate(record)) {
-  await _onUpdate$typeName?.call(
-    RepoCommitUpdate<${typeName}Record>(
-      record: const ${typeName}RecordConverter().fromJson(record),
-      uri: uri,
-      cid: op.cid,
-      author: data.repo,
-      cursor: data.seq,
-      createdAt: data.time,
-    ),
-  );
-  return;
-}
-''',
-      );
-    }
-
-    return '''Future<void> _onUpdate(final Commit data, final RepoOp op) async {
-  final uri = _getUri(data, op);
-  final record = _getRecord(data, op);
-
-  $handlers
-
-  await _onUpdateUnknown?.call(
-    RepoCommitUpdate<Map<String, dynamic>>(
-      record: record,
-      uri: uri,
-      cid: op.cid,
-      author: data.repo,
-      cursor: data.seq,
-      createdAt: data.time,
-    ),
-  );
-}
-''';
-  }
-
-  String _getOnDeleteEvent() {
-    final handlers = StringBuffer();
-
-    for (final lexiconId in lexiconIds) {
-      final typeName = getRecordTypeName(lexiconId);
-
+    for (final typeName in typeNames) {
       handlers.write('''if (uri.is$typeName) {
   await _onDelete$typeName?.call(
     RepoCommitDelete(

--- a/packages/lex_gen/lib/src/services/object/utils.dart
+++ b/packages/lex_gen/lib/src/services/object/utils.dart
@@ -7,6 +7,80 @@ import '../../utils.dart';
 import '../rule.dart' as rule;
 import 'lex_property.dart';
 
+/// Renders the freezed data-class file shared by `LexObject`, `LexRecord`,
+/// `LexInput` and `LexOutput`, which each used to keep a byte-identical copy of
+/// this template.
+///
+/// The generated class name is `name + suffix` (e.g. `FooRecord`); [suffix] is
+/// `''` for a plain object. [partBaseName] names the `part` files (e.g. `main`,
+/// `input`). When [typeDefaultId] is non-null a `@Default('<id>') String $type`
+/// field is emitted, and [validateMethod], when non-empty, is appended as the
+/// class's `validate` guard.
+String renderFreezedDataClass({
+  required final String name,
+  required final String suffix,
+  required final String partBaseName,
+  required final String? description,
+  required final List<LexProperty> properties,
+  final String? typeDefaultId,
+  final String validateMethod = '',
+}) {
+  final className = '$name$suffix';
+
+  final propertyLines = StringBuffer();
+  for (final property in properties) {
+    if (rule.isDeprecated(property.description)) continue;
+    propertyLines.writeln(property.format());
+  }
+
+  final packageImports = StringBuffer();
+  for (final packagePath
+      in properties
+          .where((e) => e.type.packagePath != null)
+          .map((e) => e.type.packagePath)
+          .toSet()) {
+    packageImports.writeln("import '$packagePath';");
+  }
+
+  final descriptionDoc = description != null ? '/// $description' : '';
+  final typeLine = typeDefaultId != null
+      ? "@Default('$typeDefaultId') String \$type,\n    "
+      : '';
+  final validateBlock = validateMethod.isEmpty ? '' : '\n\n  $validateMethod';
+
+  return '''$kHeaderHint
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:atproto_core/atproto_core.dart';
+import 'package:atproto_core/internals.dart';
+
+${packageImports.toString()}
+
+part '$partBaseName.freezed.dart';
+part '$partBaseName.g.dart';
+
+$kHeader
+
+$descriptionDoc
+@freezed
+abstract class $className with _\$$className {
+  ${getKnownProps(properties)}
+
+  @JsonSerializable(includeIfNull: false)
+  const factory $className({
+    $typeLine${propertyLines.toString()}
+    Map<String, dynamic>? \$unknown,
+  }) = _$className;
+
+  factory $className.fromJson(Map<String, Object?> json) => _\$${className}FromJson(json);$validateBlock
+}
+
+${getExtensions(name, properties, suffix: suffix)}
+
+${getObjectConverter(name, suffix: suffix)}
+''';
+}
+
 String getKnownProps(final List<LexProperty> properties) {
   final buffer = StringBuffer();
 
@@ -50,6 +124,10 @@ String getExtensions(
   String suffix = '',
 }) {
   final extensions = StringBuffer();
+  // Precompute the property-name set once so the "is this getter already a
+  // declared field?" checks below are O(1) instead of re-scanning every
+  // property (previously O(n^2) over the property list).
+  final knownNames = properties.map((e) => e.name).toSet();
 
   for (final property in properties) {
     if (rule.isDeprecated(property.description)) continue;
@@ -64,7 +142,7 @@ String getExtensions(
       final isA = 'is$functionName';
       final isNotA = 'isNot$functionName';
 
-      if (!_isKnownPropertyName(isA, properties)) {
+      if (!knownNames.contains(isA)) {
         if (property.isRequired || property.defaultValue != null) {
           extensions.writeln('bool get $isA => ${property.name};');
         } else {
@@ -74,7 +152,7 @@ String getExtensions(
           );
         }
       }
-      if (!_isKnownPropertyName(isNotA, properties)) {
+      if (!knownNames.contains(isNotA)) {
         extensions.writeln('bool get $isNotA => !$isA;');
       }
     } else {
@@ -85,11 +163,11 @@ String getExtensions(
       final hasA = 'has$functionName';
       final hasNotA = 'hasNot$functionName';
 
-      if (!_isKnownPropertyName(hasA, properties)) {
+      if (!knownNames.contains(hasA)) {
         extensions.writeln('bool get $hasA => ${property.name} != null;');
       }
-      if (!_isKnownPropertyName(hasNotA, properties)) {
-        if (_isKnownPropertyName(hasA, properties)) {
+      if (!knownNames.contains(hasNotA)) {
+        if (knownNames.contains(hasA)) {
           extensions.writeln('bool get $hasNotA => !($hasA ?? false);');
         } else {
           extensions.writeln('bool get $hasNotA => !$hasA;');
@@ -104,17 +182,4 @@ String getExtensions(
 ${extensions.toString()}
 }
 ''';
-}
-
-bool _isKnownPropertyName(
-  final String name,
-  final List<LexProperty> properties,
-) {
-  for (final property in properties) {
-    if (property.name == name) {
-      return true;
-    }
-  }
-
-  return false;
 }

--- a/packages/lex_gen/lib/src/services/rule.dart
+++ b/packages/lex_gen/lib/src/services/rule.dart
@@ -6,32 +6,11 @@
 import 'package:lexicon/lexicon.dart' hide LexRef;
 
 // Project imports:
-import '../config.dart';
 import '../model/lex_ref.dart';
 import '../model/nsid.dart';
 import '../utils.dart';
+import 'gen_context.dart';
 import 'object/lex_type.dart';
-
-LexServiceRuleConfig? _config;
-
-/// Index of every def keyed by `<lexiconId>#<defName>`, so a ref can be
-/// resolved in O(1) instead of scanning every doc's every def per lookup.
-Map<String, LexUserType> _defsByRef = const {};
-
-void setLexServiceRuleConfig(final LexServiceRuleConfig config) {
-  _config = config;
-}
-
-void setLexiconDocs(final List<LexiconDoc> docs) {
-  final index = <String, LexUserType>{};
-  for (final doc in docs) {
-    final lexiconId = doc.id.toString();
-    for (final def in doc.defs.entries) {
-      index['$lexiconId#${def.key}'] = def.value;
-    }
-  }
-  _defsByRef = Map.unmodifiable(index);
-}
 
 bool isDeprecated(final String? description) {
   if (description == null) return false;
@@ -119,24 +98,25 @@ String getLexOutputObjectFileName() {
 }
 
 String getFilePath(
+  final GenContext ctx,
   final String lexiconId,
   final String defName,
   final LexTypeState state, {
   final String? fieldName,
 }) {
   if (state == LexTypeState.input) {
-    return '${getHomeDir(lexiconId)}/${_getFileDir(lexiconId)}/input.dart';
+    return '${getHomeDir(ctx, lexiconId)}/${_getFileDir(lexiconId)}/input.dart';
   } else if (state == LexTypeState.output) {
-    return '${getHomeDir(lexiconId)}/${_getFileDir(lexiconId)}/output.dart';
+    return '${getHomeDir(ctx, lexiconId)}/${_getFileDir(lexiconId)}/output.dart';
   } else {
     if (fieldName != null) {
       final prefix = getLexObjectFileName(defName);
       final suffix = getLexObjectFileName(fieldName);
       final fileName = [prefix, suffix].join('_');
 
-      return '${getHomeDir(lexiconId)}/${_getFileDir(lexiconId)}/$fileName.dart';
+      return '${getHomeDir(ctx, lexiconId)}/${_getFileDir(lexiconId)}/$fileName.dart';
     } else {
-      return '${getHomeDir(lexiconId)}/${_getFileDir(lexiconId)}/${getLexObjectFileName(defName)}.dart';
+      return '${getHomeDir(ctx, lexiconId)}/${_getFileDir(lexiconId)}/${getLexObjectFileName(defName)}.dart';
     }
   }
 }
@@ -160,13 +140,14 @@ String getFileNameForUnion(
 }
 
 String getFilePathForUnion(
+  final GenContext ctx,
   final String lexiconId,
   final String defName,
   final String fieldName,
 ) {
   final fileName = getFileNameForUnion(lexiconId, defName, fieldName);
 
-  return '${getHomeDir(lexiconId)}/${_getFileDir(lexiconId)}/$fileName.dart';
+  return '${getHomeDir(ctx, lexiconId)}/${_getFileDir(lexiconId)}/$fileName.dart';
 }
 
 String getLexObjectTypeId(final String lexiconId, final String defName) {
@@ -177,16 +158,16 @@ String getLexObjectTypeId(final String lexiconId, final String defName) {
   return '$lexiconId#$defName';
 }
 
-String getHomeDir(final String lexiconId) {
-  return _getNamespaceRule(lexiconId).homeDir;
+String getHomeDir(final GenContext ctx, final String lexiconId) {
+  return ctx.namespaceRule(lexiconId).homeDir;
 }
 
-String _getHomeDirForExport(final String lexiconId) {
-  return _getNamespaceRule(lexiconId).exportCodegenPath;
+String _getHomeDirForExport(final GenContext ctx, final String lexiconId) {
+  return ctx.namespaceRule(lexiconId).exportCodegenPath;
 }
 
-String _getHomeDirForService(final String lexiconId) {
-  return _getNamespaceRule(lexiconId).servicePackagePath;
+String _getHomeDirForService(final GenContext ctx, final String lexiconId) {
+  return ctx.namespaceRule(lexiconId).servicePackagePath;
 }
 
 String _getFileDir(final String lexiconId) {
@@ -218,12 +199,13 @@ String getLexObjectNameFromRef(
 }
 
 String getLexObjectPackagePathFromRef(
+  final GenContext ctx,
   final String lexiconId,
   final String ref, {
   bool isUnion = false,
 }) {
   final fileNamePrefix = isUnion ? 'union_' : '';
-  final relativePath = getPackageRelativePath(lexiconId, ref);
+  final relativePath = getPackageRelativePath(ctx, lexiconId, ref);
   final samePackage = _isInTheSamePackage(lexiconId, ref);
 
   final fileName = switch (LexRef.parse(ref)) {
@@ -238,11 +220,12 @@ String getLexObjectPackagePathFromRef(
 }
 
 String getLexObjectPackagePathFromRefForService(
+  final GenContext ctx,
   final String lexiconId,
   final String ref,
 ) {
   String foreignPath(final Nsid lexicon) =>
-      '${_getHomeDirForService(lexicon.raw)}/${getPackageName(lexicon.raw)}.dart';
+      '${_getHomeDirForService(ctx, lexicon.raw)}/${getPackageName(lexicon.raw)}.dart';
 
   final samePackage = _isInTheSamePackage(lexiconId, ref);
 
@@ -270,13 +253,17 @@ String getLexObjectPackagePathForUnion(
   return './$fileName.dart';
 }
 
-String getPackageRelativePath(final String lexiconId, final String ref) {
+String getPackageRelativePath(
+  final GenContext ctx,
+  final String lexiconId,
+  final String ref,
+) {
   return switch (LexRef.parse(ref)) {
     LocalRef() => '.',
     ForeignRef(:final lexicon) || BareRef(:final lexicon) =>
       _isInTheSamePackage(lexiconId, ref)
           ? '../../../../${_getFileDir(lexicon.raw)}'
-          : 'package:${getRootPackageName(lexicon.raw)}',
+          : 'package:${getRootPackageName(ctx, lexicon.raw)}',
   };
 }
 
@@ -293,23 +280,8 @@ String getRecordTypeName(final String lexiconId) {
   return Nsid(lexiconId).segmentsAfterAuthority().map(toFirstUpperCase).join();
 }
 
-String getRootPackageName(final String lexiconId) {
-  return _getNamespaceRule(lexiconId).rootPackageName;
-}
-
-LexiconNamespaceRule _getNamespaceRule(final String lexiconId) {
-  final config = _config;
-  if (config == null) {
-    throw StateError('Lex service rule config is not set');
-  }
-
-  for (final rule in config.namespaceRules) {
-    if (rule.matches(lexiconId)) {
-      return rule;
-    }
-  }
-
-  throw ArgumentError('Unsupported lexicon ID: $lexiconId');
+String getRootPackageName(final GenContext ctx, final String lexiconId) {
+  return ctx.namespaceRule(lexiconId).rootPackageName;
 }
 
 String getPackageName(final String lexiconId) {
@@ -324,16 +296,21 @@ String getServiceApiName(final String lexiconId) {
   return Nsid(lexiconId).method;
 }
 
-String getLexObjectAbsolutePath(final String lexiconId, final String fileName) {
-  return '${_getHomeDirForExport(lexiconId)}/${_getFileDir(lexiconId)}/$fileName.dart';
+String getLexObjectAbsolutePath(
+  final GenContext ctx,
+  final String lexiconId,
+  final String fileName,
+) {
+  return '${_getHomeDirForExport(ctx, lexiconId)}/${_getFileDir(lexiconId)}/$fileName.dart';
 }
 
 String getLexObjectAbsolutePathForService(
+  final GenContext ctx,
   final String lexiconId,
   final String fileName,
 ) {
   final root = Nsid(lexiconId).serviceDir;
-  return '${_getHomeDirForExport(lexiconId)}/$root/$fileName.dart';
+  return '${_getHomeDirForExport(ctx, lexiconId)}/$root/$fileName.dart';
 }
 
 String getLexKnownValuesElementName(
@@ -372,6 +349,7 @@ String getNamespaceIdForApi(final String lexiconId) {
 }
 
 LexUserType? getRelatedDocFromRef(
+  final GenContext ctx,
   final String? ref, {
   final String? lexiconId,
 }) {
@@ -392,5 +370,5 @@ LexUserType? getRelatedDocFromRef(
       return null;
   }
 
-  return _defsByRef['$targetLexiconId#$defName'];
+  return ctx.defByRef(targetLexiconId, defName);
 }

--- a/packages/lex_gen/lib/src/services/rule.dart
+++ b/packages/lex_gen/lib/src/services/rule.dart
@@ -3,22 +3,34 @@
 // BSD-style license that can be found in the LICENSE file.
 
 // Package imports:
-import 'package:lexicon/lexicon.dart';
+import 'package:lexicon/lexicon.dart' hide LexRef;
 
 // Project imports:
 import '../config.dart';
+import '../model/lex_ref.dart';
+import '../model/nsid.dart';
 import '../utils.dart';
 import 'object/lex_type.dart';
 
 LexServiceRuleConfig? _config;
-List<LexiconDoc> _lexiconDocs = const [];
+
+/// Index of every def keyed by `<lexiconId>#<defName>`, so a ref can be
+/// resolved in O(1) instead of scanning every doc's every def per lookup.
+Map<String, LexUserType> _defsByRef = const {};
 
 void setLexServiceRuleConfig(final LexServiceRuleConfig config) {
   _config = config;
 }
 
 void setLexiconDocs(final List<LexiconDoc> docs) {
-  _lexiconDocs = List.unmodifiable(docs);
+  final index = <String, LexUserType>{};
+  for (final doc in docs) {
+    final lexiconId = doc.id.toString();
+    for (final def in doc.defs.entries) {
+      index['$lexiconId#${def.key}'] = def.value;
+    }
+  }
+  _defsByRef = Map.unmodifiable(index);
 }
 
 bool isDeprecated(final String? description) {
@@ -43,15 +55,15 @@ String getLexObjectName(
   final String defName,
   final List<String> mainVariants,
 ) {
+  String namePrefix() =>
+      Nsid(lexiconId).nameSegments().map(toFirstUpperCase).join();
+
   if (defName == 'main') {
-    final parts = lexiconId.split('.');
-    return _nameSegments(parts).map(toFirstUpperCase).join();
+    return namePrefix();
   }
 
   if (defName == 'record') {
-    final parts = lexiconId.split('.');
-    return _nameSegments(parts).map(toFirstUpperCase).join() +
-        toFirstUpperCase(defName);
+    return namePrefix() + toFirstUpperCase(defName);
   }
 
   if (lexiconId.endsWith('defs')) {
@@ -59,24 +71,10 @@ String getLexObjectName(
   }
 
   if (mainVariants.contains(lexiconId)) {
-    final parts = lexiconId.split('.');
-
-    return _nameSegments(parts).map(toFirstUpperCase).join() +
-        toFirstUpperCase(defName);
+    return namePrefix() + toFirstUpperCase(defName);
   }
 
   return toFirstUpperCase(defName);
-}
-
-/// Returns the name segments of a lexicon id after its 2-part authority,
-/// capped at two segments.
-///
-/// Most lexicon ids have at least four segments (e.g. `app.bsky.actor.profile`
-/// -> `[actor, profile]`), but shorter ids such as `com.germnetwork.declaration`
-/// -> `[declaration]` are also supported.
-List<String> _nameSegments(final List<String> parts) {
-  final end = parts.length < 4 ? parts.length : 4;
-  return parts.sublist(2, end);
 }
 
 /// Ex: URichtextFacetFeatures
@@ -192,11 +190,11 @@ String _getHomeDirForService(final String lexiconId) {
 }
 
 String _getFileDir(final String lexiconId) {
-  return lexiconId.split('.').join('/');
+  return Nsid(lexiconId).fileDir;
 }
 
 String getFileDirForService(final String lexiconId) {
-  return lexiconId.split('.').sublist(0, 2).join('/');
+  return Nsid(lexiconId).serviceDir;
 }
 
 String getLexObjectNameFromRef(
@@ -204,19 +202,19 @@ String getLexObjectNameFromRef(
   final String ref,
   final List<String> mainVariants,
 ) {
-  if (ref.startsWith('#')) {
-    final defName = ref.substring(1);
-
-    return getLexObjectName(lexiconId, defName, mainVariants);
-  }
-
-  if (ref.contains('#')) {
-    final parts = ref.split('#');
-
-    return getLexObjectName(parts[0], parts[1], mainVariants);
-  }
-
-  return getLexObjectName(ref, '', mainVariants);
+  return switch (LexRef.parse(ref)) {
+    LocalRef(:final defName) => getLexObjectName(
+      lexiconId,
+      defName,
+      mainVariants,
+    ),
+    ForeignRef(:final lexicon, :final defName) => getLexObjectName(
+      lexicon.raw,
+      defName,
+      mainVariants,
+    ),
+    BareRef(:final lexicon) => getLexObjectName(lexicon.raw, '', mainVariants),
+  };
 }
 
 String getLexObjectPackagePathFromRef(
@@ -226,58 +224,40 @@ String getLexObjectPackagePathFromRef(
 }) {
   final fileNamePrefix = isUnion ? 'union_' : '';
   final relativePath = getPackageRelativePath(lexiconId, ref);
+  final samePackage = _isInTheSamePackage(lexiconId, ref);
 
-  if (ref.startsWith('#')) {
-    final defName = ref.substring(1);
-    return '$relativePath/$fileNamePrefix${getLexObjectFileName(defName)}.dart';
-  }
+  final fileName = switch (LexRef.parse(ref)) {
+    LocalRef(:final defName) => getLexObjectFileName(defName),
+    ForeignRef(:final lexicon, :final defName) =>
+      samePackage ? getLexObjectFileName(defName) : getPackageName(lexicon.raw),
+    BareRef(:final lexicon) =>
+      samePackage ? getLexObjectFileName('main') : getPackageName(lexicon.raw),
+  };
 
-  if (_isInTheSamePackage(lexiconId, ref)) {
-    if (ref.contains('#')) {
-      final parts = ref.split('#');
-      return '$relativePath/$fileNamePrefix${getLexObjectFileName(parts[1])}.dart';
-    } else {
-      return '$relativePath/$fileNamePrefix${getLexObjectFileName('main')}.dart';
-    }
-  } else {
-    if (ref.contains('#')) {
-      final $lexiconId = ref.split('#').first;
-      return '$relativePath/$fileNamePrefix${getPackageName($lexiconId)}.dart';
-    } else {
-      return '$relativePath/$fileNamePrefix${getPackageName(ref)}.dart';
-    }
-  }
+  return '$relativePath/$fileNamePrefix$fileName.dart';
 }
 
 String getLexObjectPackagePathFromRefForService(
   final String lexiconId,
   final String ref,
 ) {
-  if (ref.startsWith('#')) {
-    final relativePath = lexiconId.split('.').sublist(2).join('/');
-    final defName = ref.substring(1);
-    return '$relativePath/${getLexObjectFileName(defName)}.dart';
-  }
+  String foreignPath(final Nsid lexicon) =>
+      '${_getHomeDirForService(lexicon.raw)}/${getPackageName(lexicon.raw)}.dart';
 
-  if (_isInTheSamePackage(lexiconId, ref)) {
-    if (ref.contains('#')) {
-      final parts = ref.split('#');
-      final relativePath = parts.first.split('.').sublist(2).join('/');
-      return '$relativePath/${getLexObjectFileName(parts[1])}.dart';
-    } else {
-      final relativePath = ref.split('.').sublist(2).join('/');
-      return '$relativePath/${getLexObjectFileName('main')}.dart';
-    }
-  } else {
-    if (ref.contains('#')) {
-      final $lexiconId = ref.split('#').first;
-      final relativePath = _getHomeDirForService($lexiconId);
-      return '$relativePath/${getPackageName($lexiconId)}.dart';
-    } else {
-      final relativePath = _getHomeDirForService(ref);
-      return '$relativePath/${getPackageName(ref)}.dart';
-    }
-  }
+  final samePackage = _isInTheSamePackage(lexiconId, ref);
+
+  return switch (LexRef.parse(ref)) {
+    LocalRef(:final defName) =>
+      '${Nsid(lexiconId).dirAfterAuthority}/${getLexObjectFileName(defName)}.dart',
+    ForeignRef(:final lexicon, :final defName) =>
+      samePackage
+          ? '${lexicon.dirAfterAuthority}/${getLexObjectFileName(defName)}.dart'
+          : foreignPath(lexicon),
+    BareRef(:final lexicon) =>
+      samePackage
+          ? '${lexicon.dirAfterAuthority}/${getLexObjectFileName('main')}.dart'
+          : foreignPath(lexicon),
+  };
 }
 
 String getLexObjectPackagePathForUnion(
@@ -291,23 +271,13 @@ String getLexObjectPackagePathForUnion(
 }
 
 String getPackageRelativePath(final String lexiconId, final String ref) {
-  if (ref.startsWith('#')) return '.';
-
-  if (_isInTheSamePackage(lexiconId, ref)) {
-    if (ref.contains('#')) {
-      final parts = ref.split('#');
-      return '../../../../${_getFileDir(parts[0])}';
-    } else {
-      return '../../../../${_getFileDir(ref)}';
-    }
-  } else {
-    if (ref.contains('#')) {
-      final lexiconId = ref.split('#').first;
-      return 'package:${getRootPackageName(lexiconId)}';
-    } else {
-      return 'package:${getRootPackageName(ref)}';
-    }
-  }
+  return switch (LexRef.parse(ref)) {
+    LocalRef() => '.',
+    ForeignRef(:final lexicon) || BareRef(:final lexicon) =>
+      _isInTheSamePackage(lexiconId, ref)
+          ? '../../../../${_getFileDir(lexicon.raw)}'
+          : 'package:${getRootPackageName(lexicon.raw)}',
+  };
 }
 
 bool _isInTheSamePackage(final String lexiconId, final String ref) {
@@ -316,11 +286,11 @@ bool _isInTheSamePackage(final String lexiconId, final String ref) {
 }
 
 String _getServiceFromLexiconId(final String lexiconId) {
-  return lexiconId.split('.').sublist(0, 2).join('.');
+  return Nsid(lexiconId).authority;
 }
 
 String getRecordTypeName(final String lexiconId) {
-  return lexiconId.split('.').sublist(2).map(toFirstUpperCase).join();
+  return Nsid(lexiconId).segmentsAfterAuthority().map(toFirstUpperCase).join();
 }
 
 String getRootPackageName(final String lexiconId) {
@@ -343,15 +313,15 @@ LexiconNamespaceRule _getNamespaceRule(final String lexiconId) {
 }
 
 String getPackageName(final String lexiconId) {
-  return lexiconId.split('.').join('_').toLowerCase();
+  return Nsid(lexiconId).packageName;
 }
 
 String getServiceName(final String lexiconId) {
-  return lexiconId.split('.')[2];
+  return Nsid(lexiconId).service;
 }
 
 String getServiceApiName(final String lexiconId) {
-  return lexiconId.split('.').last;
+  return Nsid(lexiconId).method;
 }
 
 String getLexObjectAbsolutePath(final String lexiconId, final String fileName) {
@@ -362,8 +332,7 @@ String getLexObjectAbsolutePathForService(
   final String lexiconId,
   final String fileName,
 ) {
-  final parts = lexiconId.split('.');
-  final root = parts.sublist(0, 2).join('/');
+  final root = Nsid(lexiconId).serviceDir;
   return '${_getHomeDirForExport(lexiconId)}/$root/$fileName.dart';
 }
 
@@ -385,14 +354,10 @@ String getLexKnownValuesElementName(
     if (value.startsWith('#')) {
       assert(lexiconId != null);
 
-      return toFirstLowerCase(
-            lexiconId!.split('.').map(toFirstUpperCase).join(),
-          ) +
+      return toFirstLowerCase(Nsid(lexiconId!).pascalCase()) +
           toFirstUpperCase(val);
     } else {
-      return toFirstLowerCase(
-            parts.first.split('.').map(toFirstUpperCase).join(),
-          ) +
+      return toFirstLowerCase(Nsid(parts.first).pascalCase()) +
           toFirstUpperCase(val);
     }
   }
@@ -403,7 +368,7 @@ String getLexKnownValuesElementName(
 }
 
 String getNamespaceIdForApi(final String lexiconId) {
-  return toFirstLowerCase(lexiconId.split('.').map(toFirstUpperCase).join());
+  return toFirstLowerCase(Nsid(lexiconId).pascalCase());
 }
 
 LexUserType? getRelatedDocFromRef(
@@ -414,26 +379,18 @@ LexUserType? getRelatedDocFromRef(
 
   final String targetLexiconId;
   final String defName;
-  if (ref.startsWith('#')) {
-    // Local ref within the same lexicon doc (e.g. `#draftEmbedGalleryItems`).
-    if (lexiconId == null) return null;
-    targetLexiconId = lexiconId;
-    defName = ref.substring(1);
-  } else if (ref.contains('#')) {
-    final parts = ref.split('#');
-    targetLexiconId = parts.first;
-    defName = parts.last;
-  } else {
-    return null;
+  switch (LexRef.parse(ref)) {
+    case LocalRef(defName: final name):
+      // Local ref within the same lexicon doc (e.g. `#draftEmbedGalleryItems`).
+      if (lexiconId == null) return null;
+      targetLexiconId = lexiconId;
+      defName = name;
+    case ForeignRef(:final lexicon, defName: final name):
+      targetLexiconId = lexicon.raw;
+      defName = name;
+    case BareRef():
+      return null;
   }
 
-  for (final doc in _lexiconDocs) {
-    for (final def in doc.defs.entries) {
-      if (doc.id.toString() == targetLexiconId && def.key == defName) {
-        return def.value;
-      }
-    }
-  }
-
-  return null;
+  return _defsByRef['$targetLexiconId#$defName'];
 }

--- a/packages/lex_gen/lib/src/utils.dart
+++ b/packages/lex_gen/lib/src/utils.dart
@@ -2,7 +2,7 @@
 // All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// Converts a string to camel case.
+/// Upper-cases the first character of [str], leaving the rest unchanged.
 String toFirstUpperCase(final String str) {
   if (str.isEmpty) return str;
 

--- a/packages/lex_gen/pubspec.yaml
+++ b/packages/lex_gen/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lex_gen
 resolution: workspace
 description: Provides a generator that automatically generates source code from the Lexicon in the AT Protocol.
-version: 0.4.0
+version: 0.4.1
 homepage: https://atprotodart.com
 repository: https://github.com/myConsciousness/atproto.dart/tree/main/packages/lex_gen
 issue_tracker: https://github.com/myConsciousness/atproto.dart/issues

--- a/packages/lex_gen/test/src/commands/lex_command_test.dart
+++ b/packages/lex_gen/test/src/commands/lex_command_test.dart
@@ -9,21 +9,26 @@ import 'package:test/test.dart';
 // Project imports:
 import 'package:lex_gen/src/commands/types/lex_command.dart';
 import 'package:lex_gen/src/commands/types/lex_parameter.dart';
+import 'package:lex_gen/src/model/lex_def_kind.dart';
 
 void main() {
   group('record command (L-15.3) — shared mixin', () {
-    final command =
-        LexCommand(NSID('app.bsky.feed.post'), 'A declaration of a post.', [
-          LexParameter('text', 'The primary text.', true, null, type: 'string'),
-          LexParameter(
-            'facets',
-            null,
-            false,
-            null,
-            type: 'array',
-            itemsType: 'union',
-          ),
-        ], isRecord: true);
+    final command = LexCommand(
+      NSID('app.bsky.feed.post'),
+      'A declaration of a post.',
+      [
+        LexParameter('text', 'The primary text.', true, null, type: 'string'),
+        LexParameter(
+          'facets',
+          null,
+          false,
+          null,
+          type: 'array',
+          itemsType: 'union',
+        ),
+      ],
+      kind: LexCommandKind.record,
+    );
 
     final output = command.format();
 
@@ -98,7 +103,7 @@ void main() {
       NSID('app.bsky.feed.getTimeline'),
       'Get a timeline.',
       [LexParameter('limit', null, false, '50', type: 'integer')],
-      isQuery: true,
+      kind: LexCommandKind.query,
     );
 
     test('integer option parses via int.tryParse + usageException', () {
@@ -117,7 +122,7 @@ void main() {
       NSID('tools.ozone.set.upsertSet'),
       'Upsert a set.',
       const [],
-      isProcedure: true,
+      kind: LexCommandKind.procedure,
       isRawJsonBody: true,
     );
 

--- a/packages/lex_gen/test/src/golden/feed_post_golden_test.dart
+++ b/packages/lex_gen/test/src/golden/feed_post_golden_test.dart
@@ -9,6 +9,8 @@ import 'package:test/test.dart';
 // Project imports:
 import 'package:lex_gen/src/services/fmt/lex_record_generator.dart';
 
+import '../test_context.dart';
+
 /// End-to-end golden: a fixture Lexicon document is parsed and run through the
 /// real record generator, then the emitted Dart source is asserted against the
 /// behaviors fixed in this workstream. This exercises the full
@@ -44,7 +46,14 @@ void main() {
     final doc = lex.LexiconDoc.fromJson(_fixture);
     final record = doc.defs['main']!.data as lex.LexRecord;
 
-    final output = generateLexRecord(doc.id, 'main', record, const []).format();
+    final ctx = buildTestGenContext();
+    final output = generateLexRecord(
+      ctx,
+      doc.id,
+      'main',
+      record,
+      const [],
+    ).format(ctx);
 
     test('(G-17) createdAt is UTC-normalized via iso8601', () {
       expect(

--- a/packages/lex_gen/test/src/model/lex_ref_test.dart
+++ b/packages/lex_gen/test/src/model/lex_ref_test.dart
@@ -1,0 +1,33 @@
+// Copyright (c) 2023-2026, Shinya Kato.
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// Package imports:
+import 'package:test/test.dart';
+
+// Project imports:
+import 'package:lex_gen/src/model/lex_ref.dart';
+
+void main() {
+  group('LexRef.parse', () {
+    test('classifies a local ref (#def)', () {
+      final ref = LexRef.parse('#profileView');
+      expect(ref, isA<LocalRef>());
+      expect((ref as LocalRef).defName, 'profileView');
+    });
+
+    test('classifies a foreign ref (a.b#def)', () {
+      final ref = LexRef.parse('app.bsky.actor.defs#profileView');
+      expect(ref, isA<ForeignRef>());
+      ref as ForeignRef;
+      expect(ref.lexicon.raw, 'app.bsky.actor.defs');
+      expect(ref.defName, 'profileView');
+    });
+
+    test('classifies a bare ref (a.b)', () {
+      final ref = LexRef.parse('app.bsky.actor.profile');
+      expect(ref, isA<BareRef>());
+      expect((ref as BareRef).lexicon.raw, 'app.bsky.actor.profile');
+    });
+  });
+}

--- a/packages/lex_gen/test/src/model/nsid_test.dart
+++ b/packages/lex_gen/test/src/model/nsid_test.dart
@@ -1,0 +1,48 @@
+// Copyright (c) 2023-2026, Shinya Kato.
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// Package imports:
+import 'package:test/test.dart';
+
+// Project imports:
+import 'package:lex_gen/src/model/nsid.dart';
+
+void main() {
+  group('Nsid', () {
+    final id = Nsid('app.bsky.actor.profile');
+
+    test('decomposes a 4-segment id', () {
+      expect(id.segments, ['app', 'bsky', 'actor', 'profile']);
+      expect(id.authority, 'app.bsky');
+      expect(id.service, 'actor');
+      expect(id.method, 'profile');
+      expect(id.fileDir, 'app/bsky/actor/profile');
+      expect(id.serviceDir, 'app/bsky');
+      expect(id.serviceId, 'app.bsky.actor');
+      expect(id.serviceIdDir, 'app/bsky/actor');
+      expect(id.packageName, 'app_bsky_actor_profile');
+      expect(id.dirAfterAuthority, 'actor/profile');
+      expect(id.pascalCase(), 'AppBskyActorProfile');
+    });
+
+    test('nameSegments caps at two segments after the authority', () {
+      expect(id.nameSegments(), ['actor', 'profile']);
+      expect(Nsid('app.bsky.feed.generator.extra').nameSegments(), [
+        'feed',
+        'generator',
+      ]);
+    });
+
+    test('supports short ids below four segments', () {
+      final short = Nsid('com.germnetwork.declaration');
+      expect(short.nameSegments(), ['declaration']);
+      expect(short.segmentsAfterAuthority(), ['declaration']);
+      expect(short.method, 'declaration');
+    });
+
+    test('toString returns the raw id', () {
+      expect(id.toString(), 'app.bsky.actor.profile');
+    });
+  });
+}

--- a/packages/lex_gen/test/src/services/fmt/lex_property_generator_test.dart
+++ b/packages/lex_gen/test/src/services/fmt/lex_property_generator_test.dart
@@ -10,6 +10,8 @@ import 'package:test/test.dart';
 import 'package:lex_gen/src/services/fmt/lex_property_generator.dart';
 import 'package:lex_gen/src/services/object/lex_property.dart';
 
+import '../../test_context.dart';
+
 /// Builds a `{name: LexObjectProperty}` map from raw fixture JSON, mirroring how
 /// the generator receives object properties.
 Map<String, lex.LexObjectProperty> _props(
@@ -27,6 +29,7 @@ List<LexProperty> _generate(
   final List<String>? nullable,
 }) {
   return generateLexProperties(
+    buildTestGenContext(),
     lex.NSID('app.bsky.feed.post'),
     'main',
     _props(propsJson),

--- a/packages/lex_gen/test/src/services/object/lex_object_test.dart
+++ b/packages/lex_gen/test/src/services/object/lex_object_test.dart
@@ -10,6 +10,8 @@ import 'package:lex_gen/src/dart_type.dart';
 import 'package:lex_gen/src/services/object/lex_object.dart';
 import 'package:lex_gen/src/services/object/lex_property.dart';
 
+import '../../test_context.dart';
+
 void main() {
   group('LexObject.format golden', () {
     final object = LexObject(
@@ -39,7 +41,7 @@ void main() {
       ],
     );
 
-    final output = object.format();
+    final output = object.format(buildTestGenContext());
 
     test('keeps includeIfNull:false on the class', () {
       expect(output, contains('@JsonSerializable(includeIfNull: false)'));

--- a/packages/lex_gen/test/src/services/object/lex_service_test.dart
+++ b/packages/lex_gen/test/src/services/object/lex_service_test.dart
@@ -12,6 +12,8 @@ import 'package:lex_gen/src/services/object/lex_property.dart';
 import 'package:lex_gen/src/services/object/lex_record.dart';
 import 'package:lex_gen/src/services/object/lex_service.dart';
 
+import '../../test_context.dart';
+
 void main() {
   group('LexService record accessor (G-2)', () {
     final record = LexRecord(
@@ -41,7 +43,7 @@ void main() {
       ],
     );
 
-    final output = service.format();
+    final output = service.format(buildTestGenContext());
 
     test('create() injects \$type into the record map', () {
       // The `\$type` must appear inside the `record: { ... }` literal so a

--- a/packages/lex_gen/test/src/services/object/lex_service_test.dart
+++ b/packages/lex_gen/test/src/services/object/lex_service_test.dart
@@ -7,6 +7,7 @@ import 'package:test/test.dart';
 
 // Project imports:
 import 'package:lex_gen/src/dart_type.dart';
+import 'package:lex_gen/src/model/lex_def_kind.dart';
 import 'package:lex_gen/src/services/object/lex_property.dart';
 import 'package:lex_gen/src/services/object/lex_record.dart';
 import 'package:lex_gen/src/services/object/lex_service.dart';
@@ -35,7 +36,7 @@ void main() {
           lexiconId: 'app.bsky.feed.post',
           name: 'post',
           inputType: record,
-          isRecord: true,
+          kind: LexDefKind.record,
         ),
       ],
     );

--- a/packages/lex_gen/test/src/services/object/lex_union_test.dart
+++ b/packages/lex_gen/test/src/services/object/lex_union_test.dart
@@ -8,6 +8,8 @@ import 'package:test/test.dart';
 // Project imports:
 import 'package:lex_gen/src/services/object/lex_union.dart';
 
+import '../../test_context.dart';
+
 void main() {
   group('LexUnion.format (G-4)', () {
     final union = const LexUnion(
@@ -20,7 +22,7 @@ void main() {
     );
 
     test('fromJson does not swallow conversion errors', () {
-      final output = union.format();
+      final output = union.format(buildTestGenContext());
 
       // The catch-all `try { ... } catch (_) { return unknown }` is removed so
       // a matched-`\$type` payload that fails to convert throws instead of
@@ -31,13 +33,13 @@ void main() {
 
     test('fromJson still falls back to unknown when nothing matches', () {
       expect(
-        union.format(),
+        union.format(buildTestGenContext()),
         contains('return UFeedPostReply.unknown(data: json);'),
       );
     });
 
     test('each known ref is dispatched by validate()', () {
-      final output = union.format();
+      final output = union.format(buildTestGenContext());
       expect(output, contains('if (PostView.validate(json)) {'));
       expect(output, contains('if (NotFoundPost.validate(json)) {'));
     });

--- a/packages/lex_gen/test/src/test_context.dart
+++ b/packages/lex_gen/test/src/test_context.dart
@@ -1,0 +1,31 @@
+// Copyright (c) 2023-2026, Shinya Kato.
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// Project imports:
+import 'package:lex_gen/src/config.dart';
+import 'package:lex_gen/src/services/gen_context.dart';
+
+/// A [GenContext] wired with the same namespace rules the real generator uses,
+/// for exercising `format()` / `generateLex*` helpers in unit tests.
+GenContext buildTestGenContext() => GenContext(
+  serviceRuleConfig: const LexServiceRuleConfig(
+    namespaceRules: [
+      LexiconNamespaceRule(
+        prefixes: ['com.atproto.', 'com.germnetwork.'],
+        homeDir: 'packages/atproto/lib/src/services/codegen',
+        exportCodegenPath: 'package:atproto/src/services/codegen',
+        servicePackagePath: 'package:atproto',
+        rootPackageName: 'atproto',
+      ),
+      LexiconNamespaceRule(
+        prefixes: ['app.bsky.', 'chat.bsky.', 'tools.ozone.'],
+        homeDir: 'packages/bluesky/lib/src/services/codegen',
+        exportCodegenPath: 'package:bluesky/src/services/codegen',
+        servicePackagePath: 'package:bluesky',
+        rootPackageName: 'bluesky',
+      ),
+    ],
+  ),
+  docs: const [],
+);


### PR DESCRIPTION
## Summary

Behavior-preserving readability / standardization / optimization refactor of the `lex_gen` Lexicon code generator, delivered as a sequence of focused commits.

**Generated output is byte-for-byte identical to v0.4.0.** Verified after every step by hashing the raw generator output across `atproto` / `bluesky` / `bluesky_cli` (stable hash `76e877f…`). No downstream regeneration is required. `dart analyze` clean, **70** tests pass (was 63).

## What changed

| Area | Change |
|---|---|
| **Value objects** | New `Nsid` / `LexRef` (`lib/src/model/`) parse a lexicon id / ref **once**, replacing ~40 inline `split('.')` / `split('#')` sites across 8 files. Ref classification is an exhaustive `switch` over `LocalRef`/`ForeignRef`/`BareRef`. |
| **Sealed kinds** | `LexApi` / `LexCommand` drop the mutually-exclusive `isQuery`/`isProcedure`/`isSubscription`/`isRecord` (+ `isBlobProcedure`) boolean sets for `LexDefKind` / `LexCommandKind` enums dispatched by exhaustive `switch`. |
| **Unified emit** | `renderFreezedDataClass` collapses the four byte-identical freezed data-class templates (`LexObject`/`LexRecord`/`LexInput`/`LexOutput`) into one function. |
| **RepoCommitHandler** | Resolve each record type name once (was 6 passes); merge the near-identical `_onCreate`/`_onUpdate` event builders into one `_getMutationEvent`. |
| **Record command split** | The 225-line `LexCommand._getRecordCommand` is split into per-subcommand emitters; `create`/`put` unified into `_recordMutationClass`; hardcoded `com.atproto.repo.getRecord`/`listRecords` ids hoisted to constants. |
| **Type hierarchy** | `LexType` split into a minimal base + `GeneratableType`, so the non-generatable `LexMessage` no longer throws `UnsupportedError` from inherited members. |
| **Dependency injection** | The two `rule.dart` **module singletons** (`_config`/`_defsByRef` + `setLex*` setters) are removed in favour of an explicit `GenContext` threaded through the generators and `rule.*` helpers — no hidden global state or setter-call ordering; helpers are unit-testable. |
| **Optimization** | `getExtensions` O(n²)→O(1); `LexUnion` resolves each ref name once; `getRelatedDocFromRef` O(docs×defs)→O(1) index. |
| **Cleanups** | Fix `_LexLexXrpc*` double-`Lex` typos; dedupe record-accessor `rkey` handling and `LexOutput` upload-ref predicate; remove dead `getDescription` helpers; `putIfAbsent` aggregation; doc-comment fix. |
| **Tests** | Unit tests for `Nsid` / `LexRef`; a shared `test_context.dart` builds a `GenContext` for the model tests. |

## Commits

1. `refactor(lex_gen): value objects, sealed kinds, unified emit` — F1–F7 core + v0.4.1 bump
2. `refactor(lex_gen): consolidate RepoCommitHandler builders`
3. `refactor(lex_gen): split LexCommand._getRecordCommand`
4. `refactor(lex_gen): split LexType into base + GeneratableType`
5. `refactor(lex_gen): remove rule.dart global state via GenContext`

## Verification

- Byte-identical output guard run after every commit — hash never changed.
- `dart analyze` (lib + test): no issues. `dart test`: 70/70 pass, including the golden test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)