### PR TITLE
feat: auto-generate CHANGELOG entries and version bumps from Lexicon codegen

### DIFF
--- a/.github/workflows/generate_codes.yml
+++ b/.github/workflows/generate_codes.yml
@@ -25,6 +25,9 @@ jobs:
       - uses: actions/checkout@v7
         with:
           ref: main
+          # Full history so the changelog step can diff `lexicons/` against the
+          # pre-sync base commit (github.event.pull_request.base.sha).
+          fetch-depth: 0
 
       - uses: dart-lang/setup-dart@v1
         with:
@@ -61,6 +64,15 @@ jobs:
               dart format .
             )
           done
+
+      - name: Update changelogs & versions
+        # Diff the synced lexicons against the pre-sync base commit, then append
+        # per-package CHANGELOG entries and bump versions (patch for additions,
+        # minor for breaking changes), propagating patch bumps to dependents.
+        # Changes land in the same chore-generate-codes PR for human review.
+        run: dart run ./scripts/gen_changelog.dart
+        env:
+          CHANGELOG_BASE_REF: ${{ github.event.pull_request.base.sha || 'HEAD~1' }}
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v8

--- a/scripts/gen_changelog.dart
+++ b/scripts/gen_changelog.dart
@@ -1,0 +1,136 @@
+// Copyright (c) 2023-2025, Shinya Kato.
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// Dart imports:
+import 'dart:io';
+
+// Project imports:
+import 'gen_changelog/change_classifier.dart';
+import 'gen_changelog/lexicon_diff.dart';
+import 'gen_changelog/lexicon_snapshot.dart';
+import 'gen_changelog/models.dart';
+import 'gen_changelog/package_mapper.dart';
+import 'gen_changelog/semver.dart';
+import 'gen_changelog/version_planner.dart';
+import 'gen_changelog/writer.dart';
+
+const _packagesDir = 'packages';
+
+/// Pure orchestration: diff -> classify -> group by package -> plan versions.
+Map<String, PackagePlan> run({
+  required Snapshot oldSnap,
+  required Snapshot newSnap,
+  required Map<String, Version> currentVersions,
+  required Map<String, List<String>> dependents,
+}) {
+  final changesByPackage = <String, List<ClassifiedChange>>{};
+  for (final change in diffSnapshots(oldSnap, newSnap)) {
+    final pkg = packageForNsid(change.nsid);
+    if (pkg == null) continue; // unmapped namespace (e.g. site.standard.*)
+    changesByPackage.putIfAbsent(pkg, () => []).add(classify(change));
+  }
+  return planVersions(
+    changesByPackage: changesByPackage,
+    currentVersions: currentVersions,
+    dependents: dependents,
+  );
+}
+
+/// Reads `version:` from every workspace package pubspec.
+Map<String, Version> readCurrentVersions() {
+  final versions = <String, Version>{};
+  for (final dir in Directory(_packagesDir).listSync().whereType<Directory>()) {
+    final pubspec = File('${dir.path}/pubspec.yaml');
+    if (!pubspec.existsSync()) continue;
+    final name = dir.path.split(Platform.pathSeparator).last;
+    final match = RegExp(r'^version:\s*(\S+)', multiLine: true)
+        .firstMatch(pubspec.readAsStringSync());
+    if (match != null) {
+      try {
+        versions[name] = Version.parse(match.group(1)!);
+      } catch (_) {
+        // Skip packages with non semver versions.
+      }
+    }
+  }
+  return versions;
+}
+
+/// Returns the package names declared under the top-level `dependencies:` block
+/// of [pubspecContent]. `dev_dependencies:` and other sections are ignored, so
+/// test-only back-references (e.g. `bluesky_text` -> `bluesky`) never trigger a
+/// release bump. Only `^`-ranged entries are returned (path deps are skipped).
+Set<String> directDependencyNames(String pubspecContent) {
+  final names = <String>{};
+  var inDeps = false;
+  for (final raw in pubspecContent.split('\n')) {
+    // A non-indented, non-blank line starts a new top-level section.
+    final isTopLevel = raw.isNotEmpty && !raw.startsWith(' ') && !raw.startsWith('#');
+    if (isTopLevel) {
+      inDeps = raw.trimRight() == 'dependencies:';
+      continue;
+    }
+    if (!inDeps) continue;
+    final match = RegExp(r'^\s+([a-z0-9_]+):\s*\^').firstMatch(raw);
+    if (match != null) names.add(match.group(1)!);
+  }
+  return names;
+}
+
+/// Builds a `package -> dependents` map among workspace packages only,
+/// considering runtime `dependencies:` (not `dev_dependencies:`).
+Map<String, List<String>> readDependents() {
+  final packages = Directory(_packagesDir)
+      .listSync()
+      .whereType<Directory>()
+      .map((d) => d.path.split(Platform.pathSeparator).last)
+      .toSet();
+
+  final dependents = <String, List<String>>{};
+  for (final pkg in packages) {
+    final pubspec = File('$_packagesDir/$pkg/pubspec.yaml');
+    if (!pubspec.existsSync()) continue;
+    final deps = directDependencyNames(pubspec.readAsStringSync());
+    for (final dep in deps) {
+      if (dep == pkg || !packages.contains(dep)) continue;
+      dependents.putIfAbsent(dep, () => []).add(pkg);
+    }
+  }
+  return dependents;
+}
+
+String? _argValue(List<String> args, String flag) {
+  final idx = args.indexOf(flag);
+  if (idx >= 0 && idx + 1 < args.length) return args[idx + 1];
+  return null;
+}
+
+void main(List<String> args) {
+  final base = _argValue(args, '--base') ??
+      Platform.environment['CHANGELOG_BASE_REF'] ??
+      'HEAD~1';
+
+  final oldSnap = loadSnapshotFromGit(base);
+  final newSnap = loadSnapshotFromDisk();
+
+  final plans = run(
+    oldSnap: oldSnap,
+    newSnap: newSnap,
+    currentVersions: readCurrentVersions(),
+    dependents: readDependents(),
+  );
+
+  if (plans.isEmpty) {
+    stdout.writeln('gen_changelog: no lexicon changes to record.');
+    return;
+  }
+
+  for (final plan in plans.values) {
+    applyPlan(plan);
+    stdout.writeln(
+      'gen_changelog: ${plan.package} ${plan.oldVersion} -> ${plan.newVersion} '
+      '(${plan.changelogLines.length} lines)',
+    );
+  }
+}

