### PR TITLE
ci: add melos release scripts for the Flutter package

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -81,6 +81,32 @@ melos:
         git push origin --tags
       description: Publish all packages, create git tags and push them to origin.
 
+    # Flutter packages live outside the Dart pub workspace, so `melos` (and
+    # therefore `publish_all`) does not manage them. Release them explicitly.
+    flutter_publish_dry:
+      run: |
+        cd packages/bluesky_text_flutter
+        flutter pub publish --dry-run
+      description: Dry-run publish the Flutter package (bluesky_text_flutter).
+
+    flutter_publish:
+      run: |
+        cd packages/bluesky_text_flutter
+        flutter pub publish
+      description: >-
+        Publish the Flutter package (bluesky_text_flutter) to pub.dev. Run
+        `flutter_publish_dry` first; append `--force` to skip the prompt.
+
+    flutter_tag:
+      run: |
+        cd packages/bluesky_text_flutter
+        version=$(grep '^version:' pubspec.yaml | awk '{print $2}')
+        git tag "bluesky_text_flutter-v$version"
+        git push origin "bluesky_text_flutter-v$version"
+      description: >-
+        Tag and push the Flutter package release
+        (bluesky_text_flutter-vX.Y.Z), matching melos' tag format.
+
     gen:
       run: |
         dart run ./scripts/gen_lexicon_docs.dart


### PR DESCRIPTION
## Why

`bluesky_text_flutter` is a Flutter package and can't join the Dart-only pub workspace (a Flutter member breaks `dart pub get` for every package), so `melos list` doesn't include it and `publish_all` skips it. Its analyze/format/test are covered by the dedicated Flutter CI job, but **releasing** it was unmanaged — easy to forget at release time.

## What

Three melos scripts in the root `pubspec.yaml`, matching how the Dart packages are released:

| Script | Runs |
| --- | --- |
| `melos run flutter_publish_dry` | `flutter pub publish --dry-run` |
| `melos run flutter_publish` | `flutter pub publish` (append `--force` to skip the prompt) |
| `melos run flutter_tag` | `git tag bluesky_text_flutter-vX.Y.Z && git push` (same tag format as the Dart packages, e.g. `bluesky_text-v1.5.0`) |

## Verified

- `melos run` lists the three scripts.
- `melos run flutter_publish_dry` executes the dry-run end-to-end → **Package has 0 warnings** (the temporary override hint is gone now that it depends on published `bluesky_text ^1.5.0`).
- The tag script resolves to `bluesky_text_flutter-v0.1.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)