### PR TITLE
feat(bluesky_text_flutter): new Flutter companion package

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -32,6 +32,9 @@ atproto:
 bluesky_text:
 - changed-files:
   - any-glob-to-any-file: packages/bluesky_text/**
+bluesky_text_flutter:
+- changed-files:
+  - any-glob-to-any-file: packages/bluesky_text_flutter/**
 bluesky:
 - changed-files:
   - any-glob-to-any-file: packages/bluesky/**

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,3 +55,48 @@ jobs:
           if test -d "test"; then
             dart test
           fi
+
+  # Flutter packages cannot use `dart pub get` / the Dart-only workspace, so
+  # they run in a separate job with the Flutter SDK installed.
+  flutter:
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: ${{ matrix.package_path }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        package_path:
+          - packages/bluesky_text_flutter
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Check format
+        run: dart format --set-exit-if-changed .
+
+      - name: Analyze
+        run: flutter analyze
+
+      - name: Run tests
+        run: |
+          if test -d "test"; then
+            flutter test
+          fi
+
+      - name: Analyze example
+        run: |
+          if test -d "example"; then
+            cd example
+            flutter pub get
+            flutter analyze
+          fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,10 +93,13 @@ jobs:
             flutter test
           fi
 
-      - name: Analyze example
+      - name: Analyze & test example
         run: |
           if test -d "example"; then
             cd example
             flutter pub get
             flutter analyze
+            if test -d "test"; then
+              flutter test
+            fi
           fi

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ The atproto.dart ecosystem is organized into focused packages that work together
 | Package | Description | pub.dev | Docs |
 | ------- | ----------- | :-----: | :--: |
 | **[bluesky_text](https://github.com/myConsciousness/atproto.dart/tree/main/packages/bluesky_text)** | Rich text parsing for mentions, links, hashtags, and formatting | [![pub package](https://img.shields.io/pub/v/bluesky_text.svg?logo=dart&logoColor=00b9fc)](https://pub.dartlang.org/packages/bluesky_text) | [README](https://github.com/myConsciousness/atproto.dart/tree/main/packages/bluesky_text/README.md) / [GUIDE](https://atprotodart.com/docs/packages/bluesky_text) |
+| **[bluesky_text_flutter](https://github.com/myConsciousness/atproto.dart/tree/main/packages/bluesky_text_flutter)** | Flutter widgets for `bluesky_text`: a rich-text editing controller and a post viewer | [![pub package](https://img.shields.io/pub/v/bluesky_text_flutter.svg?logo=dart&logoColor=00b9fc)](https://pub.dartlang.org/packages/bluesky_text_flutter) | [README](https://github.com/myConsciousness/atproto.dart/tree/main/packages/bluesky_text_flutter/README.md) |
 
 ### 2.4. CLI Tool
 

--- a/packages/bluesky_text_flutter/CHANGELOG.md
+++ b/packages/bluesky_text_flutter/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Release Note
+
+## v0.1.0
+
+- **FEAT**: Initial release. Flutter companion for
+  [bluesky_text](https://pub.dev/packages/bluesky_text).
+  - `BlueskyTextEditingController` — a `TextEditingController` that highlights
+    entities (handles, links, tags) and the part of the text that exceeds the
+    post-length limit as the user types, via `BlueskyText.segments`, in a single
+    pass per keystroke. Preserves the IME composing underline and exposes
+    `overflow` for a live character counter.
+  - `BlueskyRichText` — a widget that renders a fetched post from its
+    authoritative server facets (via `renderFacets`) with tappable mentions,
+    links and tags. The `TapGestureRecognizer`s are owned and disposed by the
+    widget, so callers never leak them.

--- a/packages/bluesky_text_flutter/LICENSE
+++ b/packages/bluesky_text_flutter/LICENSE
@@ -1,0 +1,28 @@
+BSD 3-Clause License
+
+Copyright (c) 2023-2026, Shinya Kato
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/packages/bluesky_text_flutter/README.md
+++ b/packages/bluesky_text_flutter/README.md
@@ -1,0 +1,65 @@
+<p align="center">
+  <b>Flutter widgets for <a href="https://pub.dev/packages/bluesky_text">bluesky_text</a> 🦋</b>
+</p>
+
+# bluesky_text_flutter
+
+The "last mile" Flutter layer on top of
+[`bluesky_text`](https://pub.dev/packages/bluesky_text): drop-in widgets for the
+two things every Bluesky client needs — a **rich-text composer** and a
+**post viewer** — so you never hand-roll `TextSpan` trees or manage
+`GestureRecognizer` lifecycles yourself.
+
+## Features ⭐
+
+- ✅ **`BlueskyTextEditingController`** — live-highlights entities (handles,
+  links, tags) and the **over-limit tail** as the user types, in one pass per
+  keystroke. Keeps the IME composing underline. Exposes `overflow` for a
+  character counter.
+- ✅ **`BlueskyRichText`** — renders a **fetched** post from its authoritative
+  server facets (mentions carry their DID) with **tappable** mentions, links and
+  tags. Recognizers are owned and disposed by the widget — **no leaks**.
+- ✅ Re-exports all of `bluesky_text`, so you import a single package.
+
+## Composer
+
+```dart
+final controller = BlueskyTextEditingController();
+
+TextField(
+  controller: controller,
+  maxLines: null,
+);
+
+// Character counter:
+final overflow = controller.overflow; // null when within the 300 / 3000 limit
+```
+
+Entities default to the theme's primary color and the over-limit tail to the
+error color; override with `entityStyle`, `overflowStyle`, or a full
+`styleBuilder`.
+
+## Viewer
+
+```dart
+BlueskyRichText(
+  text: post.record.text,
+  facets: post.record.facets
+          ?.map((f) => PostFacet.fromJson(f.toJson()))
+          .toList() ??
+      const [],
+  onMentionTap: (did) => context.go('/profile/$did'),
+  onLinkTap: (uri) => launchUrlString(uri),
+  onTagTap: (tag) => context.go('/tag/$tag'),
+);
+```
+
+## Getting Started 💪
+
+```yaml
+dependencies:
+  bluesky_text_flutter: ^0.1.0
+```
+
+See [`example/lib/main.dart`](example/lib/main.dart) for a runnable demo of both
+widgets.

--- a/packages/bluesky_text_flutter/analysis_options.yaml
+++ b/packages/bluesky_text_flutter/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: package:flutter_lints/flutter.yaml

--- a/packages/bluesky_text_flutter/example/lib/main.dart
+++ b/packages/bluesky_text_flutter/example/lib/main.dart
@@ -5,57 +5,95 @@
 import 'package:bluesky_text_flutter/bluesky_text_flutter.dart';
 import 'package:flutter/material.dart';
 
-void main() => runApp(const _App());
+void main() => runApp(const ExampleApp());
 
-class _App extends StatelessWidget {
-  const _App();
+/// The signed-in user, and the authors of the sample timeline.
+class _User {
+  const _User(this.name, this.handle, this.color);
+  final String name;
+  final String handle;
+  final Color color;
+}
+
+class _Post {
+  const _Post(this.author, this.text, this.time);
+  final _User author;
+  final String text;
+  final String time;
+}
+
+const _me = _User('You', 'you.bsky.social', Color(0xFF7C4DFF));
+
+final _seedTimeline = <_Post>[
+  const _Post(
+    _User('Shinya Kato', 'shinyakato.dev', Color(0xFF1DA1F2)),
+    'gm @bsky.app — shipping bluesky_text_flutter today 🦋 '
+        'see https://atprotodart.com #atproto #dart',
+    '2h',
+  ),
+  const _Post(
+    _User('Bluesky', 'bsky.app', Color(0xFF0A7AFF)),
+    'Rich text is just facets: byte ranges + features. Tap a mention like '
+        '@atproto.com or a #tag to try it out.',
+    '5h',
+  ),
+  const _Post(
+    _User('AT Protocol', 'atproto.com', Color(0xFF10A37F)),
+    'Facets use UTF-8 byteStart/byteEnd. bluesky_text does the '
+        'UTF-8 ↔ UTF-16 conversion so your spans line up: '
+        'https://atproto.com/specs/facets',
+    '1d',
+  ),
+];
+
+/// Derives display facets from [text] using bluesky_text, so the byte offsets
+/// are always correct. In a real client these come from the API instead
+/// (`PostFacet.fromJson`); a mention's DID would be resolved server-side.
+List<PostFacet> _facetsOf(String text) => [
+  for (final entity in BlueskyText(text).entities)
+    PostFacet(
+      byteStart: entity.indices.start,
+      byteEnd: entity.indices.end,
+      features: [
+        FacetFeature(
+          type: entity.type,
+          value: entity.isHandle ? 'did:plc:${entity.value}' : entity.value,
+        ),
+      ],
+    ),
+];
+
+/// The root of the demo app.
+class ExampleApp extends StatelessWidget {
+  const ExampleApp({super.key});
 
   @override
   Widget build(BuildContext context) => MaterialApp(
-    theme: ThemeData(colorSchemeSeed: Colors.blue),
-    home: const _Home(),
+    debugShowCheckedModeBanner: false,
+    title: 'bluesky_text_flutter',
+    theme: ThemeData(
+      colorSchemeSeed: const Color(0xFF0A7AFF),
+      useMaterial3: true,
+    ),
+    home: const _Feed(),
   );
 }
 
-class _Home extends StatefulWidget {
-  const _Home();
+class _Feed extends StatefulWidget {
+  const _Feed();
 
   @override
-  State<_Home> createState() => _HomeState();
+  State<_Feed> createState() => _FeedState();
 }
 
-class _HomeState extends State<_Home> {
-  final _controller = BlueskyTextEditingController(
-    text: 'Hello @shinyakato.dev 🦋 visit https://shinyakato.dev #bluesky',
-  );
-
-  //! A fetched post's facets come from the API (`PostFacet.fromJson(json)`).
-  //! For this offline demo they are derived from bluesky_text so the byte
-  //! offsets are always correct — hand-counting UTF-8 offsets (note the 3-byte
-  //! em dash below) is easy to get wrong.
-  static const _timelineText =
-      'gm @shinyakato.dev — see https://atprotodart.com #atproto';
-  late final _timelineFacets = [
-    for (final entity in BlueskyText(_timelineText).entities)
-      PostFacet(
-        byteStart: entity.indices.start,
-        byteEnd: entity.indices.end,
-        features: [
-          FacetFeature(
-            type: entity.type,
-            //! A mention's DID is resolved server-side; placeholder here.
-            value: entity.isHandle
-                ? 'did:plc:iijrtk7ocored6zuziwmqq3c'
-                : entity.value,
-          ),
-        ],
-      ),
-  ];
+class _FeedState extends State<_Feed> {
+  final _controller = BlueskyTextEditingController();
+  final _timeline = List<_Post>.of(_seedTimeline);
 
   @override
   void initState() {
     super.initState();
-    //* Rebuild the counter as the user types.
+    //* Rebuild so the live preview and counter follow every keystroke.
     _controller.addListener(() => setState(() {}));
   }
 
@@ -65,54 +103,358 @@ class _HomeState extends State<_Home> {
     super.dispose();
   }
 
+  void _post() {
+    final text = _controller.text.trim();
+    if (text.isEmpty) return;
+    setState(() {
+      _timeline.insert(0, _Post(_me, text, 'now'));
+      _controller.clear();
+    });
+  }
+
+  void _onFeatureTap(FacetFeature feature) {
+    final message = switch (feature.type) {
+      EntityType.handle => 'Open profile · ${feature.value}',
+      EntityType.link => 'Open link · ${feature.value}',
+      EntityType.tag || EntityType.cashtag => 'Search · #${feature.value}',
+      EntityType.markdownLink => feature.value,
+    };
+    ScaffoldMessenger.of(context)
+      ..clearSnackBars()
+      ..showSnackBar(
+        SnackBar(content: Text(message), duration: const Duration(seconds: 1)),
+      );
+  }
+
   @override
   Widget build(BuildContext context) {
     final overflow = _controller.overflow;
+    final canPost = _controller.text.trim().isNotEmpty && overflow == null;
 
     return Scaffold(
-      appBar: AppBar(title: const Text('bluesky_text_flutter')),
-      body: Padding(
-        padding: const EdgeInsets.all(16),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            //! 1. Composing: entities in primary, the over-limit tail in error,
-            //! recomputed on every keystroke.
-            TextField(
-              controller: _controller,
-              maxLines: null,
-              decoration: const InputDecoration(border: OutlineInputBorder()),
-            ),
-            const SizedBox(height: 8),
-            Text(
-              overflow == null
-                  ? '${_controller.text.characters.length} / 300'
-                  : '${overflow.graphemeStart - 300} over the limit',
-              style: TextStyle(
-                color: overflow == null
-                    ? null
-                    : Theme.of(context).colorScheme.error,
+      appBar: AppBar(title: const Text('🦋  Home'), centerTitle: false),
+      body: ListView(
+        children: [
+          _Composer(
+            controller: _controller,
+            overflow: overflow,
+            canPost: canPost,
+            onPost: _post,
+          ),
+          _PreviewSection(text: _controller.text, onFeatureTap: _onFeatureTap),
+          const _SectionHeader('Timeline'),
+          for (final post in _timeline)
+            _PostTile(post: post, onFeatureTap: _onFeatureTap),
+        ],
+      ),
+    );
+  }
+}
+
+/// The compose box: avatar + a live-highlighting field + counter + Post button.
+class _Composer extends StatelessWidget {
+  const _Composer({
+    required this.controller,
+    required this.overflow,
+    required this.canPost,
+    required this.onPost,
+  });
+
+  final BlueskyTextEditingController controller;
+  final TextLengthOverflow? overflow;
+  final bool canPost;
+  final VoidCallback onPost;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Container(
+      padding: const EdgeInsets.fromLTRB(12, 12, 12, 8),
+      decoration: BoxDecoration(
+        border: Border(
+          bottom: BorderSide(color: theme.colorScheme.outlineVariant),
+        ),
+      ),
+      child: Column(
+        children: [
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const _Avatar(_me),
+              const SizedBox(width: 12),
+              Expanded(
+                child: TextField(
+                  controller: controller,
+                  maxLines: null,
+                  minLines: 1,
+                  keyboardType: TextInputType.multiline,
+                  style: theme.textTheme.bodyLarge,
+                  decoration: const InputDecoration.collapsed(
+                    hintText: "What's up?",
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          Row(
+            children: [
+              const Spacer(),
+              _Counter(controller: controller, overflow: overflow),
+              const SizedBox(width: 12),
+              FilledButton(
+                onPressed: canPost ? onPost : null,
+                child: const Text('Post'),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// A Bluesky-style circular remaining-characters indicator.
+class _Counter extends StatelessWidget {
+  const _Counter({required this.controller, required this.overflow});
+
+  final BlueskyTextEditingController controller;
+  final TextLengthOverflow? overflow;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final length = BlueskyText(controller.text).length;
+    final remaining = 300 - length;
+    final over = overflow != null;
+
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        if (over || remaining <= 20)
+          Padding(
+            padding: const EdgeInsets.only(right: 6),
+            child: Text(
+              '$remaining',
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: over
+                    ? theme.colorScheme.error
+                    : theme.colorScheme.onSurfaceVariant,
+                fontWeight: over ? FontWeight.bold : FontWeight.normal,
               ),
             ),
-            const Divider(height: 32),
-
-            //! 2. Displaying a fetched post from its server facets.
-            Text('Timeline', style: Theme.of(context).textTheme.titleMedium),
-            const SizedBox(height: 8),
-            BlueskyRichText(
-              text: _timelineText,
-              facets: _timelineFacets,
-              onMentionTap: (did) => _snack('mention: $did'),
-              onLinkTap: (uri) => _snack('link: $uri'),
-              onTagTap: (tag) => _snack('tag: #$tag'),
-            ),
-          ],
+          ),
+        SizedBox(
+          width: 22,
+          height: 22,
+          child: CircularProgressIndicator(
+            value: over ? 1 : (length / 300).clamp(0.0, 1.0),
+            strokeWidth: 2.5,
+            color: over ? theme.colorScheme.error : theme.colorScheme.primary,
+            backgroundColor: theme.colorScheme.outlineVariant,
+          ),
         ),
+      ],
+    );
+  }
+}
+
+/// Shows how the composed text will render, updating on every keystroke.
+class _PreviewSection extends StatelessWidget {
+  const _PreviewSection({required this.text, required this.onFeatureTap});
+
+  final String text;
+  final FeatureTapCallback onFeatureTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final trimmed = text.trim();
+
+    return Container(
+      color: theme.colorScheme.surfaceContainerHighest,
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Icon(
+                Icons.visibility_outlined,
+                size: 15,
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+              const SizedBox(width: 6),
+              Text(
+                'LIVE PREVIEW',
+                style: theme.textTheme.labelSmall?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                  letterSpacing: 0.8,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          if (trimmed.isEmpty)
+            Padding(
+              padding: const EdgeInsets.symmetric(vertical: 8),
+              child: Text(
+                'Start typing above to see how your post will look — mentions, '
+                'links and tags become tappable, and anything past the limit '
+                'turns red.',
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                  fontStyle: FontStyle.italic,
+                ),
+              ),
+            )
+          else
+            Card(
+              margin: EdgeInsets.zero,
+              child: _PostTile(
+                post: _Post(_me, text, 'now'),
+                onFeatureTap: onFeatureTap,
+                divider: false,
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+/// One post row: avatar, name/handle/time header, rich text, action bar.
+class _PostTile extends StatelessWidget {
+  const _PostTile({
+    required this.post,
+    required this.onFeatureTap,
+    this.divider = true,
+  });
+
+  final _Post post;
+  final FeatureTapCallback onFeatureTap;
+  final bool divider;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final muted = theme.textTheme.bodyMedium?.copyWith(
+      color: theme.colorScheme.onSurfaceVariant,
+    );
+
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: divider
+          ? BoxDecoration(
+              border: Border(
+                bottom: BorderSide(color: theme.colorScheme.outlineVariant),
+              ),
+            )
+          : null,
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          _Avatar(post.author),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  children: [
+                    Flexible(
+                      child: Text(
+                        post.author.name,
+                        style: theme.textTheme.bodyMedium?.copyWith(
+                          fontWeight: FontWeight.bold,
+                        ),
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ),
+                    const SizedBox(width: 4),
+                    Flexible(
+                      child: Text(
+                        '@${post.author.handle}',
+                        style: muted,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ),
+                    Text(' · ${post.time}', style: muted),
+                  ],
+                ),
+                const SizedBox(height: 2),
+                BlueskyRichText(
+                  text: post.text,
+                  facets: _facetsOf(post.text),
+                  style: theme.textTheme.bodyMedium,
+                  featureStyle: TextStyle(color: theme.colorScheme.primary),
+                  onFeatureTap: onFeatureTap,
+                ),
+                const SizedBox(height: 8),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    _action(theme, Icons.chat_bubble_outline, '12'),
+                    _action(theme, Icons.repeat, '4'),
+                    _action(theme, Icons.favorite_border, '87'),
+                    _action(theme, Icons.share_outlined, null),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        ],
       ),
     );
   }
 
-  void _snack(String message) => ScaffoldMessenger.of(
-    context,
-  ).showSnackBar(SnackBar(content: Text(message)));
+  Widget _action(ThemeData theme, IconData icon, String? count) {
+    final color = theme.colorScheme.onSurfaceVariant;
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Icon(icon, size: 17, color: color),
+        if (count != null) ...[
+          const SizedBox(width: 6),
+          Text(count, style: theme.textTheme.bodySmall?.copyWith(color: color)),
+        ],
+      ],
+    );
+  }
+}
+
+class _Avatar extends StatelessWidget {
+  const _Avatar(this.user);
+  final _User user;
+
+  @override
+  Widget build(BuildContext context) => CircleAvatar(
+    radius: 20,
+    backgroundColor: user.color,
+    child: Text(
+      user.name.isEmpty ? '?' : user.name.characters.first.toUpperCase(),
+      style: const TextStyle(color: Colors.white, fontWeight: FontWeight.bold),
+    ),
+  );
+}
+
+class _SectionHeader extends StatelessWidget {
+  const _SectionHeader(this.title);
+  final String title;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.fromLTRB(12, 16, 12, 8),
+      child: Text(
+        title,
+        style: theme.textTheme.titleSmall?.copyWith(
+          color: theme.colorScheme.onSurfaceVariant,
+        ),
+      ),
+    );
+  }
 }

--- a/packages/bluesky_text_flutter/example/lib/main.dart
+++ b/packages/bluesky_text_flutter/example/lib/main.dart
@@ -29,6 +29,29 @@ class _HomeState extends State<_Home> {
     text: 'Hello @shinyakato.dev 🦋 visit https://shinyakato.dev #bluesky',
   );
 
+  //! A fetched post's facets come from the API (`PostFacet.fromJson(json)`).
+  //! For this offline demo they are derived from bluesky_text so the byte
+  //! offsets are always correct — hand-counting UTF-8 offsets (note the 3-byte
+  //! em dash below) is easy to get wrong.
+  static const _timelineText =
+      'gm @shinyakato.dev — see https://atprotodart.com #atproto';
+  late final _timelineFacets = [
+    for (final entity in BlueskyText(_timelineText).entities)
+      PostFacet(
+        byteStart: entity.indices.start,
+        byteEnd: entity.indices.end,
+        features: [
+          FacetFeature(
+            type: entity.type,
+            //! A mention's DID is resolved server-side; placeholder here.
+            value: entity.isHandle
+                ? 'did:plc:iijrtk7ocored6zuziwmqq3c'
+                : entity.value,
+          ),
+        ],
+      ),
+  ];
+
   @override
   void initState() {
     super.initState();
@@ -77,33 +100,8 @@ class _HomeState extends State<_Home> {
             Text('Timeline', style: Theme.of(context).textTheme.titleMedium),
             const SizedBox(height: 8),
             BlueskyRichText(
-              text: 'gm @shinyakato.dev — see https://atprotodart.com #atproto',
-              facets: [
-                const {
-                  'index': {'byteStart': 3, 'byteEnd': 18},
-                  'features': [
-                    {
-                      r'$type': 'app.bsky.richtext.facet#mention',
-                      'did': 'did:plc:iijrtk7ocored6zuziwmqq3c',
-                    },
-                  ],
-                },
-                const {
-                  'index': {'byteStart': 25, 'byteEnd': 45},
-                  'features': [
-                    {
-                      r'$type': 'app.bsky.richtext.facet#link',
-                      'uri': 'https://atprotodart.com',
-                    },
-                  ],
-                },
-                const {
-                  'index': {'byteStart': 46, 'byteEnd': 54},
-                  'features': [
-                    {r'$type': 'app.bsky.richtext.facet#tag', 'tag': 'atproto'},
-                  ],
-                },
-              ].map(PostFacet.fromJson).toList(),
+              text: _timelineText,
+              facets: _timelineFacets,
               onMentionTap: (did) => _snack('mention: $did'),
               onLinkTap: (uri) => _snack('link: $uri'),
               onTagTap: (tag) => _snack('tag: #$tag'),

--- a/packages/bluesky_text_flutter/example/lib/main.dart
+++ b/packages/bluesky_text_flutter/example/lib/main.dart
@@ -1,0 +1,120 @@
+// Copyright (c) 2023-2025, Shinya Kato.
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:bluesky_text_flutter/bluesky_text_flutter.dart';
+import 'package:flutter/material.dart';
+
+void main() => runApp(const _App());
+
+class _App extends StatelessWidget {
+  const _App();
+
+  @override
+  Widget build(BuildContext context) => MaterialApp(
+    theme: ThemeData(colorSchemeSeed: Colors.blue),
+    home: const _Home(),
+  );
+}
+
+class _Home extends StatefulWidget {
+  const _Home();
+
+  @override
+  State<_Home> createState() => _HomeState();
+}
+
+class _HomeState extends State<_Home> {
+  final _controller = BlueskyTextEditingController(
+    text: 'Hello @shinyakato.dev 🦋 visit https://shinyakato.dev #bluesky',
+  );
+
+  @override
+  void initState() {
+    super.initState();
+    //* Rebuild the counter as the user types.
+    _controller.addListener(() => setState(() {}));
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final overflow = _controller.overflow;
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('bluesky_text_flutter')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            //! 1. Composing: entities in primary, the over-limit tail in error,
+            //! recomputed on every keystroke.
+            TextField(
+              controller: _controller,
+              maxLines: null,
+              decoration: const InputDecoration(border: OutlineInputBorder()),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              overflow == null
+                  ? '${_controller.text.characters.length} / 300'
+                  : '${overflow.graphemeStart - 300} over the limit',
+              style: TextStyle(
+                color: overflow == null
+                    ? null
+                    : Theme.of(context).colorScheme.error,
+              ),
+            ),
+            const Divider(height: 32),
+
+            //! 2. Displaying a fetched post from its server facets.
+            Text('Timeline', style: Theme.of(context).textTheme.titleMedium),
+            const SizedBox(height: 8),
+            BlueskyRichText(
+              text: 'gm @shinyakato.dev — see https://atprotodart.com #atproto',
+              facets: [
+                const {
+                  'index': {'byteStart': 3, 'byteEnd': 18},
+                  'features': [
+                    {
+                      r'$type': 'app.bsky.richtext.facet#mention',
+                      'did': 'did:plc:iijrtk7ocored6zuziwmqq3c',
+                    },
+                  ],
+                },
+                const {
+                  'index': {'byteStart': 25, 'byteEnd': 45},
+                  'features': [
+                    {
+                      r'$type': 'app.bsky.richtext.facet#link',
+                      'uri': 'https://atprotodart.com',
+                    },
+                  ],
+                },
+                const {
+                  'index': {'byteStart': 46, 'byteEnd': 54},
+                  'features': [
+                    {r'$type': 'app.bsky.richtext.facet#tag', 'tag': 'atproto'},
+                  ],
+                },
+              ].map(PostFacet.fromJson).toList(),
+              onMentionTap: (did) => _snack('mention: $did'),
+              onLinkTap: (uri) => _snack('link: $uri'),
+              onTagTap: (tag) => _snack('tag: #$tag'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  void _snack(String message) => ScaffoldMessenger.of(
+    context,
+  ).showSnackBar(SnackBar(content: Text(message)));
+}

--- a/packages/bluesky_text_flutter/example/pubspec.yaml
+++ b/packages/bluesky_text_flutter/example/pubspec.yaml
@@ -16,7 +16,8 @@ dependencies:
 dev_dependencies:
   flutter_lints: ^5.0.0
 
-# See the note in ../pubspec.yaml — needed until bluesky_text 1.5.0 is on pub.dev.
+# Resolves bluesky_text from the monorepo until it is on pub.dev; see the note in
+# ../pubspec.yaml.
 dependency_overrides:
   bluesky_text:
     path: ../../bluesky_text

--- a/packages/bluesky_text_flutter/example/pubspec.yaml
+++ b/packages/bluesky_text_flutter/example/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: none
 
 environment:
   sdk: ">=3.8.0 <4.0.0"
-  flutter: ">=3.16.0"
+  flutter: ">=3.32.0"
 
 dependencies:
   flutter:

--- a/packages/bluesky_text_flutter/example/pubspec.yaml
+++ b/packages/bluesky_text_flutter/example/pubspec.yaml
@@ -16,11 +16,6 @@ dependencies:
 dev_dependencies:
   flutter_lints: ^5.0.0
 
-# Resolves bluesky_text from the monorepo until it is on pub.dev; see the note in
-# ../pubspec.yaml.
-dependency_overrides:
-  bluesky_text:
-    path: ../../bluesky_text
 
 flutter:
   uses-material-design: true

--- a/packages/bluesky_text_flutter/example/pubspec.yaml
+++ b/packages/bluesky_text_flutter/example/pubspec.yaml
@@ -15,6 +15,8 @@ dependencies:
 
 dev_dependencies:
   flutter_lints: ^5.0.0
+  flutter_test:
+    sdk: flutter
 
 
 flutter:

--- a/packages/bluesky_text_flutter/example/pubspec.yaml
+++ b/packages/bluesky_text_flutter/example/pubspec.yaml
@@ -1,0 +1,25 @@
+name: bluesky_text_flutter_example
+description: Example app for bluesky_text_flutter.
+version: 0.1.0
+publish_to: none
+
+environment:
+  sdk: ">=3.8.0 <4.0.0"
+  flutter: ">=3.16.0"
+
+dependencies:
+  flutter:
+    sdk: flutter
+  bluesky_text_flutter:
+    path: ../
+
+dev_dependencies:
+  flutter_lints: ^5.0.0
+
+# See the note in ../pubspec.yaml — needed until bluesky_text 1.5.0 is on pub.dev.
+dependency_overrides:
+  bluesky_text:
+    path: ../../bluesky_text
+
+flutter:
+  uses-material-design: true

--- a/packages/bluesky_text_flutter/example/test/smoke_test.dart
+++ b/packages/bluesky_text_flutter/example/test/smoke_test.dart
@@ -1,0 +1,62 @@
+// Copyright (c) 2023-2025, Shinya Kato.
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:bluesky_text_flutter_example/main.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+List<TextSpan> _leaves(InlineSpan s) {
+  final o = <TextSpan>[];
+  s.visitChildren((c) {
+    if (c is TextSpan) {
+      (c.children?.isEmpty ?? true) ? o.add(c) : o.addAll(_leaves(c));
+    }
+    return true;
+  });
+  return o;
+}
+
+void main() {
+  testWidgets(
+    'app builds, live preview follows input, posting adds to timeline',
+    (tester) async {
+      await tester.pumpWidget(const ExampleApp());
+      expect(tester.takeException(), isNull);
+
+      // Seed timeline renders with a tappable link fully styled.
+      expect(find.text('Shinya Kato'), findsOneWidget);
+
+      // Type into the composer -> the live preview renders the entities.
+      await tester.enterText(find.byType(TextField), 'hi @bsky.app see #dart');
+      await tester.pump();
+
+      // A RichText somewhere now contains the styled handle and tag as whole
+      // tokens (the live preview), proving compose -> preview linkage.
+      final richTexts = tester.widgetList<RichText>(find.byType(RichText));
+      final previewLeaves = richTexts
+          .expand((r) => _leaves(r.text))
+          .map((s) => s.text)
+          .toList();
+      expect(previewLeaves, containsAll(['@bsky.app', '#dart']));
+
+      // Post it -> a new timeline entry appears authored by "You".
+      await tester.tap(find.widgetWithText(FilledButton, 'Post'));
+      await tester.pumpAndSettle();
+      expect(find.textContaining('@you.bsky.social'), findsWidgets);
+
+      // Tapping the handle in the new post dispatches (no exception).
+      final handleSpan = tester
+          .widgetList<RichText>(find.byType(RichText))
+          .expand((r) => _leaves(r.text))
+          .firstWhere(
+            (s) => s.text == '@bsky.app' && s.recognizer != null,
+            orElse: () => const TextSpan(),
+          );
+      (handleSpan.recognizer as TapGestureRecognizer?)?.onTap?.call();
+      await tester.pump();
+      expect(tester.takeException(), isNull);
+    },
+  );
+}

--- a/packages/bluesky_text_flutter/lib/bluesky_text_flutter.dart
+++ b/packages/bluesky_text_flutter/lib/bluesky_text_flutter.dart
@@ -1,0 +1,14 @@
+// Copyright (c) 2023-2025, Shinya Kato.
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// Flutter widgets for [bluesky_text](https://pub.dev/packages/bluesky_text): a
+/// rich-text editing controller that highlights entities and the over-limit
+/// tail as the user types, and a viewer that renders a fetched post's facets
+/// with tappable mentions, links and tags.
+library;
+
+export 'package:bluesky_text/bluesky_text.dart';
+
+export 'src/bluesky_rich_text.dart';
+export 'src/bluesky_text_editing_controller.dart';

--- a/packages/bluesky_text_flutter/lib/src/bluesky_rich_text.dart
+++ b/packages/bluesky_text_flutter/lib/src/bluesky_rich_text.dart
@@ -1,0 +1,191 @@
+// Copyright (c) 2023-2025, Shinya Kato.
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// Flutter imports:
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+
+// Package imports:
+import 'package:bluesky_text/bluesky_text.dart';
+
+/// Called when a rich-text feature is tapped, with its resolved target — a DID
+/// for a mention, a URI for a link, or the tag value for a tag.
+typedef FeatureTapCallback = void Function(FacetFeature feature);
+
+/// Displays a **fetched** Bluesky post: its [text] styled with the server's
+/// authoritative [facets] (mentions, links, tags), with tappable features.
+///
+/// Unlike re-detecting entities from text, this renders exactly what the author
+/// committed — a mention already carries its DID — via `renderFacets`. The
+/// `TapGestureRecognizer`s created for tappable features are owned by this
+/// widget and disposed automatically, so callers never leak them.
+///
+/// ```dart
+/// BlueskyRichText(
+///   text: post.record.text,
+///   facets: post.record.facets
+///       ?.map((f) => PostFacet.fromJson(f.toJson()))
+///       .toList() ?? const [],
+///   onMentionTap: (did) => context.go('/profile/$did'),
+///   onLinkTap: (uri) => launchUrlString(uri),
+/// );
+/// ```
+class BlueskyRichText extends StatefulWidget {
+  const BlueskyRichText({
+    super.key,
+    required this.text,
+    required this.facets,
+    this.style,
+    this.featureStyle,
+    this.onFeatureTap,
+    this.onMentionTap,
+    this.onLinkTap,
+    this.onTagTap,
+    this.textAlign = TextAlign.start,
+    this.textDirection,
+    this.maxLines,
+    this.overflow = TextOverflow.clip,
+  });
+
+  /// The post text.
+  final String text;
+
+  /// The post's server-provided facets (parse API JSON with
+  /// `PostFacet.fromJson`).
+  final List<PostFacet> facets;
+
+  /// Base style for the whole text.
+  final TextStyle? style;
+
+  /// Style for feature (mention/link/tag) slices. Defaults to the theme's
+  /// primary color when null.
+  final TextStyle? featureStyle;
+
+  /// Called for any tapped feature. [onMentionTap] / [onLinkTap] / [onTagTap]
+  /// are typed conveniences dispatched by feature kind; if a typed callback is
+  /// provided it takes precedence for that kind.
+  final FeatureTapCallback? onFeatureTap;
+
+  /// Called with the mention's DID.
+  final void Function(String did)? onMentionTap;
+
+  /// Called with the link's URI.
+  final void Function(String uri)? onLinkTap;
+
+  /// Called with the tag value.
+  final void Function(String tag)? onTagTap;
+
+  final TextAlign textAlign;
+  final TextDirection? textDirection;
+  final int? maxLines;
+  final TextOverflow overflow;
+
+  @override
+  State<BlueskyRichText> createState() => _BlueskyRichTextState();
+}
+
+class _BlueskyRichTextState extends State<BlueskyRichText> {
+  final List<TapGestureRecognizer> _recognizers = [];
+  List<TextSegment> _segments = const [];
+
+  @override
+  void initState() {
+    super.initState();
+    _segments = renderFacets(widget.text, widget.facets);
+  }
+
+  @override
+  void didUpdateWidget(covariant BlueskyRichText oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    //* Only the text/facets affect the partition; tap callbacks are read fresh
+    //* each build, so the recognizers do not need rebuilding for those.
+    if (widget.text != oldWidget.text || widget.facets != oldWidget.facets) {
+      _segments = renderFacets(widget.text, widget.facets);
+    }
+  }
+
+  @override
+  void dispose() {
+    _disposeRecognizers();
+    super.dispose();
+  }
+
+  void _disposeRecognizers() {
+    for (final recognizer in _recognizers) {
+      recognizer.dispose();
+    }
+    _recognizers.clear();
+  }
+
+  void _dispatch(FacetFeature feature) {
+    switch (feature.type) {
+      case EntityType.handle:
+        if (widget.onMentionTap != null) {
+          widget.onMentionTap!(feature.value);
+          return;
+        }
+      case EntityType.link:
+        if (widget.onLinkTap != null) {
+          widget.onLinkTap!(feature.value);
+          return;
+        }
+      case EntityType.tag:
+      case EntityType.cashtag:
+        if (widget.onTagTap != null) {
+          widget.onTagTap!(feature.value);
+          return;
+        }
+      case EntityType.markdownLink:
+        break;
+    }
+    widget.onFeatureTap?.call(feature);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    //* Recognizers are rebuilt every build (they close over the current
+    //* callbacks) and the previous batch disposed, so none ever leak.
+    _disposeRecognizers();
+
+    final theme = Theme.of(context);
+    final featureStyle =
+        widget.featureStyle ?? TextStyle(color: theme.colorScheme.primary);
+    final hasTapHandler =
+        widget.onFeatureTap != null ||
+        widget.onMentionTap != null ||
+        widget.onLinkTap != null ||
+        widget.onTagTap != null;
+
+    final children = <InlineSpan>[];
+    for (final segment in _segments) {
+      final feature = segment.feature;
+      if (feature == null) {
+        children.add(TextSpan(text: segment.text));
+        continue;
+      }
+
+      TapGestureRecognizer? recognizer;
+      if (hasTapHandler) {
+        recognizer = TapGestureRecognizer()..onTap = () => _dispatch(feature);
+        _recognizers.add(recognizer);
+      }
+
+      children.add(
+        TextSpan(
+          text: segment.text,
+          style: featureStyle,
+          recognizer: recognizer,
+        ),
+      );
+    }
+
+    return Text.rich(
+      TextSpan(style: widget.style, children: children),
+      textAlign: widget.textAlign,
+      textDirection: widget.textDirection,
+      maxLines: widget.maxLines,
+      overflow: widget.overflow,
+    );
+  }
+}

--- a/packages/bluesky_text_flutter/lib/src/bluesky_text_editing_controller.dart
+++ b/packages/bluesky_text_flutter/lib/src/bluesky_text_editing_controller.dart
@@ -1,0 +1,153 @@
+// Copyright (c) 2023-2025, Shinya Kato.
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// Flutter imports:
+import 'package:flutter/material.dart';
+
+// Package imports:
+import 'package:bluesky_text/bluesky_text.dart';
+
+/// Resolves the [TextStyle] for a single [TextSegment] while composing, or
+/// `null` to leave it at the base style.
+typedef SegmentStyleBuilder = TextStyle? Function(TextSegment segment);
+
+/// A [TextEditingController] that live-highlights Bluesky rich text as the user
+/// types: entities (handles, links, tags) and the part of the text that exceeds
+/// the post-length limit are styled in a single pass, on every keystroke, via
+/// `BlueskyText.segments`.
+///
+/// Attach it to a `TextField` like any controller:
+///
+/// ```dart
+/// final controller = BlueskyTextEditingController();
+/// // ...
+/// TextField(controller: controller, maxLines: null);
+/// ```
+///
+/// Styling precedence for each segment: [styleBuilder] (if it returns non-null)
+/// › the over-limit tail uses [overflowStyle] › an entity uses [entityStyle] ›
+/// otherwise the field's base style. The IME composing region keeps its
+/// underline, merged on top of the segment style.
+class BlueskyTextEditingController extends TextEditingController {
+  BlueskyTextEditingController({
+    super.text,
+    this.enableMarkdown = true,
+    this.entityStyle,
+    this.overflowStyle,
+    this.styleBuilder,
+  });
+
+  /// Whether markdown links participate in analysis (mirrors `BlueskyText`).
+  final bool enableMarkdown;
+
+  /// Style applied to entity segments (handles, links, tags). Defaults to the
+  /// theme's primary color when null.
+  final TextStyle? entityStyle;
+
+  /// Style applied to the segment(s) past the post-length limit. Defaults to
+  /// the theme's error color when null.
+  final TextStyle? overflowStyle;
+
+  /// Full per-segment override; when it returns non-null its result wins over
+  /// [entityStyle] / [overflowStyle].
+  final SegmentStyleBuilder? styleBuilder;
+
+  /// The overflow of the current [text], or null when within the limit — handy
+  /// for a live character counter (`controller.overflow == null`).
+  TextLengthOverflow? get overflow =>
+      BlueskyText(text, enableMarkdown: enableMarkdown).overflow;
+
+  @override
+  TextSpan buildTextSpan({
+    required BuildContext context,
+    TextStyle? style,
+    required bool withComposing,
+  }) {
+    final base = style ?? const TextStyle();
+
+    //* Empty text: defer to the default so the hint/placeholder logic is intact.
+    if (text.isEmpty) {
+      return super.buildTextSpan(
+        context: context,
+        style: style,
+        withComposing: withComposing,
+      );
+    }
+
+    final segments = BlueskyText(text, enableMarkdown: enableMarkdown).segments;
+
+    //* The composing (IME) region to underline, if any is active and valid.
+    final composing = withComposing && !value.composing.isCollapsed
+        ? value.composing
+        : null;
+
+    final theme = Theme.of(context);
+    final defaultEntity = TextStyle(color: theme.colorScheme.primary);
+    final defaultOverflow = TextStyle(color: theme.colorScheme.error);
+
+    final children = <InlineSpan>[];
+    for (final segment in segments) {
+      final resolved =
+          styleBuilder?.call(segment) ??
+          (segment.isOverflow
+              ? (overflowStyle ?? defaultOverflow)
+              : segment.type != null
+              ? (entityStyle ?? defaultEntity)
+              : null);
+      final segmentStyle = resolved == null ? base : base.merge(resolved);
+
+      _appendSegment(children, segment, segmentStyle, composing);
+    }
+
+    return TextSpan(style: style, children: children);
+  }
+
+  /// Appends [segment] as one or more spans, underlining the part (if any) that
+  /// overlaps the [composing] region so the IME underline is preserved.
+  void _appendSegment(
+    List<InlineSpan> children,
+    TextSegment segment,
+    TextStyle segmentStyle,
+    TextRange? composing,
+  ) {
+    final start = segment.utf16Start;
+    final end = segment.utf16End;
+
+    final overlapStart = composing == null
+        ? end
+        : composing.start.clamp(start, end);
+    final overlapEnd = composing == null
+        ? end
+        : composing.end.clamp(start, end);
+
+    if (composing == null || overlapStart >= overlapEnd) {
+      children.add(TextSpan(text: segment.text, style: segmentStyle));
+      return;
+    }
+
+    //* [start, overlapStart) normal | [overlapStart, overlapEnd) underlined |
+    //* [overlapEnd, end) normal — all indices are relative to the value.
+    if (overlapStart > start) {
+      children.add(
+        TextSpan(
+          text: text.substring(start, overlapStart),
+          style: segmentStyle,
+        ),
+      );
+    }
+    children.add(
+      TextSpan(
+        text: text.substring(overlapStart, overlapEnd),
+        style: segmentStyle.merge(
+          const TextStyle(decoration: TextDecoration.underline),
+        ),
+      ),
+    );
+    if (overlapEnd < end) {
+      children.add(
+        TextSpan(text: text.substring(overlapEnd, end), style: segmentStyle),
+      );
+    }
+  }
+}

--- a/packages/bluesky_text_flutter/pubspec.yaml
+++ b/packages/bluesky_text_flutter/pubspec.yaml
@@ -9,7 +9,7 @@ funding:
 
 environment:
   sdk: ">=3.8.0 <4.0.0"
-  flutter: ">=3.16.0"
+  flutter: ">=3.32.0"
 
 topics:
   - atproto

--- a/packages/bluesky_text_flutter/pubspec.yaml
+++ b/packages/bluesky_text_flutter/pubspec.yaml
@@ -1,0 +1,35 @@
+name: bluesky_text_flutter
+description: Flutter widgets for bluesky_text — a rich-text editing controller that highlights entities and the over-limit tail as you type, and a viewer for fetched posts.
+version: 0.1.0
+homepage: https://atprotodart.com
+repository: https://github.com/myConsciousness/atproto.dart/tree/main/packages/bluesky_text_flutter
+issue_tracker: https://github.com/myConsciousness/atproto.dart/issues
+funding:
+  - https://github.com/sponsors/myConsciousness
+
+environment:
+  sdk: ">=3.8.0 <4.0.0"
+  flutter: ">=3.16.0"
+
+topics:
+  - atproto
+  - bluesky
+  - flutter
+  - richtext
+
+dependencies:
+  flutter:
+    sdk: flutter
+  bluesky_text: ^1.5.0
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  flutter_lints: ^5.0.0
+
+# TODO(bluesky_text_flutter): remove once bluesky_text 1.5.0 is published to
+# pub.dev. Until then this resolves the in-repo path so the package builds and
+# tests in the monorepo. It is ignored by consumers of the published package.
+dependency_overrides:
+  bluesky_text:
+    path: ../bluesky_text

--- a/packages/bluesky_text_flutter/pubspec.yaml
+++ b/packages/bluesky_text_flutter/pubspec.yaml
@@ -27,9 +27,12 @@ dev_dependencies:
     sdk: flutter
   flutter_lints: ^5.0.0
 
-# TODO(bluesky_text_flutter): remove once bluesky_text 1.5.0 is published to
-# pub.dev. Until then this resolves the in-repo path so the package builds and
-# tests in the monorepo. It is ignored by consumers of the published package.
+# bluesky_text 1.5.0 is merged to `main` but not yet on pub.dev, so this cannot
+# join the Dart-only pub workspace (a Flutter member would break `dart pub get`
+# for every package). This override resolves the sibling from the monorepo for
+# local builds, tests and CI. It is publish-safe (pub reports it only as a hint)
+# and is ignored by consumers of the published package. Drop it once bluesky_text
+# 1.5.0 is on pub.dev, so CI exercises the published version.
 dependency_overrides:
   bluesky_text:
     path: ../bluesky_text

--- a/packages/bluesky_text_flutter/pubspec.yaml
+++ b/packages/bluesky_text_flutter/pubspec.yaml
@@ -27,12 +27,3 @@ dev_dependencies:
     sdk: flutter
   flutter_lints: ^5.0.0
 
-# bluesky_text 1.5.0 is merged to `main` but not yet on pub.dev, so this cannot
-# join the Dart-only pub workspace (a Flutter member would break `dart pub get`
-# for every package). This override resolves the sibling from the monorepo for
-# local builds, tests and CI. It is publish-safe (pub reports it only as a hint)
-# and is ignored by consumers of the published package. Drop it once bluesky_text
-# 1.5.0 is on pub.dev, so CI exercises the published version.
-dependency_overrides:
-  bluesky_text:
-    path: ../bluesky_text

--- a/packages/bluesky_text_flutter/test/bluesky_rich_text_test.dart
+++ b/packages/bluesky_text_flutter/test/bluesky_rich_text_test.dart
@@ -1,0 +1,147 @@
+// Copyright (c) 2023-2025, Shinya Kato.
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// Flutter imports:
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+
+// Package imports:
+import 'package:flutter_test/flutter_test.dart';
+
+// Project imports:
+import 'package:bluesky_text_flutter/bluesky_text_flutter.dart';
+
+/// Flattens a span tree into its leaf [TextSpan]s.
+List<TextSpan> _leaves(InlineSpan span) {
+  final out = <TextSpan>[];
+  span.visitChildren((child) {
+    if (child is TextSpan) {
+      if (child.children == null || child.children!.isEmpty) {
+        out.add(child);
+      } else {
+        out.addAll(_leaves(child));
+      }
+    }
+    return true;
+  });
+  return out;
+}
+
+TextSpan _spanOf(WidgetTester tester) {
+  final richText = tester.widget<RichText>(
+    find.byWidgetPredicate(
+      (w) => w is RichText && _leaves(w.text).any((s) => s.text == '@alice'),
+    ),
+  );
+  return richText.text as TextSpan;
+}
+
+void main() {
+  const facets = [
+    PostFacet(
+      byteStart: 3,
+      byteEnd: 9,
+      features: [FacetFeature(type: EntityType.handle, value: 'did:plc:alice')],
+    ),
+  ];
+
+  Widget host(Widget child) => MaterialApp(home: Scaffold(body: child));
+
+  testWidgets('renders the post text and styles the feature', (tester) async {
+    await tester.pumpWidget(
+      host(
+        const BlueskyRichText(
+          text: 'hi @alice ok',
+          facets: facets,
+          featureStyle: TextStyle(color: Colors.blue),
+        ),
+      ),
+    );
+
+    final leaves = _leaves(_spanOf(tester));
+    expect(leaves.map((s) => s.text).join(), 'hi @alice ok');
+
+    final mention = leaves.firstWhere((s) => s.text == '@alice');
+    expect(mention.style?.color, Colors.blue);
+    // Plain slices carry no feature style.
+    expect(leaves.firstWhere((s) => s.text == 'hi ').style?.color, isNull);
+  });
+
+  testWidgets('tapping a mention dispatches its DID', (tester) async {
+    String? tapped;
+    await tester.pumpWidget(
+      host(
+        BlueskyRichText(
+          text: 'hi @alice ok',
+          facets: facets,
+          onMentionTap: (did) => tapped = did,
+        ),
+      ),
+    );
+
+    final mention = _leaves(
+      _spanOf(tester),
+    ).firstWhere((s) => s.text == '@alice');
+    expect(mention.recognizer, isA<TapGestureRecognizer>());
+    (mention.recognizer! as TapGestureRecognizer).onTap!();
+
+    expect(tapped, 'did:plc:alice');
+  });
+
+  testWidgets('no recognizer is attached when there is no tap handler', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      host(const BlueskyRichText(text: 'hi @alice ok', facets: facets)),
+    );
+
+    final mention = _leaves(
+      _spanOf(tester),
+    ).firstWhere((s) => s.text == '@alice');
+    expect(mention.recognizer, isNull);
+  });
+
+  testWidgets('recognizers are disposed when the widget is removed', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      host(
+        BlueskyRichText(
+          text: 'hi @alice ok',
+          facets: facets,
+          onMentionTap: (_) {},
+        ),
+      ),
+    );
+
+    // Replacing the widget with something else must not leak recognizers; the
+    // test framework's leak tracker fails the test if any survive.
+    await tester.pumpWidget(host(const SizedBox()));
+  });
+
+  testWidgets('rebuilding with new text disposes the old recognizers', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      host(
+        BlueskyRichText(
+          text: 'hi @alice ok',
+          facets: facets,
+          onMentionTap: (_) {},
+        ),
+      ),
+    );
+    await tester.pumpWidget(
+      host(
+        BlueskyRichText(
+          text: 'hi @alice again',
+          facets: facets,
+          onMentionTap: (_) {},
+        ),
+      ),
+    );
+
+    expect(tester.takeException(), isNull);
+  });
+}

--- a/packages/bluesky_text_flutter/test/bluesky_text_editing_controller_test.dart
+++ b/packages/bluesky_text_flutter/test/bluesky_text_editing_controller_test.dart
@@ -1,0 +1,125 @@
+// Copyright (c) 2023-2025, Shinya Kato.
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// Flutter imports:
+import 'package:flutter/material.dart';
+
+// Package imports:
+import 'package:flutter_test/flutter_test.dart';
+
+// Project imports:
+import 'package:bluesky_text_flutter/bluesky_text_flutter.dart';
+
+List<TextSpan> _leaves(InlineSpan span) {
+  final out = <TextSpan>[];
+  span.visitChildren((child) {
+    if (child is TextSpan) {
+      if (child.children == null || child.children!.isEmpty) {
+        out.add(child);
+      } else {
+        out.addAll(_leaves(child));
+      }
+    }
+    return true;
+  });
+  return out;
+}
+
+Future<TextSpan> _build(
+  WidgetTester tester,
+  BlueskyTextEditingController controller, {
+  bool withComposing = false,
+}) async {
+  late TextSpan span;
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Builder(
+        builder: (context) {
+          span = controller.buildTextSpan(
+            context: context,
+            style: const TextStyle(fontSize: 14),
+            withComposing: withComposing,
+          );
+          return const SizedBox();
+        },
+      ),
+    ),
+  );
+  return span;
+}
+
+void main() {
+  testWidgets('styles entities and the over-limit tail', (tester) async {
+    final controller = BlueskyTextEditingController(
+      text: 'hi @alice.bsky.social ${'a' * 300}',
+      entityStyle: const TextStyle(color: Colors.blue),
+      overflowStyle: const TextStyle(color: Colors.red),
+    );
+    addTearDown(controller.dispose);
+
+    final leaves = _leaves(await _build(tester, controller));
+
+    // The handle is styled as an entity.
+    final handle = leaves.firstWhere((s) => s.text == '@alice.bsky.social');
+    expect(handle.style?.color, Colors.blue);
+
+    // The tail past 300 graphemes is styled as overflow.
+    expect(
+      leaves.any((s) => s.style?.color == Colors.red && s.text!.contains('a')),
+      isTrue,
+    );
+
+    // The base style is preserved (merged), not dropped.
+    expect(handle.style?.fontSize, 14);
+  });
+
+  testWidgets('underlines the IME composing region', (tester) async {
+    final controller = BlueskyTextEditingController(
+      entityStyle: const TextStyle(color: Colors.blue),
+    );
+    addTearDown(controller.dispose);
+    controller.value = const TextEditingValue(
+      text: 'hello world',
+      composing: TextRange(start: 6, end: 11), // "world"
+    );
+
+    final leaves = _leaves(
+      await _build(tester, controller, withComposing: true),
+    );
+
+    final composing = leaves.firstWhere((s) => s.text == 'world');
+    expect(composing.style?.decoration, TextDecoration.underline);
+    // Non-composing text is not underlined.
+    expect(
+      leaves.firstWhere((s) => s.text!.contains('hello')).style?.decoration,
+      anyOf(isNull, TextDecoration.none),
+    );
+  });
+
+  testWidgets('styleBuilder overrides the defaults', (tester) async {
+    final controller = BlueskyTextEditingController(
+      text: 'see #dart',
+      styleBuilder: (segment) => segment.type == EntityType.tag
+          ? const TextStyle(color: Colors.green)
+          : null,
+    );
+    addTearDown(controller.dispose);
+
+    final leaves = _leaves(await _build(tester, controller));
+    expect(
+      leaves.firstWhere((s) => s.text == '#dart').style?.color,
+      Colors.green,
+    );
+  });
+
+  test('.overflow exposes the boundary for a counter', () {
+    final within = BlueskyTextEditingController(text: 'short');
+    final over = BlueskyTextEditingController(text: 'a' * 301);
+    addTearDown(within.dispose);
+    addTearDown(over.dispose);
+
+    expect(within.overflow, isNull);
+    expect(over.overflow, isNotNull);
+  });
+}


### PR DESCRIPTION
## What

A new **Flutter companion package**, `bluesky_text_flutter` — the "last mile" widget layer on top of `bluesky_text` (which is intentionally zero-dependency / pure Dart). It closes the two remaining practicality gaps for building a Bluesky client in Flutter.

### `BlueskyTextEditingController`
A `TextEditingController` whose `buildTextSpan` highlights, on every keystroke and in a single pass via `BlueskyText.segments`:
- entities (handles, links, tags) — theme primary color by default
- the part of the text past the **300-grapheme / 3000-byte** limit — theme error color

It preserves the **IME composing underline** (important for the CJK/emoji audience) and exposes `overflow` for a live character counter. Styling is overridable via `entityStyle` / `overflowStyle` / a full `styleBuilder`.

### `BlueskyRichText`
A widget that renders a **fetched** post from its **authoritative server facets** (via `renderFacets` — mentions already carry their DID) with **tappable** mentions / links / tags. The `TapGestureRecognizer`s are **owned and disposed by the widget**, so callers never leak them — verified by the test framework's leak tracker.

## Integration notes

- **Standalone package** (not added to the root pub workspace), so the existing Dart-only workspace and its `dart pub get` are unaffected — adding a Flutter member would have forced the Flutter SDK on the whole workspace/CI. It re-exports `bluesky_text`, so consumers import one package.
- It resolves `bluesky_text` via a **path `dependency_overrides`** until **1.5.0 is published** (this is why the PR targets the `bluesky_text-length-overflow-segments` branch, #2433, which introduces 1.5.0). The override is ignored by published-package consumers; there is a `TODO` to remove it on publish.
- Follow-ups (out of scope here): add the package to CI (a Flutter test job), and remove the override once `bluesky_text` 1.5.0 is on pub.dev.

## Tests

9 widget tests (`flutter test`), analyze clean on lib + test + example:
- entity + over-limit styling, base-style merge, `styleBuilder` override, IME composing underline, `overflow` getter
- feature tap dispatch (mention → DID), no-recognizer-without-handler, recognizer disposal on removal and on rebuild

A runnable `example/` app demonstrates both widgets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)