--- a/scripts/gen_changelog/change_classifier.dart
+++ b/scripts/gen_changelog/change_classifier.dart
@@ -1,0 +1,53 @@
+// Copyright (c) 2023-2025, Shinya Kato.
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// Project imports:
+import 'models.dart';
+
+/// Renders the NSID reference for a change: `` `nsid` `` for the `main` def,
+/// `` `nsid#def` `` otherwise, with `.field` appended when present.
+String _ref(LexChange c) {
+  final base = c.defName == 'main' ? c.nsid : '${c.nsid}#${c.defName}';
+  final full = c.field == null ? base : '$base.${c.field}';
+  return '`$full`';
+}
+
+/// Classifies a single lexicon change into a bump level and changelog line.
+ClassifiedChange classify(LexChange change) {
+  final ref = _ref(change);
+  return switch (change.kind) {
+    LexChangeKind.defAdded ||
+    LexChangeKind.propertyAdded => ClassifiedChange(
+      change: change,
+      level: BumpLevel.patch,
+      changelogLine: 'feat: added $ref',
+    ),
+    LexChangeKind.defRemoved ||
+    LexChangeKind.propertyRemoved => ClassifiedChange(
+      change: change,
+      level: BumpLevel.minor,
+      changelogLine: 'fix!: removed $ref (BREAKING)',
+    ),
+    LexChangeKind.propertyBecameRequired => ClassifiedChange(
+      change: change,
+      level: BumpLevel.minor,
+      changelogLine: 'fix!: $ref is now required (BREAKING)',
+    ),
+    LexChangeKind.propertyTypeChanged => ClassifiedChange(
+      change: change,
+      level: BumpLevel.minor,
+      changelogLine: 'fix!: $ref changed type (${change.detail}) (BREAKING)',
+    ),
+    LexChangeKind.propertyBecameOptional => ClassifiedChange(
+      change: change,
+      level: BumpLevel.patch,
+      changelogLine: 'chore: $ref is now optional',
+    ),
+    LexChangeKind.metadataChanged => ClassifiedChange(
+      change: change,
+      level: BumpLevel.patch,
+      changelogLine: 'chore: updated $ref',
+    ),
+  };
+}

--- a/scripts/gen_changelog/change_classifier_test.dart
+++ b/scripts/gen_changelog/change_classifier_test.dart
@@ -1,0 +1,31 @@
+// Package imports:
+import 'package:test/test.dart';
+
+// Project imports:
+import 'models.dart';
+import 'change_classifier.dart';
+
+void main() {
+  test('property added -> feat/patch', () {
+    final c = classify(const LexChange(nsid: 'app.bsky.feed.post', defName: 'main', field: 'langs', kind: LexChangeKind.propertyAdded));
+    expect(c.level, BumpLevel.patch);
+    expect(c.changelogLine, 'feat: added `app.bsky.feed.post.langs`');
+  });
+
+  test('property removed -> fix!/minor with BREAKING', () {
+    final c = classify(const LexChange(nsid: 'app.bsky.feed.post', defName: 'main', field: 'entities', kind: LexChangeKind.propertyRemoved));
+    expect(c.level, BumpLevel.minor);
+    expect(c.changelogLine, 'fix!: removed `app.bsky.feed.post.entities` (BREAKING)');
+  });
+
+  test('non-main def uses #def ref', () {
+    final c = classify(const LexChange(nsid: 'tools.ozone.report.defs', defName: 'reportView', kind: LexChangeKind.defAdded));
+    expect(c.changelogLine, 'feat: added `tools.ozone.report.defs#reportView`');
+  });
+
+  test('type change includes detail', () {
+    final c = classify(const LexChange(nsid: 'x.y.z', defName: 'main', field: 'a', kind: LexChangeKind.propertyTypeChanged, detail: 'string -> integer'));
+    expect(c.level, BumpLevel.minor);
+    expect(c.changelogLine, 'fix!: `x.y.z.a` changed type (string -> integer) (BREAKING)');
+  });
+}

