### PR TITLE
docs(bluesky_text): restore dropped memoization bullet in the 1.5.0 changelog

### DIFF
--- a/packages/bluesky_text/CHANGELOG.md
+++ b/packages/bluesky_text/CHANGELOG.md
@@ -60,6 +60,7 @@
   chunk starts or ends with whitespace. A markdown link is also kept atomic, so
   one straddling a chunk boundary is no longer torn open (which would drop its
   facet).
+- **PERF**: `BlueskyText` now lazily memoizes every derived value (`length`,
   `handles`, `entities`, `overflow`, `segments`, `format()`…), so touching
   several properties of one instance in a Flutter `build` costs one analysis
   instead of one per property (~1.6x faster when touching seven). Note: as a


### PR DESCRIPTION
## What

The 1.5.0 changelog entry for `bluesky_text` is missing the first line of the memoization `PERF` bullet — it was dropped during the release merge, so the entry currently reads as a dangling fragment attached to the preceding `split()` `FIX`:

```
  ...no longer torn open (which would drop its
  facet).
  `handles`, `entities`, `overflow`, `segments`, `format()`…), so touching   ← no bullet
```

This restores the single missing line:

```
- **PERF**: `BlueskyText` now lazily memoizes every derived value (`length`,
```

**Documentation only** — one-line insertion, no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)