--- a/scripts/gen_changelog/lexicon_diff.dart
+++ b/scripts/gen_changelog/lexicon_diff.dart
@@ -1,0 +1,115 @@
+// Copyright (c) 2023-2025, Shinya Kato.
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// Dart imports:
+import 'dart:convert';
+
+// Project imports:
+import 'models.dart';
+
+/// Computes the semantic difference between two lexicon snapshots.
+List<LexChange> diffSnapshots(Snapshot old, Snapshot updated) {
+  final changes = <LexChange>[];
+  final nsids = {...old.keys, ...updated.keys};
+
+  for (final nsid in nsids) {
+    final oldDefs = old[nsid];
+    final newDefs = updated[nsid];
+
+    if (oldDefs == null) {
+      for (final def in newDefs!.keys) {
+        changes.add(LexChange(nsid: nsid, defName: def, kind: LexChangeKind.defAdded));
+      }
+      continue;
+    }
+    if (newDefs == null) {
+      for (final def in oldDefs.keys) {
+        changes.add(LexChange(nsid: nsid, defName: def, kind: LexChangeKind.defRemoved));
+      }
+      continue;
+    }
+
+    for (final def in {...oldDefs.keys, ...newDefs.keys}) {
+      final oldDef = oldDefs[def];
+      final newDef = newDefs[def];
+      if (oldDef == null) {
+        changes.add(LexChange(nsid: nsid, defName: def, kind: LexChangeKind.defAdded));
+      } else if (newDef == null) {
+        changes.add(LexChange(nsid: nsid, defName: def, kind: LexChangeKind.defRemoved));
+      } else {
+        changes.addAll(_diffDef(nsid, def, oldDef as Map<String, dynamic>, newDef as Map<String, dynamic>));
+      }
+    }
+  }
+
+  changes.sort((a, b) {
+    final byNsid = a.nsid.compareTo(b.nsid);
+    if (byNsid != 0) return byNsid;
+    final byDef = a.defName.compareTo(b.defName);
+    if (byDef != 0) return byDef;
+    return (a.field ?? '').compareTo(b.field ?? '');
+  });
+  return changes;
+}
+
+/// For a `record` def the schema lives under `record`; otherwise it is the def.
+Map<String, dynamic> _schemaOf(Map<String, dynamic> def) {
+  final record = def['record'];
+  if (def['type'] == 'record' && record is Map<String, dynamic>) return record;
+  return def;
+}
+
+List<LexChange> _diffDef(String nsid, String def, Map<String, dynamic> oldDef, Map<String, dynamic> newDef) {
+  final changes = <LexChange>[];
+  final oldSchema = _schemaOf(oldDef);
+  final newSchema = _schemaOf(newDef);
+
+  final oldProps = (oldSchema['properties'] as Map<String, dynamic>?) ?? const {};
+  final newProps = (newSchema['properties'] as Map<String, dynamic>?) ?? const {};
+  final oldRequired = ((oldSchema['required'] as List?) ?? const []).cast<String>().toSet();
+  final newRequired = ((newSchema['required'] as List?) ?? const []).cast<String>().toSet();
+
+  for (final prop in {...oldProps.keys, ...newProps.keys}) {
+    final oldProp = oldProps[prop];
+    final newProp = newProps[prop];
+
+    if (oldProp == null) {
+      changes.add(LexChange(nsid: nsid, defName: def, field: prop, kind: LexChangeKind.propertyAdded));
+      continue;
+    }
+    if (newProp == null) {
+      changes.add(LexChange(nsid: nsid, defName: def, field: prop, kind: LexChangeKind.propertyRemoved));
+      continue;
+    }
+
+    final oldType = _typeSig(oldProp);
+    final newType = _typeSig(newProp);
+    if (oldType != newType) {
+      changes.add(LexChange(nsid: nsid, defName: def, field: prop, kind: LexChangeKind.propertyTypeChanged, detail: '$oldType -> $newType'));
+      continue;
+    }
+
+    final wasRequired = oldRequired.contains(prop);
+    final isRequired = newRequired.contains(prop);
+    if (!wasRequired && isRequired) {
+      changes.add(LexChange(nsid: nsid, defName: def, field: prop, kind: LexChangeKind.propertyBecameRequired));
+    } else if (wasRequired && !isRequired) {
+      changes.add(LexChange(nsid: nsid, defName: def, field: prop, kind: LexChangeKind.propertyBecameOptional));
+    } else if (jsonEncode(oldProp) != jsonEncode(newProp)) {
+      changes.add(LexChange(nsid: nsid, defName: def, field: prop, kind: LexChangeKind.metadataChanged));
+    }
+  }
+  return changes;
+}
+
+/// A comparable signature of a property's type (includes `ref`/`refs` targets).
+String _typeSig(Object? prop) {
+  if (prop is! Map<String, dynamic>) return '$prop';
+  final type = prop['type'];
+  final ref = prop['ref'];
+  final refs = prop['refs'];
+  final items = prop['items'];
+  final itemSig = items == null ? '' : '<${_typeSig(items)}>';
+  return '$type${ref == null ? '' : '($ref)'}${refs == null ? '' : '($refs)'}$itemSig';
+}

--- a/scripts/gen_changelog/lexicon_diff_test.dart
+++ b/scripts/gen_changelog/lexicon_diff_test.dart
@@ -1,0 +1,69 @@
+// Dart imports:
+import 'dart:convert';
+
+// Package imports:
+import 'package:test/test.dart';
+
+// Project imports:
+import 'models.dart';
+import 'lexicon_diff.dart';
+
+Snapshot _snap(Map<String, String> byNsid) =>
+    byNsid.map((k, v) => MapEntry(k, jsonDecode(v) as Map<String, dynamic>));
+
+void main() {
+  test('detects added and removed property on a record', () {
+    final old = _snap({
+      'app.bsky.feed.post':
+          '{"main":{"type":"record","record":{"type":"object","required":["text"],"properties":{"text":{"type":"string"},"entities":{"type":"array"}}}}}',
+    });
+    final updated = _snap({
+      'app.bsky.feed.post':
+          '{"main":{"type":"record","record":{"type":"object","required":["text"],"properties":{"text":{"type":"string"},"langs":{"type":"array"}}}}}',
+    });
+    final changes = diffSnapshots(old, updated);
+    expect(
+      changes,
+      containsAll([
+        const LexChange(nsid: 'app.bsky.feed.post', defName: 'main', field: 'langs', kind: LexChangeKind.propertyAdded),
+        const LexChange(nsid: 'app.bsky.feed.post', defName: 'main', field: 'entities', kind: LexChangeKind.propertyRemoved),
+      ]),
+    );
+  });
+
+  test('detects optional -> required', () {
+    final old = _snap({
+      'x.y.z': '{"main":{"type":"object","required":[],"properties":{"a":{"type":"string"}}}}',
+    });
+    final updated = _snap({
+      'x.y.z': '{"main":{"type":"object","required":["a"],"properties":{"a":{"type":"string"}}}}',
+    });
+    expect(
+      diffSnapshots(old, updated),
+      contains(const LexChange(nsid: 'x.y.z', defName: 'main', field: 'a', kind: LexChangeKind.propertyBecameRequired)),
+    );
+  });
+
+  test('detects new nsid as defAdded', () {
+    final changes = diffSnapshots({}, _snap({
+      'com.atproto.repo.applyWrites': '{"main":{"type":"procedure"}}',
+    }));
+    expect(changes, [
+      const LexChange(nsid: 'com.atproto.repo.applyWrites', defName: 'main', kind: LexChangeKind.defAdded),
+    ]);
+  });
+
+  test('detects type change', () {
+    final old = _snap({'x.y.z': '{"main":{"type":"object","properties":{"a":{"type":"string"}}}}'});
+    final updated = _snap({'x.y.z': '{"main":{"type":"object","properties":{"a":{"type":"integer"}}}}'});
+    expect(
+      diffSnapshots(old, updated),
+      contains(const LexChange(nsid: 'x.y.z', defName: 'main', field: 'a', kind: LexChangeKind.propertyTypeChanged, detail: 'string -> integer')),
+    );
+  });
+
+  test('no change yields empty list', () {
+    final s = _snap({'x.y.z': '{"main":{"type":"object","properties":{"a":{"type":"string"}}}}'});
+    expect(diffSnapshots(s, _snap({'x.y.z': '{"main":{"type":"object","properties":{"a":{"type":"string"}}}}'})), isEmpty);
+  });
+}

--- a/scripts/gen_changelog/lexicon_snapshot.dart
+++ b/scripts/gen_changelog/lexicon_snapshot.dart
@@ -1,0 +1,71 @@
+// Copyright (c) 2023-2025, Shinya Kato.
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// Dart imports:
+import 'dart:convert';
+import 'dart:io';
+
+// Project imports:
+import 'models.dart';
+
+const _lexiconsDir = 'lexicons';
+
+/// Parses raw JSON strings (keyed by an arbitrary path) into a [Snapshot].
+/// Files that are not valid JSON, or lack `id`/`defs`, are skipped.
+Snapshot parseSnapshot(Map<String, String> filesByPath) {
+  final snapshot = <String, LexiconDefs>{};
+  for (final entry in filesByPath.entries) {
+    try {
+      final json = jsonDecode(entry.value);
+      if (json is! Map<String, dynamic>) continue;
+      final id = json['id'];
+      final defs = json['defs'];
+      if (id is! String || defs is! Map<String, dynamic>) continue;
+      snapshot[id] = defs;
+    } catch (_) {
+      // Skip invalid lexicon file.
+    }
+  }
+  return snapshot;
+}
+
+/// Loads the lexicon snapshot from the working tree.
+Snapshot loadSnapshotFromDisk() {
+  final files = <String, String>{};
+  final dir = Directory(_lexiconsDir);
+  if (!dir.existsSync()) return {};
+  for (final file in dir.listSync(recursive: true).whereType<File>()) {
+    if (!file.path.endsWith('.json')) continue;
+    files[file.path] = file.readAsStringSync();
+  }
+  return parseSnapshot(files);
+}
+
+/// Loads the lexicon snapshot as it existed at git [ref].
+Snapshot loadSnapshotFromGit(String ref) {
+  final list = Process.runSync('git', [
+    'ls-tree',
+    '-r',
+    '--name-only',
+    ref,
+    '--',
+    _lexiconsDir,
+  ]);
+  if (list.exitCode != 0) {
+    throw StateError('git ls-tree failed for $ref: ${list.stderr}');
+  }
+  final paths = (list.stdout as String)
+      .split('\n')
+      .map((e) => e.trim())
+      .where((e) => e.endsWith('.json'));
+
+  final files = <String, String>{};
+  for (final path in paths) {
+    final show = Process.runSync('git', ['show', '$ref:$path']);
+    if (show.exitCode == 0) {
+      files[path] = show.stdout as String;
+    }
+  }
+  return parseSnapshot(files);
+}

--- a/scripts/gen_changelog/lexicon_snapshot_test.dart
+++ b/scripts/gen_changelog/lexicon_snapshot_test.dart
@@ -1,0 +1,24 @@
+// Package imports:
+import 'package:test/test.dart';
+
+// Project imports:
+import 'lexicon_snapshot.dart';
+
+void main() {
+  test('parseSnapshot keys by id and stores defs', () {
+    final snap = parseSnapshot({
+      'a.json': '{"id":"app.bsky.feed.post","defs":{"main":{"type":"record"}}}',
+    });
+    expect(snap.keys, ['app.bsky.feed.post']);
+    expect(snap['app.bsky.feed.post']!['main'], {'type': 'record'});
+  });
+
+  test('parseSnapshot skips invalid or incomplete files', () {
+    final snap = parseSnapshot({
+      'bad.json': 'not json',
+      'nodefs.json': '{"id":"x.y.z"}',
+      'ok.json': '{"id":"com.atproto.repo.createRecord","defs":{"main":{"type":"query"}}}',
+    });
+    expect(snap.keys, ['com.atproto.repo.createRecord']);
+  });
+}

--- a/scripts/gen_changelog/models.dart
+++ b/scripts/gen_changelog/models.dart
@@ -1,0 +1,88 @@
+// Copyright (c) 2023-2025, Shinya Kato.
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// Project imports:
+import 'semver.dart';
+
+/// Raw `defs` object of a single lexicon: def name -> def JSON.
+typedef LexiconDefs = Map<String, dynamic>;
+
+/// A parsed snapshot of all lexicons: NSID -> defs.
+typedef Snapshot = Map<String, LexiconDefs>;
+
+enum LexChangeKind {
+  defAdded,
+  defRemoved,
+  propertyAdded,
+  propertyRemoved,
+  propertyBecameRequired,
+  propertyBecameOptional,
+  propertyTypeChanged,
+  metadataChanged,
+}
+
+/// Version bump severity; `index` is ordered least -> most severe.
+enum BumpLevel { none, patch, minor }
+
+BumpLevel maxBump(BumpLevel a, BumpLevel b) => a.index >= b.index ? a : b;
+
+class LexChange {
+  const LexChange({
+    required this.nsid,
+    required this.defName,
+    this.field,
+    required this.kind,
+    this.detail,
+  });
+
+  final String nsid;
+  final String defName;
+  final String? field;
+  final LexChangeKind kind;
+  final String? detail;
+
+  @override
+  bool operator ==(Object other) =>
+      other is LexChange &&
+      other.nsid == nsid &&
+      other.defName == defName &&
+      other.field == field &&
+      other.kind == kind &&
+      other.detail == detail;
+
+  @override
+  int get hashCode => Object.hash(nsid, defName, field, kind, detail);
+
+  @override
+  String toString() =>
+      'LexChange($nsid#$defName${field == null ? '' : '.$field'}, $kind${detail == null ? '' : ', $detail'})';
+}
+
+class ClassifiedChange {
+  const ClassifiedChange({
+    required this.change,
+    required this.level,
+    required this.changelogLine,
+  });
+
+  final LexChange change;
+  final BumpLevel level;
+  final String changelogLine;
+}
+
+class PackagePlan {
+  const PackagePlan({
+    required this.package,
+    required this.oldVersion,
+    required this.newVersion,
+    required this.changelogLines,
+    required this.depRangeUpdates,
+  });
+
+  final String package;
+  final Version oldVersion;
+  final Version newVersion;
+  final List<String> changelogLines;
+  final Map<String, Version> depRangeUpdates;
+}

--- a/scripts/gen_changelog/models_test.dart
+++ b/scripts/gen_changelog/models_test.dart
@@ -1,0 +1,31 @@
+// Package imports:
+import 'package:test/test.dart';
+
+// Project imports:
+import 'models.dart';
+
+void main() {
+  test('LexChange value equality and toString', () {
+    const a = LexChange(
+      nsid: 'app.bsky.feed.post',
+      defName: 'main',
+      field: 'langs',
+      kind: LexChangeKind.propertyAdded,
+    );
+    const b = LexChange(
+      nsid: 'app.bsky.feed.post',
+      defName: 'main',
+      field: 'langs',
+      kind: LexChangeKind.propertyAdded,
+    );
+    expect(a, equals(b));
+    expect(a.hashCode, equals(b.hashCode));
+    expect(a.toString(), contains('propertyAdded'));
+  });
+
+  test('maxBump returns the more severe level', () {
+    expect(maxBump(BumpLevel.patch, BumpLevel.minor), BumpLevel.minor);
+    expect(maxBump(BumpLevel.none, BumpLevel.patch), BumpLevel.patch);
+    expect(maxBump(BumpLevel.patch, BumpLevel.patch), BumpLevel.patch);
+  });
+}

--- a/scripts/gen_changelog/package_mapper.dart
+++ b/scripts/gen_changelog/package_mapper.dart
@@ -1,0 +1,22 @@
+// Copyright (c) 2023-2025, Shinya Kato.
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// NSID prefix -> package. MUST stay in sync with `scripts/gen_codes.dart`
+/// `namespaceRules` and `scripts/gen_lexicon_ids.dart` `_packages`.
+const Map<String, List<String>> packageNamespaces = {
+  'atproto': ['com.atproto', 'com.germnetwork'],
+  'bluesky': ['app.bsky', 'chat.bsky', 'tools.ozone'],
+};
+
+/// Returns the owning package for [nsid], or null if no package generates it.
+String? packageForNsid(String nsid) {
+  for (final entry in packageNamespaces.entries) {
+    for (final prefix in entry.value) {
+      if (nsid == prefix || nsid.startsWith('$prefix.')) {
+        return entry.key;
+      }
+    }
+  }
+  return null;
+}

--- a/scripts/gen_changelog/package_mapper_test.dart
+++ b/scripts/gen_changelog/package_mapper_test.dart
@@ -1,0 +1,23 @@
+// Package imports:
+import 'package:test/test.dart';
+
+// Project imports:
+import 'package_mapper.dart';
+
+void main() {
+  test('maps known namespaces', () {
+    expect(packageForNsid('app.bsky.feed.post'), 'bluesky');
+    expect(packageForNsid('tools.ozone.queue.createQueue'), 'bluesky');
+    expect(packageForNsid('chat.bsky.convo.defs'), 'bluesky');
+    expect(packageForNsid('com.atproto.repo.createRecord'), 'atproto');
+    expect(packageForNsid('com.germnetwork.declaration'), 'atproto');
+  });
+
+  test('returns null for unmapped namespaces', () {
+    expect(packageForNsid('site.standard.document'), isNull);
+  });
+
+  test('does not match on partial segment', () {
+    expect(packageForNsid('app.bskything.foo'), isNull);
+  });
+}

--- a/scripts/gen_changelog/semver.dart
+++ b/scripts/gen_changelog/semver.dart
@@ -1,0 +1,47 @@
+// Copyright (c) 2023-2025, Shinya Kato.
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// Project imports:
+import 'models.dart';
+
+/// A minimal semantic version (major.minor.patch) sufficient for this repo's
+/// version lines. Pre-release/build metadata is intentionally unsupported.
+class Version {
+  const Version(this.major, this.minor, this.patch);
+
+  factory Version.parse(String input) {
+    final parts = input.trim().split('.');
+    if (parts.length != 3) {
+      throw FormatException('Unsupported version: $input');
+    }
+    return Version(
+      int.parse(parts[0]),
+      int.parse(parts[1]),
+      int.parse(parts[2]),
+    );
+  }
+
+  final int major;
+  final int minor;
+  final int patch;
+
+  Version bump(BumpLevel level) => switch (level) {
+    BumpLevel.none => this,
+    BumpLevel.patch => Version(major, minor, patch + 1),
+    BumpLevel.minor => Version(major, minor + 1, 0),
+  };
+
+  @override
+  bool operator ==(Object other) =>
+      other is Version &&
+      other.major == major &&
+      other.minor == minor &&
+      other.patch == patch;
+
+  @override
+  int get hashCode => Object.hash(major, minor, patch);
+
+  @override
+  String toString() => '$major.$minor.$patch';
+}

--- a/scripts/gen_changelog/semver_test.dart
+++ b/scripts/gen_changelog/semver_test.dart
@@ -1,0 +1,25 @@
+// Package imports:
+import 'package:test/test.dart';
+
+// Project imports:
+import 'models.dart';
+import 'semver.dart';
+
+void main() {
+  test('parse and toString round-trip', () {
+    expect(Version.parse('1.7.1').toString(), '1.7.1');
+    expect(Version.parse('0.6.0').toString(), '0.6.0');
+  });
+
+  test('patch bump increments patch', () {
+    expect(Version.parse('1.7.1').bump(BumpLevel.patch).toString(), '1.7.2');
+  });
+
+  test('minor bump increments minor and resets patch', () {
+    expect(Version.parse('1.7.1').bump(BumpLevel.minor).toString(), '1.8.0');
+  });
+
+  test('none bump is identity', () {
+    expect(Version.parse('1.7.1').bump(BumpLevel.none).toString(), '1.7.1');
+  });
+}

--- a/scripts/gen_changelog/version_planner.dart
+++ b/scripts/gen_changelog/version_planner.dart
@@ -1,0 +1,85 @@
+// Copyright (c) 2023-2025, Shinya Kato.
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// Project imports:
+import 'models.dart';
+import 'semver.dart';
+
+class _Draft {
+  _Draft(this.package, this.oldVersion, this.level);
+  final String package;
+  final Version oldVersion;
+  BumpLevel level;
+  final List<String> lines = [];
+  final Map<String, Version> depRangeUpdates = {};
+  final Set<String> _bumpedDeps = {};
+
+  Version get newVersion => oldVersion.bump(level);
+}
+
+/// Plans per-package version bumps and changelog lines from classified changes.
+Map<String, PackagePlan> planVersions({
+  required Map<String, List<ClassifiedChange>> changesByPackage,
+  required Map<String, Version> currentVersions,
+  required Map<String, List<String>> dependents,
+}) {
+  final drafts = <String, _Draft>{};
+
+  // 1. Direct bumps.
+  for (final entry in changesByPackage.entries) {
+    final pkg = entry.key;
+    if (entry.value.isEmpty) continue;
+    var level = BumpLevel.none;
+    for (final c in entry.value) {
+      level = maxBump(level, c.level);
+    }
+    if (level == BumpLevel.none) continue;
+
+    final draft = _Draft(pkg, currentVersions[pkg]!, level);
+    final seen = <String>{};
+    for (final c in entry.value) {
+      if (seen.add(c.changelogLine)) draft.lines.add(c.changelogLine);
+    }
+    draft.lines.add('chore: regenerated from synced lexicons');
+    drafts[pkg] = draft;
+  }
+
+  // 2. Propagate to dependents until fixed point.
+  var changed = true;
+  while (changed) {
+    changed = false;
+    for (final pkg in drafts.keys.toList()) {
+      final producer = drafts[pkg]!;
+      for (final dep in dependents[pkg] ?? const <String>[]) {
+        var draft = drafts[dep];
+        if (draft == null) {
+          draft = _Draft(dep, currentVersions[dep]!, BumpLevel.patch);
+          drafts[dep] = draft;
+          changed = true;
+        }
+        if (draft._bumpedDeps.add(pkg)) {
+          draft.depRangeUpdates[pkg] = producer.newVersion;
+          draft.lines.add('chore: bump `$pkg` to `^${producer.newVersion}`');
+          changed = true;
+        } else if (draft.depRangeUpdates[pkg] != producer.newVersion) {
+          // Producer version rose during propagation; refresh the recorded range.
+          draft.depRangeUpdates[pkg] = producer.newVersion;
+          final idx = draft.lines.indexWhere((l) => l.startsWith('chore: bump `$pkg` to '));
+          if (idx >= 0) draft.lines[idx] = 'chore: bump `$pkg` to `^${producer.newVersion}`';
+        }
+      }
+    }
+  }
+
+  return drafts.map((pkg, d) => MapEntry(
+        pkg,
+        PackagePlan(
+          package: pkg,
+          oldVersion: d.oldVersion,
+          newVersion: d.newVersion,
+          changelogLines: d.lines,
+          depRangeUpdates: d.depRangeUpdates,
+        ),
+      ));
+}

--- a/scripts/gen_changelog/version_planner_test.dart
+++ b/scripts/gen_changelog/version_planner_test.dart
@@ -1,0 +1,64 @@
+// Package imports:
+import 'package:test/test.dart';
+
+// Project imports:
+import 'models.dart';
+import 'semver.dart';
+import 'version_planner.dart';
+
+ClassifiedChange _c(BumpLevel level, String line) => ClassifiedChange(
+      change: const LexChange(nsid: 'x.y.z', defName: 'main', kind: LexChangeKind.defAdded),
+      level: level,
+      changelogLine: line,
+    );
+
+void main() {
+  test('patch bump for additions and trailing regenerated line', () {
+    final plans = planVersions(
+      changesByPackage: {
+        'atproto': [_c(BumpLevel.patch, 'feat: added `com.atproto.repo.applyWrites`')],
+      },
+      currentVersions: {'atproto': Version.parse('1.7.0'), 'bluesky': Version.parse('1.7.1'), 'bluesky_cli': Version.parse('0.6.0')},
+      dependents: {'atproto': ['bluesky'], 'bluesky': ['bluesky_cli']},
+    );
+    expect(plans['atproto']!.newVersion.toString(), '1.7.1');
+    expect(plans['atproto']!.changelogLines.last, 'chore: regenerated from synced lexicons');
+  });
+
+  test('minor bump when a breaking change is present', () {
+    final plans = planVersions(
+      changesByPackage: {
+        'bluesky': [_c(BumpLevel.patch, 'feat: added `app.bsky.a`'), _c(BumpLevel.minor, 'fix!: removed `app.bsky.b` (BREAKING)')],
+      },
+      currentVersions: {'bluesky': Version.parse('1.7.1'), 'bluesky_cli': Version.parse('0.6.0')},
+      dependents: {'bluesky': ['bluesky_cli']},
+    );
+    expect(plans['bluesky']!.newVersion.toString(), '1.8.0');
+  });
+
+  test('propagates patch bump and dep range update transitively', () {
+    final plans = planVersions(
+      changesByPackage: {
+        'atproto': [_c(BumpLevel.patch, 'feat: added `com.atproto.x`')],
+      },
+      currentVersions: {'atproto': Version.parse('1.7.0'), 'bluesky': Version.parse('1.7.1'), 'bluesky_cli': Version.parse('0.6.0')},
+      dependents: {'atproto': ['bluesky'], 'bluesky': ['bluesky_cli']},
+    );
+    expect(plans['bluesky']!.newVersion.toString(), '1.7.2');
+    expect(plans['bluesky']!.depRangeUpdates['atproto']!.toString(), '1.7.1');
+    expect(plans['bluesky']!.changelogLines, contains('chore: bump `atproto` to `^1.7.1`'));
+    expect(plans['bluesky_cli']!.newVersion.toString(), '0.6.1');
+    expect(plans['bluesky_cli']!.changelogLines, contains('chore: bump `bluesky` to `^1.7.2`'));
+  });
+
+  test('deduplicates identical changelog lines', () {
+    final plans = planVersions(
+      changesByPackage: {
+        'atproto': [_c(BumpLevel.patch, 'feat: added `com.atproto.x`'), _c(BumpLevel.patch, 'feat: added `com.atproto.x`')],
+      },
+      currentVersions: {'atproto': Version.parse('1.7.0')},
+      dependents: {},
+    );
+    expect(plans['atproto']!.changelogLines.where((l) => l == 'feat: added `com.atproto.x`').length, 1);
+  });
+}

--- a/scripts/gen_changelog/writer.dart
+++ b/scripts/gen_changelog/writer.dart
@@ -1,0 +1,61 @@
+// Copyright (c) 2023-2025, Shinya Kato.
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// Dart imports:
+import 'dart:io';
+
+// Project imports:
+import 'models.dart';
+
+/// Rewrites the `version:` line and any bumped dependency ranges.
+String bumpPubspec(String content, PackagePlan plan) {
+  final lines = content.split('\n');
+  for (var i = 0; i < lines.length; i++) {
+    final line = lines[i];
+    if (RegExp(r'^version:\s').hasMatch(line)) {
+      lines[i] = 'version: ${plan.newVersion}';
+      continue;
+    }
+    for (final dep in plan.depRangeUpdates.entries) {
+      final match = RegExp('^(\\s+)${RegExp.escape(dep.key)}:\\s*\\^').firstMatch(line);
+      if (match != null) {
+        lines[i] = '${match.group(1)}${dep.key}: ^${dep.value}';
+      }
+    }
+  }
+  return lines.join('\n');
+}
+
+/// Inserts a new `## vX.Y.Z` section after the `# Release Note` header.
+/// Idempotent: if the target version section already exists, returns [content].
+String insertChangelog(String content, PackagePlan plan) {
+  final header = '## v${plan.newVersion}';
+  if (content.contains('$header\n') || content.endsWith(header)) return content;
+
+  final body = StringBuffer()
+    ..writeln(header)
+    ..writeln();
+  for (final line in plan.changelogLines) {
+    body.writeln('- $line');
+  }
+  body.writeln();
+
+  const marker = '# Release Note\n\n';
+  final idx = content.indexOf(marker);
+  if (idx < 0) {
+    // No recognizable header; prepend the section.
+    return '$body$content';
+  }
+  final insertAt = idx + marker.length;
+  return content.substring(0, insertAt) + body.toString() + content.substring(insertAt);
+}
+
+/// Applies [plan] to the package's pubspec and changelog on disk.
+void applyPlan(PackagePlan plan) {
+  final pubspec = File('packages/${plan.package}/pubspec.yaml');
+  pubspec.writeAsStringSync(bumpPubspec(pubspec.readAsStringSync(), plan));
+
+  final changelog = File('packages/${plan.package}/CHANGELOG.md');
+  changelog.writeAsStringSync(insertChangelog(changelog.readAsStringSync(), plan));
+}

--- a/scripts/gen_changelog/writer_test.dart
+++ b/scripts/gen_changelog/writer_test.dart
@@ -1,0 +1,40 @@
+// Package imports:
+import 'package:test/test.dart';
+
+// Project imports:
+import 'models.dart';
+import 'semver.dart';
+import 'writer.dart';
+
+PackagePlan _plan() => PackagePlan(
+      package: 'bluesky',
+      oldVersion: Version.parse('1.7.1'),
+      newVersion: Version.parse('1.7.2'),
+      changelogLines: const ['feat: added `app.bsky.feed.post.langs`', 'chore: bump `atproto` to `^1.7.1`', 'chore: regenerated from synced lexicons'],
+      depRangeUpdates: {'atproto': Version.parse('1.7.1')},
+    );
+
+void main() {
+  test('bumpPubspec rewrites version and dep range', () {
+    const pubspec = 'name: bluesky\nversion: 1.7.1\ndependencies:\n  atproto: ^1.7.0\n  http: ^1.4.0\n';
+    final out = bumpPubspec(pubspec, _plan());
+    expect(out, contains('version: 1.7.2'));
+    expect(out, contains('  atproto: ^1.7.1'));
+    expect(out, contains('  http: ^1.4.0'));
+  });
+
+  test('insertChangelog adds a new section after the header', () {
+    const changelog = '# Release Note\n\n## v1.7.1\n\n- old entry\n';
+    final out = insertChangelog(changelog, _plan());
+    expect(out, contains('## v1.7.2'));
+    expect(out.indexOf('## v1.7.2'), lessThan(out.indexOf('## v1.7.1')));
+    expect(out, contains('- feat: added `app.bsky.feed.post.langs`'));
+  });
+
+  test('insertChangelog is idempotent', () {
+    const changelog = '# Release Note\n\n## v1.7.1\n\n- old entry\n';
+    final once = insertChangelog(changelog, _plan());
+    final twice = insertChangelog(once, _plan());
+    expect(twice, once);
+  });
+}

--- a/scripts/gen_changelog_test.dart
+++ b/scripts/gen_changelog_test.dart
@@ -1,0 +1,84 @@
+// Dart imports:
+import 'dart:convert';
+
+// Package imports:
+import 'package:test/test.dart';
+
+// Project imports:
+import 'gen_changelog.dart';
+import 'gen_changelog/models.dart';
+import 'gen_changelog/semver.dart';
+
+Snapshot _snap(Map<String, String> byNsid) =>
+    byNsid.map((k, v) => MapEntry(k, jsonDecode(v) as Map<String, dynamic>));
+
+void main() {
+  test('run maps a bluesky property addition to a patch plan and propagates', () {
+    final plans = run(
+      oldSnap: _snap({
+        'app.bsky.feed.post':
+            '{"main":{"type":"object","properties":{"text":{"type":"string"}}}}',
+      }),
+      newSnap: _snap({
+        'app.bsky.feed.post':
+            '{"main":{"type":"object","properties":{"text":{"type":"string"},"langs":{"type":"array"}}}}',
+      }),
+      currentVersions: {
+        'bluesky': Version.parse('1.7.1'),
+        'bluesky_cli': Version.parse('0.6.0'),
+      },
+      dependents: {
+        'bluesky': ['bluesky_cli'],
+      },
+    );
+    expect(plans['bluesky']!.newVersion.toString(), '1.7.2');
+    expect(plans['bluesky']!.changelogLines,
+        contains('feat: added `app.bsky.feed.post.langs`'));
+    expect(plans['bluesky_cli']!.newVersion.toString(), '0.6.1');
+  });
+
+  test('run drops changes for unmapped namespaces', () {
+    final plans = run(
+      oldSnap: {},
+      newSnap: _snap({'site.standard.document': '{"main":{"type":"record"}}'}),
+      currentVersions: {'atproto': Version.parse('1.7.0')},
+      dependents: {},
+    );
+    expect(plans, isEmpty);
+  });
+
+  test('directDependencyNames reads dependencies: only, not dev_dependencies:', () {
+    const pubspec = '''
+name: bluesky_text
+version: 1.5.0
+
+dependencies:
+  xrpc: ^1.1.0
+  http: ^1.4.0
+
+dev_dependencies:
+  bluesky: ^1.7.0
+  test: ^1.26.2
+''';
+    final names = directDependencyNames(pubspec);
+    expect(names, containsAll(['xrpc', 'http']));
+    expect(names, isNot(contains('bluesky')));
+    expect(names, isNot(contains('test')));
+  });
+
+  test('directDependencyNames skips path dependencies', () {
+    const pubspec = '''
+name: bluesky
+version: 1.7.1
+
+dependencies:
+  atproto: ^1.7.0
+
+dependency_overrides:
+  atproto_test:
+    path: ../atproto_test
+''';
+    final names = directDependencyNames(pubspec);
+    expect(names, {'atproto'});
+  });
+}


### PR DESCRIPTION
## Summary

Automates CHANGELOG entries and version bumps whenever Lexicon-driven codegen
runs (the `chore-generate-codes` PRs, e.g. #2439). A new self-contained Dart
tool diffs the synced Lexicon JSON semantically, maps each changed NSID to its
owning package, and writes `feat:`/`fix!:`/`chore:` entries plus a `pubspec.yaml`
version bump into the same PR for human review.

Motivated by PRs like #2439, where the regenerated source previously landed
with no CHANGELOG entry and no version bump.

## What it does

For each affected package:

- **Semantic diff** of raw Lexicon JSON (added/removed defs, added/removed
  properties, optional↔required transitions, type changes, metadata-only edits).
  Parsing is plain `jsonDecode` — intentionally **decoupled from `lex_gen`**.
- **Classification** into changelog lines with an API-impact note on breaking
  changes, e.g. `fix!: removed \`app.bsky.feed.post.entities\` (BREAKING)`.
- **Version policy**: additions/edits → **patch**; breaking changes (property
  removed, def removed, optional→required, type changed) → **minor** (never
  major — packages are in the 1.x line).
- **Dependency propagation**: when a package bumps, dependents get a **patch**
  bump, their `^` dependency range is rewritten, and a `chore: bump ...` line is
  added. Only the runtime `dependencies:` block is considered, so test-only
  sibling back-references never trigger a release.
- **NSID → package mapping** matches `scripts/gen_codes.dart` (`com.atproto`,
  `com.germnetwork` → `atproto`; `app.bsky`, `chat.bsky`, `tools.ozone` →
  `bluesky`). Unmapped namespaces (e.g. `site.standard.*`) are skipped.

Changes land in the existing `chore-generate-codes` PR; **merge stays manual**
(no auto-merge, no auto-publish).

## Wiring

`generate_codes.yml` gains a step after **Format** / before **Create Pull
Request** that runs `dart run ./scripts/gen_changelog.dart`, and `fetch-depth: 0`
on checkout so the pre-sync base commit is reachable for the diff.

## Testing

- 31 unit tests across the diff, classifier, version planner (incl. dependency
  propagation), writer (incl. idempotency), and orchestration. `dart analyze`
  clean.
- **End-to-end validated against real git history**: replaying the Lexicon delta
  between two real sync points produced `atproto 1.7.0 → 1.7.1` (patch),
  `bluesky 1.7.1 → 1.8.0` (minor, from breaking changes), correct dependency
  propagation, and correctly skipped `site.standard.*`.

## Note

The output of this tool for #2439 (`bluesky 1.7.1 → 1.7.2`) has already been
pushed to that PR as a first real application.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
