### PR TITLE
refactor(lex_gen): structural readability pass (output byte-identical)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,5 @@ coverage.lcov
 
 # Kiro IDE
 .kiro
+.lex_gen_baseline/
+docs

--- a/docs/superpowers/specs/2026-07-15-lex-gen-structural-refactor-design.md
+++ b/docs/superpowers/specs/2026-07-15-lex-gen-structural-refactor-design.md
@@ -9,6 +9,30 @@
 
 ---
 
+## 0. 実装結果（as-built・2026-07-15 完了）
+
+ブランチ `refactor/lex-gen-structural`。全 Theme を10ワークストリームに分解し、隔離 git worktree の並列エージェントで実装。各ワークストリームは Tier A（出力不変）+ analyze + 70テストを合格制約に自己検証し、integration worktree へ順次マージ。
+
+| ワークストリーム | 対象 | 状態 |
+|---|---|---|
+| S1 | `object/lex_service.dart` 648→618 | ✅ record accessors/function-method対 統合 |
+| S2 | `object/repo_commit_handler.dart` 407→378 | ✅ 定数DTO退避・create/update統合 |
+| S4 | `fmt/lex_property_generator.dart` | ✅ array重複解消・単一RefVariant |
+| C1 | `commands/types/lex_command.dart` 652→611 | ✅ preamble/ヘッダ抽出・kind分割 |
+| B1 | freezed 4モデル + `FreezedModel` 基底 | ✅ 共通フィールド/validate集約 |
+| B2 | services orchestrator（`is`ラダー→switch, `services_common.dart` 新設で dedup） | ✅ |
+| B3 | `services/rule.dart` パスヘルパ内部dedup | ✅ 保守的 |
+| B4 | commands dispatch平坦化 + parent/root import dedup | ✅ |
+| C-theme1 | 拡張getterエミッタ集約 + known_values elements helper | ✅ 部分（分岐する変種は据置） |
+| C-theme5 | `LexParameter`→`LexCliParameter` 衝突リネーム | ✅ |
+
+**最終検証**: Tier A PASS / analyze クリーン / 70テスト / **Tier B PASS（フルパイプライン→空 git diff、出力バイト一致を決定的に立証）**。lib 22ファイル・純減 −51行、重複は `services_common.dart` と `FreezedModel` 基底に集約。
+
+### 得られた教訓（重要・ハーネスに反映済）
+Tier A（gen→dart format→diff）は生成**出力**の不変は担保するが、**lex_gen 自身のソースが `melos fmt`(import_sorter) を生き延びるか**は検証しない。C1 の record-command emitter が `import 'dart:convert';'''`（import 行が三重引用の閉じ `'''` に密着する形）を生み、import_sorter がこれを誤ってトップへ hoist してファイルを破壊した（生成出力は不変・analyze/testは合格のため10エージェント全員が見逃した）。Tier B で捕捉→ソースを内容不変のまま import_sorter 安全に修正。ハーネスに **`srccheck`**（lex_gen ソースに import_sorter+analyze をかけ安定性を確認）を追加し、per-change でこのクラスの退行を検出できるようにした。
+
+---
+
 ## 1. 現状アーキテクチャ（維持する骨格）
 
 `lex_gen` は 2 つの独立した生成ワールドを持ち、各ワールドが 3 層のパイプラインで構成される。

--- a/docs/superpowers/specs/2026-07-15-lex-gen-structural-refactor-design.md
+++ b/docs/superpowers/specs/2026-07-15-lex-gen-structural-refactor-design.md
@@ -1,0 +1,183 @@
+# lex_gen 構造リファクタ設計（出力不変）
+
+- **日付**: 2026-07-15
+- **対象**: `packages/lex_gen`
+- **前提リファクタ**: PR #2434（F1–F7 + follow-up A/B/C/D）が main にマージ済。本設計はその続きとして、残る構造的・可読性上の負債を解消する。
+- **不変条件**: **最終コミット物（`dart format` + `import_sorter` 適用後の生成ファイル）がバイト一致**。生成中間文字列の空白は問わない。
+- **スコープ**: `services/` ワールド + `commands/` ワールド + 共有基盤（`rule`/`utils`/`model`）。
+- **アペタイト**: 構造改善パス（巨大メソッド分割・重複統合・ディスパッチのテーブル化・型化・共有プリミティブ抽出）。エミッション機構の全面刷新（`package:code_builder` 移行等）は**スコープ外**。
+
+---
+
+## 1. 現状アーキテクチャ（維持する骨格）
+
+`lex_gen` は 2 つの独立した生成ワールドを持ち、各ワールドが 3 層のパイプラインで構成される。
+
+```
+orchestrator (lib/src/**/lex_*_generator.dart)
+    ├─ Lexicon AST(package:lexicon) を走査
+    ├─ def の kind で分岐
+    └─ ファイル I/O（生成物を書き出す）
+          │
+          ▼
+fmt/ model builder (lib/src/services/fmt/*.dart)
+    └─ Lexicon AST → 中間モデル（LexObject / LexUnion / LexRecord / LexInput / ...）
+          │
+          ▼
+emitter (lib/src/services/object/*.dart, lib/src/commands/types/*.dart)
+    └─ 中間モデル → Dart ソース文字列（StringBuffer / 三重引用テンプレート）
+```
+
+| ワールド | orchestrator | model builder | emitter | 抽象度 |
+|---|---|---|---|---|
+| `services/` | `lex_type_generator` / `lex_service_generator` / `lex_tools_generator` | `fmt/*` | `object/*` | 高（`DartType`/`LexRef`/`GenContext` 済） |
+| `commands/` | `lex_command_generator` | （なし・orchestrator が直接組立） | `commands/types/*` | 低（stringly-typed） |
+
+**この 3 層の責務境界は良好なので壊さない。** 改善は各層内部の分割・重複排除・型化に限定する。
+
+---
+
+## 2. 不変条件と検証ハーネス（Theme 0 — 最優先・全作業のゲート）
+
+不変条件が「最終コミット物一致」であるため、生成中間文字列の空白変更が許容される。その代償として、検証は正規パイプライン全通しが必要になる。
+
+### 2.1 正規パイプライン（`melos gen` のコード生成サブセット）
+
+docs/ids/matrix 生成（`gen_lexicon_docs` / `gen_lexicon_ids` / `gen_lexicon_matrix` / `gen_supported_api_matrix`）は本リファクタと無関係なノイズ源なので**含めない**。コード生成の確定に必要なのは以下:
+
+```
+dart run ./scripts/gen_codes.dart
+(packages/atproto)     dart run build_runner build --delete-conflicting-outputs && dart fix --apply
+(packages/bluesky)     dart run build_runner build --delete-conflicting-outputs && dart fix --apply
+(packages/bluesky_cli) dart fix --apply
+melos fmt   # = import_sorter:main + dart format
+```
+
+出力 3 ディレクトリ:
+- `packages/atproto/lib/src/services/codegen`（~562 dart）
+- `packages/bluesky/lib/src/services/codegen`（~2632 dart）
+- `packages/bluesky_cli/lib/src/commands/codegen`（~371 dart）
+
+### 2.2 二層検証
+
+`melos gen` フルは build_runner を含み分単位で遅い。per-change で回すには重いため、二層に分ける。
+
+**Tier A — 高速プロキシ（per-change / 数秒）**
+`gen_codes.dart` を実行し、生の 3 出力 dir に `dart format` のみ適用して、**リファクタ前の main で同手順取得したベースライン**と比較する。
+- 意味的に等価な生成 → `dart format` 後は等価に収束するため、大半の退行をここで即検知。
+- 注意: import 順は import_sorter が確定するので Tier A では import 集合が変わらない限り安定。import を触る変更は Tier B で確認。
+- build_runner 不要（`.g/.freezed` は生成ソースが確定すれば決定的）。
+
+**Tier B — フルゲート（マイルストーン / merge 前 / 分単位）**
+正規パイプライン全通し後に `git diff --exit-code` を 3 出力 dir に対して実行。**空 diff = 出力不変の最終的機械担保**。
+
+### 2.3 成果物
+
+- `scripts/verify_gen_unchanged.dart`（または `.sh`）— Tier A/B を切替実行できる開発ツールとしてリポジトリに追加。
+- Theme 0 の受け入れ条件: **現行 main のクリーン再生成が空 diff を生む**ことを最初に確認する。もし drift があれば、リファクタ着手前に本ドキュメントで報告し方針を再検討する。
+
+### 2.4 既存テスト
+
+- `packages/lex_gen/test` の 13 テストファイル（ユニット + `feed_post_golden_test` の E2E golden）。
+- 各コミットで `dart test`（lex_gen）+ Tier A、各マイルストーンで Tier B。
+
+---
+
+## 3. リファクタ Theme（Theme 0 以降）
+
+各 Theme は**小さく独立検証可能なコミット**に分割し、全て Theme 0 のゲートを通過させる。
+
+### Theme 1 — 共有エミッションプリミティブ（両ワールド横断）
+
+- **ヘッダ/import 定型の集約**: ライセンスバナー・`package:` import ブロック・class 宣言スキャフォールドが各 emitter に手埋めで重複（`lex_service` / `repo_commit_handler` / `renderFreezedDataClass` / `commands/types/*`）。共有ヘルパへ。
+- **`is / isNot / has` 拡張 getter イディオムの統合**: `utils.getExtensions` / `lex_union._getExtensions` / `lex_known_values._getExtensions` / `at_uri_extension` に散在する同一 idiom を単一エミッタに集約。
+- **小さな内部 `CodeWriter`（限定導入）**: インデント・ブロック・`$` エスケープを吸収する StringBuffer ラッパ。**全面適用はしない**。`_getRecordAccessors` 等、最も `writeln`/`\$` ノイズが多い高レバレッジ箇所に限定使用。
+
+### Theme 2 — services/ emitter ホットスポット
+
+- **`object/lex_service.dart`（648 行）**:
+  - `LexService`（ファイル組立）と `LexApi`（API 単位 emitter）を別ファイルへ分離。
+  - `_getRecordAccessors`（~127 行 / ~100 `writeln`）: get/list/create/put/delete が共有する「XRPC 呼び出し末尾（collection/rkey/`$ctx`/`$headers`/`$unknown`）」を 1 ヘルパに畳む。create↔put は record マップ組立以外ほぼ同一なので統合。
+  - `_getQueryFunction↔_getQueryMethod` / `_getProcedureFunction↔_getProcedureMethod` / `_getSubscriptionFunction↔_getSubscriptionMethod` の 3 対を、シグネチャ行 + 委譲本体の差分だけに縮約（description preamble と param ループは共通化）。
+  - `_getPackagePaths`: import 解決を専用コレクタへ分離し、union 分岐の二重アーム（ref!=null / else）を統合。`_hasRecordApi()` の per-api 再評価を除去。
+- **`object/repo_commit_handler.dart`（407 行）**:
+  - 定数 DTO ブロック（`RepoCommitCreate/Update/Delete`、~150 行）を `format()` から定数テンプレートへ退避。create↔update は `createdAt` の有無のみ差分なので統合。
+  - `_getFields` / `_getConstructorArgs` / `_getConstructorArgsSetter` の 3 並列 per-typeName ループを 1 パスに。
+  - `_getMutationEvent`（verb 統合済）に `_getOnDeleteEvent` を可能な範囲で畳む。
+- **freezed 4 モデル（`object/lex_object` / `lex_record` / `lex_input` / `lex_output`）**:
+  - 共通フィールド（`lexiconId`/`defName`/`name`/`description`/`properties`）と近似重複の `_getValidateMethod` を共通基底 `FreezedModel` に集約。suffix/partBaseName/validate 分岐をパラメータ化。
+
+### Theme 3 — services/ model builder(fmt/) + orchestrator
+
+- **`fmt/lex_property_generator.dart`（421 行）**:
+  - `_getDartType` の array-item サブ switch（5 分岐で `DartType.array(...)` フィールドコピー 4x）をヘルパ化し重複解消。
+  - `_getLexRefVariantType` の二重 3 項（`name` と `annotation` が同じ 3-way 判定を 2 回）を 1 つの解決済み `RefVariant`（enum/record）へ。
+- **パラメータオブジェクト化**: fmt/ 全体を貫く `(lexiconId, defName, mainVariants[, fieldName])` の位置引数タプルを 1 型に。
+- **fmt/ の単一 `execute()` クラス儀式**（6 ファイル）を素の関数へ。
+- **orchestrator**:
+  - `lex_type_generator.execute()` の `is lex.ULexUserType*` ラダー（7 分岐 / ~90 行）を **def kind → builder のテーブル/ディスパッチ**へ。
+  - `_generateLexPackages` / `_getBasePackages` の逐字重複（`lex_type_generator` と `lex_service_generator`）を共有モジュールへ。
+  - doc 型述語（`_isDocA<T>` / `_isRecord` / `_kindOf` / `_getApiDef`）を単一 classifier へ。
+  - ファイル I/O をモデル組立から分離。
+- **`services/rule.dart`（374 行）**:
+  - `*ForService` / `*ForExport` パスヘルパ双子を統合。
+  - 文字列四つ組（`lexiconId`/`defName`/`fieldName`/`ref`）を `LexRef` 拡張として型化。
+
+### Theme 4 — commands/ ワールド（services 並みへ引き上げ）
+
+- **`commands/types/lex_command.dart`（652 行）**:
+  - preamble 三つ組（`serviceName`/`typeName`/`commandName`）とヘッダ/import/class 宣言の定型を抽出。
+  - 4 kind（query / procedure / blobProcedure / record）+ 5 record サブ emitter を別ユニット（ファイル）へ分割。
+  - ハードコードされた `"bsky …"` 起動文字列を集約（既存の構造化 `_getInvocation` 系に寄せる）。
+- **`commands/types/lex_parameter.dart`**: `type` / `itemsType` を **enum 型化**（stringly-typed 分岐の解消）。services の `DartType` 完全共有は規模が大きいため今回は enum 化を目標とし、DartType 再利用は将来オプションとして注記。
+- **親/ルートコマンド**: `lex_parent_command` / `lex_root_command` の `_getImportPaths` 重複を統合。
+- **`lex_command_generator`**: def ディスパッチループ（procedure サブケースの入れ子 continue）を classifier で平坦化。
+
+### Theme 5 — 命名衝突の衛生（横断作業の前提）
+
+- 2 つの `LexParameter`（`commands`=CLI 引数 / `services`=Dart 関数引数、**コード共有ゼロ・同名**）の一方をリネームし衝突を解消。
+- 2 つの `rule.dart` の `getServiceName` が**同名別意味**（commands: `serviceId.replaceAll('.','-')` / services: `Nsid(...).service`）である点を明記。素朴なマージを禁止する注意書きを残す。
+
+---
+
+## 4. 実行シーケンス & 並列化
+
+依存関係と競合を踏まえた波状実行。
+
+```
+Wave 0（直列・オーケストレータ本人）
+  設計ドキュメント + Theme 0 ハーネス + ベースライン取得 + 現行 main が空 diff で再生成されることを確認
+
+Wave 1（直列 or 軽並列・共有基盤の前提）
+  Theme 5（リネーム衛生） → Theme 1（共有プリミティブ）
+  ※ 両ワールド/共有ファイルを触るため後続の前提。ここは競合が多いので直列気味に。
+
+Wave 2（並列・独立ファイル集合）
+  ├─ services 系（Theme 2 + Theme 3）  … object/ + fmt/ + services orchestrator
+  └─ commands 系（Theme 4）             … commands/ 一式
+  ※ ファイル集合がほぼ交わらないので worktree 分離で並列。各 worktree で Tier A を独立実行。
+```
+
+- **並列化の制約**: 同一ファイルを触る変更は直列化 or worktree 分離後にマージ。マージ後は必ず Tier B を通す。
+- **各 Theme = 独立コミット**。analyze クリーン + lex_gen テスト全パス + Tier A を各コミットの受け入れ条件に。
+
+---
+
+## 5. スコープ外（YAGNI / 明示的除外）
+
+- `package:code_builder` への全面移行、全 emitter の `CodeWriter` 全面書き換え（アペタイト超過）。
+- 生成される **API 表面の変更**（メソッド名・引数・生成コードの意味的変化は一切しない）。
+- 文書化済みの命名衝突**バグ**（`services/rule.dart` TODO G-5）修正 — これは出力を変えるため本リファクタでは扱わない。
+- docs/ids/matrix 生成物の変更。
+
+---
+
+## 6. リスクと緩和
+
+| リスク | 緩和 |
+|---|---|
+| 空白許容により退行検知が生バイト比較で効かない | Theme 0 の二層検証（Tier A 高速プロキシ + Tier B フルゲート）で機械担保 |
+| build_runner を含むフルゲートが遅く per-change で回せない | Tier A（gen_codes → dart format → baseline 比較）を per-change の主検証に |
+| 並列 worktree 間のファイル競合 | services/commands の disjoint 分割 + Wave 1 の共有基盤先行 + マージ後 Tier B |
+| 現行 main がそもそも空 diff で再生成されない（drift 存在） | Wave 0 で最初に確認。drift があれば着手前に報告し方針再検討 |
+| `commands` の型化が波及して出力が変わる | enum 化に留め、生成文字列の分岐結果が同一であることを Tier A で逐次確認 |

--- a/packages/lex_gen/lib/src/commands/lex_command_generator.dart
+++ b/packages/lex_gen/lib/src/commands/lex_command_generator.dart
@@ -26,130 +26,143 @@ void generateLexCommands(
   final result = <String, List<LexCommand>>{};
   for (final doc in docs) {
     for (final def in doc.defs.entries) {
-      if (def.value is ULexUserTypeXrpcQuery) {
-        final query = def.value.data as LexXrpcQuery;
-
-        _appendCommand(
-          result,
-          doc.id,
-          LexCommand(
-            doc.id,
-            query.description,
-            _getParameters(
-              query.parameters?.requiredProperties,
-              query.parameters?.properties,
-            ),
-            kind: LexCommandKind.query,
-          ),
-        );
-      } else if (def.value is ULexUserTypeXrpcProcedure) {
-        final procedure = def.value.data as LexXrpcProcedure;
-        final input = procedure.input;
-
-        if (input == null) {
-          // Procedures without input body, e.g. com.atproto.server
-          // .refreshSession.
-          _appendCommand(
-            result,
-            doc.id,
-            LexCommand(
-              doc.id,
-              procedure.description,
-              const [],
-              kind: LexCommandKind.procedure,
-            ),
-          );
-
-          continue;
-        }
-
-        if (input.encoding != 'application/json') {
-          // Procedures with binary input, e.g. com.atproto.repo.uploadBlob.
-          _appendCommand(
-            result,
-            doc.id,
-            LexCommand(
-              doc.id,
-              procedure.description,
-              const [],
-              encoding: input.encoding,
-              kind: LexCommandKind.blobProcedure,
-            ),
-          );
-
-          continue;
-        }
-
-        final object = input.schema?.whenOrNull(object: (data) => data);
-        if (object == null) {
-          // JSON procedures whose input schema is a ref or union,
-          // e.g. tools.ozone.set.upsertSet.
-          _appendCommand(
-            result,
-            doc.id,
-            LexCommand(
-              doc.id,
-              procedure.description,
-              const [],
-              kind: LexCommandKind.procedure,
-              isRawJsonBody: true,
-            ),
-          );
-
-          continue;
-        }
-
-        _appendCommand(
-          result,
-          doc.id,
-          LexCommand(
-            doc.id,
-            procedure.description,
-            _getParameters(object.requiredProperties, object.properties),
-            kind: LexCommandKind.procedure,
-          ),
-        );
-      } else if (def.value is ULexUserTypeXrpcSubscription) {
-      } else if (def.value is ULexUserTypeRecord) {
-        final record = def.value.data as LexRecord;
-        final object = record.record;
-
-        _appendCommand(
-          result,
-          doc.id,
-          LexCommand(
-            doc.id,
-            record.description,
-            _getParameters(object.requiredProperties, object.properties),
-            rkey: record.key,
-            kind: LexCommandKind.record,
-          ),
-        );
+      final command = _buildCommand(doc.id, def.value);
+      if (command != null) {
+        _appendCommand(result, doc.id, command);
       }
     }
   }
 
   final parentCommands = <LexParentCommand>[];
   for (final entry in result.entries) {
-    for (final command in entry.value) {
-      File(getAbsoluteFilePath(config, command.lexiconId.toString()))
-        ..createSync(recursive: true)
-        ..writeAsStringSync(command.format());
-    }
+    _writeChildCommands(config, entry.value);
 
     final parentCommand = LexParentCommand(entry.key, entry.value);
-    File(
-        getAbsoluteFilePathForParent(
-          config,
-          parentCommand.lexiconId.toString(),
-        ),
-      )
-      ..createSync(recursive: true)
-      ..writeAsStringSync(parentCommand.format());
+    _writeParentCommand(config, parentCommand);
 
     parentCommands.add(parentCommand);
   }
 
+  _writeRootCommand(config, parentCommands);
+}
+
+/// Builds the [LexCommand] for a single lexicon [def], or returns `null`
+/// when the def has no command surface (e.g. subscriptions).
+LexCommand? _buildCommand(final NSID lexiconId, final LexUserType def) {
+  if (def is ULexUserTypeXrpcQuery) {
+    final query = def.data;
+
+    return LexCommand(
+      lexiconId,
+      query.description,
+      _getParameters(
+        query.parameters?.requiredProperties,
+        query.parameters?.properties,
+      ),
+      kind: LexCommandKind.query,
+    );
+  }
+
+  if (def is ULexUserTypeXrpcProcedure) {
+    return _buildProcedureCommand(lexiconId, def.data);
+  }
+
+  if (def is ULexUserTypeXrpcSubscription) {
+    // Subscriptions expose no CLI command, so they are intentionally skipped.
+    return null;
+  }
+
+  if (def is ULexUserTypeRecord) {
+    final record = def.data;
+    final object = record.record;
+
+    return LexCommand(
+      lexiconId,
+      record.description,
+      _getParameters(object.requiredProperties, object.properties),
+      rkey: record.key,
+      kind: LexCommandKind.record,
+    );
+  }
+
+  return null;
+}
+
+/// Classifies an XRPC procedure by its input schema into one of the four
+/// command shapes: no input body, binary (blob) input, raw-JSON body, or a
+/// structured object body.
+LexCommand _buildProcedureCommand(
+  final NSID lexiconId,
+  final LexXrpcProcedure procedure,
+) {
+  final input = procedure.input;
+
+  if (input == null) {
+    // Procedures without input body, e.g. com.atproto.server.refreshSession.
+    return LexCommand(
+      lexiconId,
+      procedure.description,
+      const [],
+      kind: LexCommandKind.procedure,
+    );
+  }
+
+  if (input.encoding != 'application/json') {
+    // Procedures with binary input, e.g. com.atproto.repo.uploadBlob.
+    return LexCommand(
+      lexiconId,
+      procedure.description,
+      const [],
+      encoding: input.encoding,
+      kind: LexCommandKind.blobProcedure,
+    );
+  }
+
+  final object = input.schema?.whenOrNull(object: (data) => data);
+  if (object == null) {
+    // JSON procedures whose input schema is a ref or union,
+    // e.g. tools.ozone.set.upsertSet.
+    return LexCommand(
+      lexiconId,
+      procedure.description,
+      const [],
+      kind: LexCommandKind.procedure,
+      isRawJsonBody: true,
+    );
+  }
+
+  return LexCommand(
+    lexiconId,
+    procedure.description,
+    _getParameters(object.requiredProperties, object.properties),
+    kind: LexCommandKind.procedure,
+  );
+}
+
+void _writeChildCommands(
+  final LexCommandRuleConfig config,
+  final List<LexCommand> commands,
+) {
+  for (final command in commands) {
+    File(getAbsoluteFilePath(config, command.lexiconId.toString()))
+      ..createSync(recursive: true)
+      ..writeAsStringSync(command.format());
+  }
+}
+
+void _writeParentCommand(
+  final LexCommandRuleConfig config,
+  final LexParentCommand parentCommand,
+) {
+  File(getAbsoluteFilePathForParent(config, parentCommand.lexiconId.toString()))
+    ..createSync(recursive: true)
+    ..writeAsStringSync(parentCommand.format());
+}
+
+void _writeRootCommand(
+  final LexCommandRuleConfig config,
+  final List<LexParentCommand> parentCommands,
+) {
   final rootCommand = LexRootCommand(parentCommands);
   File('${config.homeDir}/lex_commands.dart')
     ..createSync(recursive: true)

--- a/packages/lex_gen/lib/src/commands/lex_command_generator.dart
+++ b/packages/lex_gen/lib/src/commands/lex_command_generator.dart
@@ -169,18 +169,18 @@ void _writeRootCommand(
     ..writeAsStringSync(rootCommand.format());
 }
 
-List<LexParameter> _getParameters(
+List<LexCliParameter> _getParameters(
   final List<String>? requiredProperties,
   final Map<String, dynamic>? properties,
 ) {
   final requiredProps = requiredProperties ?? const [];
   final props = properties ?? const {};
 
-  final parameters = <LexParameter>[];
+  final parameters = <LexCliParameter>[];
   for (final prop in props.entries) {
     final propJson = prop.value.toJson();
     parameters.add(
-      LexParameter(
+      LexCliParameter(
         prop.key,
         propJson['description'],
         requiredProps.contains(prop.key),

--- a/packages/lex_gen/lib/src/commands/rule.dart
+++ b/packages/lex_gen/lib/src/commands/rule.dart
@@ -84,3 +84,24 @@ String getRelativePathForParent(final String lexiconId) {
 String getRelativePathForRoot(final String lexiconId) {
   return Nsid(lexiconId).serviceDir;
 }
+
+/// Builds the shared `import '...';` block emitted by both the parent and
+/// root command generators.
+///
+/// Each import path is derived from a lexicon id via [relativePathOf], which
+/// differs between the two callers (parent vs. root relative paths).
+String getCommandImports(
+  final Iterable<String> lexiconIds,
+  final String Function(String lexiconId) relativePathOf,
+) {
+  final buffer = StringBuffer();
+
+  for (final lexiconId in lexiconIds) {
+    final relativePath = relativePathOf(lexiconId);
+    final fileName = getFileName(lexiconId);
+
+    buffer.writeln("import '$relativePath/$fileName.dart';");
+  }
+
+  return buffer.toString();
+}

--- a/packages/lex_gen/lib/src/commands/types/lex_command.dart
+++ b/packages/lex_gen/lib/src/commands/types/lex_command.dart
@@ -14,7 +14,7 @@ import 'lex_parameter.dart';
 final class LexCommand {
   final NSID lexiconId;
   final String? description;
-  final List<LexParameter> parameters;
+  final List<LexCliParameter> parameters;
 
   final String? rkey;
 
@@ -478,7 +478,7 @@ ${_listRecordClass()}
     return result.join(' ');
   }
 
-  String _getInvocationOption(final LexParameter param) {
+  String _getInvocationOption(final LexCliParameter param) {
     if (param.isBoolean) {
       return '[--${param.name}]';
     }

--- a/packages/lex_gen/lib/src/commands/types/lex_command.dart
+++ b/packages/lex_gen/lib/src/commands/types/lex_command.dart
@@ -235,7 +235,12 @@ $contentTypeOverride}
 
     final rkeyOverride = _getReferenceKeyOverride();
 
-    const imports = '''
+    // NOTE: the closing `'''` is kept on its own line and the trailing
+    // `import 'dart:convert';` is a concatenated literal so that no source line
+    // reads `import '...';'''` — import_sorter mis-hoists that shape out of the
+    // template. The emitted string content is unchanged.
+    const imports =
+        '''
 import 'dart:async';
 
 import 'package:args/command_runner.dart';
@@ -245,7 +250,8 @@ import '../../../../create_record_command.dart';
 import '../../../../put_record_command.dart';
 import '../../../../delete_record_command.dart';
 
-import 'dart:convert';''';
+'''
+        "import 'dart:convert';";
 
     return '''${_fileHeader(imports)}
 

--- a/packages/lex_gen/lib/src/commands/types/lex_command.dart
+++ b/packages/lex_gen/lib/src/commands/types/lex_command.dart
@@ -46,22 +46,35 @@ final class LexCommand {
     };
   }
 
+  /// The three derived names every emitter needs, computed once from
+  /// [lexiconId]: the service (e.g. `feed`), the generated class type name,
+  /// and the CLI command name.
+  ({String serviceName, String typeName, String commandName}) get _names {
+    final id = lexiconId.toString();
+    return (
+      serviceName: getServiceName(id),
+      typeName: getCommandTypeName(id),
+      commandName: getCommandName(id),
+    );
+  }
+
+  /// The shared top-of-file boilerplate (license/hint banner, the given
+  /// [imports] block, then the generated-code header) prepended to every
+  /// emitted command file.
+  String _fileHeader(final String imports) => '''$kHeaderHint
+
+$imports
+
+$kHeader''';
+
   String _getQueryCommand() {
-    final serviceName = getServiceName(lexiconId.toString());
-    final typeName = getCommandTypeName(lexiconId.toString());
-    final commandName = getCommandName(lexiconId.toString());
+    final (:serviceName, :typeName, :commandName) = _names;
 
     final invocation = _getInvocation(serviceName, commandName);
     final opts = _getOpts();
     final parameters = _getParameters();
 
-    return '''$kHeaderHint
-
-import '../../../../query_command.dart';
-
-import 'dart:convert';
-
-$kHeader
+    return '''${_fileHeader("import '../../../../query_command.dart';\n\nimport 'dart:convert';")}
 
 final class $typeName extends QueryCommand {
   $typeName() {
@@ -89,98 +102,52 @@ ${_getInputHelpers()}}
   }
 
   String _getProcedureCommand() {
-    final serviceName = getServiceName(lexiconId.toString());
-    final typeName = getCommandTypeName(lexiconId.toString());
-    final commandName = getCommandName(lexiconId.toString());
+    final (:serviceName, :typeName, :commandName) = _names;
+
+    // The three procedure variants share the same class shell and differ only
+    // in constructor body, invocation, `body` getter and trailing helpers.
+    final String constructorBody;
+    final String invocation;
+    final String bodyMember;
+    final String helpers;
 
     if (isRawJsonBody) {
-      return '''$kHeaderHint
-
-import '../../../../procedure_command.dart';
-
-import 'dart:convert';
-
-$kHeader
-
-final class $typeName extends ProcedureCommand {
-  $typeName() {
+      constructorBody = '''{
     argParser.addOption(
       "json",
       help: r"JSON string representing the entire request body.",
       mandatory: true,
     );
-  }
-
-  @override
-  final String name = "$commandName";
-
-  @override
-  final String description = r"${_getDescription()}";
-
-  @override
-  final String invocation = "bsky $serviceName $commandName --json=<value>";
-
-  @override
-  String get methodId => "${lexiconId.toString()}";
-
-  @override
-  Map<String, dynamic>? get body {
+  }''';
+      invocation = 'bsky $serviceName $commandName --json=<value>';
+      bodyMember = '''Map<String, dynamic>? get body {
     try {
       return Map<String, dynamic>.from(jsonDecode(argResults!["json"]));
     } on FormatException catch (e) {
       usageException("Invalid JSON for option \\"json\\": \${e.message}");
     }
-  }
-}
-''';
+  }''';
+      helpers = '';
+    } else if (parameters.isEmpty) {
+      constructorBody = ';';
+      invocation = 'bsky $serviceName $commandName';
+      bodyMember = 'Map<String, dynamic>? get body => null;';
+      helpers = '';
+    } else {
+      constructorBody = '''{
+    ${_getOpts()}
+  }''';
+      invocation = _getInvocation(serviceName, commandName);
+      bodyMember = '''Map<String, dynamic>? get body => {
+    ${_getParameters()}
+  };''';
+      helpers = _getInputHelpers();
     }
 
-    if (parameters.isEmpty) {
-      return '''$kHeaderHint
-
-import '../../../../procedure_command.dart';
-
-import 'dart:convert';
-
-$kHeader
+    return '''${_fileHeader("import '../../../../procedure_command.dart';\n\nimport 'dart:convert';")}
 
 final class $typeName extends ProcedureCommand {
-  $typeName();
-
-  @override
-  final String name = "$commandName";
-
-  @override
-  final String description = r"${_getDescription()}";
-
-  @override
-  final String invocation = "bsky $serviceName $commandName";
-
-  @override
-  String get methodId => "${lexiconId.toString()}";
-
-  @override
-  Map<String, dynamic>? get body => null;
-}
-''';
-    }
-
-    final invocation = _getInvocation(serviceName, commandName);
-    final opts = _getOpts();
-    final body = _getParameters();
-
-    return '''$kHeaderHint
-
-import '../../../../procedure_command.dart';
-
-import 'dart:convert';
-
-$kHeader
-
-final class $typeName extends ProcedureCommand {
-  $typeName() {
-    $opts
-  }
+  $typeName()$constructorBody
 
   @override
   final String name = "$commandName";
@@ -195,17 +162,13 @@ final class $typeName extends ProcedureCommand {
   String get methodId => "${lexiconId.toString()}";
 
   @override
-  Map<String, dynamic>? get body => {
-    $body
-  };
-${_getInputHelpers()}}
+  $bodyMember
+$helpers}
 ''';
   }
 
   String _getBlobProcedureCommand() {
-    final serviceName = getServiceName(lexiconId.toString());
-    final typeName = getCommandTypeName(lexiconId.toString());
-    final commandName = getCommandName(lexiconId.toString());
+    final (:serviceName, :typeName, :commandName) = _names;
 
     final contentTypeOverride = encoding == null || encoding == '*/*'
         ? ''
@@ -214,11 +177,7 @@ ${_getInputHelpers()}}
   String get contentType => "$encoding";
 ''';
 
-    return '''$kHeaderHint
-
-import '../../../../blob_command.dart';
-
-$kHeader
+    return '''${_fileHeader("import '../../../../blob_command.dart';")}
 
 final class $typeName extends BlobCommand {
   $typeName();
@@ -239,9 +198,7 @@ $contentTypeOverride}
   }
 
   String _getRecordCommand() {
-    final serviceName = getServiceName(lexiconId.toString());
-    final typeName = getCommandTypeName(lexiconId.toString());
-    final commandName = getCommandName(lexiconId.toString());
+    final (:serviceName, :typeName, :commandName) = _names;
 
     final literalRkey = _getReferenceKey();
 
@@ -275,8 +232,7 @@ $contentTypeOverride}
 
     final rkeyOverride = _getReferenceKeyOverride();
 
-    return '''$kHeaderHint
-
+    const imports = '''
 import 'dart:async';
 
 import 'package:args/command_runner.dart';
@@ -286,9 +242,9 @@ import '../../../../create_record_command.dart';
 import '../../../../put_record_command.dart';
 import '../../../../delete_record_command.dart';
 
-import 'dart:convert';
+import 'dart:convert';''';
 
-$kHeader
+    return '''${_fileHeader(imports)}
 
 final class $typeName extends Command<void> {
   $typeName() {
@@ -316,11 +272,11 @@ ${_recordMutationClass(typeName: typeName, classPrefix: 'Create', baseClass: 'Cr
 
 ${_recordMutationClass(typeName: typeName, classPrefix: 'Put', baseClass: 'PutRecordCommand', recordArgsMixin: recordArgsMixin, rkeyStmt: putRkeyStmt, name: 'put', descriptionVerb: 'Updates a record', invocation: invocationForUpdate, rkeyOverride: rkeyOverride, parameters: parameters)}
 
-${_deleteRecordClass(typeName, serviceName, commandName, literalRkey)}
+${_deleteRecordClass()}
 
-${_getRecordClass(typeName, serviceName, commandName, literalRkey)}
+${_getRecordClass()}
 
-${_listRecordClass(typeName, serviceName, commandName)}
+${_listRecordClass()}
 ''';
   }
 
@@ -328,6 +284,13 @@ ${_listRecordClass(typeName, serviceName, commandName)}
   /// into the generated `get`/`list` record subcommands.
   static const _getRecordMethodId = 'com.atproto.repo.getRecord';
   static const _listRecordsMethodId = 'com.atproto.repo.listRecords';
+
+  /// The `bsky <service> <command>` prefix every record subcommand invocation
+  /// string is built on.
+  String get _recordInvocationBase {
+    final names = _names;
+    return 'bsky ${names.serviceName} ${names.commandName}';
+  }
 
   /// Renders a `create` or `put` record subcommand. The two differ only by the
   /// [classPrefix]/[baseClass], their `rkey` option ([rkeyStmt]), [name],
@@ -374,19 +337,18 @@ ${_listRecordClass(typeName, serviceName, commandName)}
 }''';
   }
 
-  String _deleteRecordClass(
-    final String typeName,
-    final String serviceName,
-    final String commandName,
-    final String? literalRkey,
-  ) {
+  String _deleteRecordClass() {
     final id = lexiconId.toString();
-    final deleteOpts = literalRkey == null
-        ? 'argParser..addOption("rkey", help: r"The record key.", mandatory: true,);'
-        : '';
-    final deleteInvocation = literalRkey == null
-        ? 'bsky $serviceName $commandName delete --rkey=<value>'
-        : 'bsky $serviceName $commandName delete';
+    final typeName = _names.typeName;
+    final base = _recordInvocationBase;
+    final hasLiteralRkey = _getReferenceKey() != null;
+
+    final deleteOpts = hasLiteralRkey
+        ? ''
+        : 'argParser..addOption("rkey", help: r"The record key.", mandatory: true,);';
+    final deleteInvocation = hasLiteralRkey
+        ? '$base delete'
+        : '$base delete --rkey=<value>';
 
     return '''final class _Delete$typeName extends DeleteRecordCommand {
   _Delete$typeName() {
@@ -409,13 +371,12 @@ ${_listRecordClass(typeName, serviceName, commandName)}
 }''';
   }
 
-  String _getRecordClass(
-    final String typeName,
-    final String serviceName,
-    final String commandName,
-    final String? literalRkey,
-  ) {
+  String _getRecordClass() {
     final id = lexiconId.toString();
+    final typeName = _names.typeName;
+    final base = _recordInvocationBase;
+    final literalRkey = _getReferenceKey();
+
     final getRkeyOpt = literalRkey == null
         ? '..addOption("rkey", help: r"The record key.", mandatory: true,)'
         : '';
@@ -423,8 +384,8 @@ ${_listRecordClass(typeName, serviceName, commandName)}
         ? "argResults!['rkey']"
         : "'$literalRkey'";
     final getInvocation = literalRkey == null
-        ? 'bsky $serviceName $commandName get --rkey=<value> [--repo=<value>] [--cid=<value>]'
-        : 'bsky $serviceName $commandName get [--repo=<value>] [--cid=<value>]';
+        ? '$base get --rkey=<value> [--repo=<value>] [--cid=<value>]'
+        : '$base get [--repo=<value>] [--cid=<value>]';
 
     return '''final class _Get$typeName extends QueryCommand {
   _Get$typeName() {
@@ -455,12 +416,10 @@ ${_listRecordClass(typeName, serviceName, commandName)}
 }''';
   }
 
-  String _listRecordClass(
-    final String typeName,
-    final String serviceName,
-    final String commandName,
-  ) {
+  String _listRecordClass() {
     final id = lexiconId.toString();
+    final typeName = _names.typeName;
+    final base = _recordInvocationBase;
 
     return '''final class _List$typeName extends QueryCommand {
   _List$typeName() {
@@ -478,7 +437,7 @@ ${_listRecordClass(typeName, serviceName, commandName)}
   final String description = r"Lists records for $id.";
 
   @override
-  final String invocation = "bsky $serviceName $commandName list [--repo=<value>] [--limit=<value>] [--cursor=<value>] [--reverse]";
+  final String invocation = "$base list [--repo=<value>] [--limit=<value>] [--cursor=<value>] [--reverse]";
 
   @override
   String get methodId => "$_listRecordsMethodId";

--- a/packages/lex_gen/lib/src/commands/types/lex_command.dart
+++ b/packages/lex_gen/lib/src/commands/types/lex_command.dart
@@ -61,7 +61,8 @@ final class LexCommand {
   /// The shared top-of-file boilerplate (license/hint banner, the given
   /// [imports] block, then the generated-code header) prepended to every
   /// emitted command file.
-  String _fileHeader(final String imports) => '''$kHeaderHint
+  String _fileHeader(final String imports) =>
+      '''$kHeaderHint
 
 $imports
 
@@ -134,11 +135,13 @@ ${_getInputHelpers()}}
       bodyMember = 'Map<String, dynamic>? get body => null;';
       helpers = '';
     } else {
-      constructorBody = '''{
+      constructorBody =
+          '''{
     ${_getOpts()}
   }''';
       invocation = _getInvocation(serviceName, commandName);
-      bodyMember = '''Map<String, dynamic>? get body => {
+      bodyMember =
+          '''Map<String, dynamic>? get body => {
     ${_getParameters()}
   };''';
       helpers = _getInputHelpers();

--- a/packages/lex_gen/lib/src/commands/types/lex_parameter.dart
+++ b/packages/lex_gen/lib/src/commands/types/lex_parameter.dart
@@ -2,7 +2,7 @@
 // All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-final class LexParameter {
+final class LexCliParameter {
   final String name;
   final String? description;
   final bool isRequired;
@@ -15,7 +15,7 @@ final class LexParameter {
   /// The lexicon type of array items when [type] is `array`.
   final String? itemsType;
 
-  const LexParameter(
+  const LexCliParameter(
     this.name,
     this.description,
     this.isRequired,

--- a/packages/lex_gen/lib/src/commands/types/lex_parent_command.dart
+++ b/packages/lex_gen/lib/src/commands/types/lex_parent_command.dart
@@ -13,7 +13,10 @@ final class LexParentCommand {
     final serviceName = getServiceName(lexiconId.toString());
     final commandName = getParentCommandTypeName(lexiconId.toString());
 
-    final importPaths = _getImportPaths();
+    final importPaths = getCommandImports(
+      commands.map((command) => command.lexiconId.toString()),
+      getRelativePathForParent,
+    );
     final subcommands = _getSubcommands();
 
     return '''$kHeaderHint
@@ -36,21 +39,6 @@ final class $commandName extends Command<void>  {
   String get description => "Provides commands for $lexiconId.*";
 }
 ''';
-  }
-
-  String _getImportPaths() {
-    final buffer = StringBuffer();
-
-    for (final command in commands) {
-      final relativePath = getRelativePathForParent(
-        command.lexiconId.toString(),
-      );
-      final fileName = getFileName(command.lexiconId.toString());
-
-      buffer.writeln("import '$relativePath/$fileName.dart';");
-    }
-
-    return buffer.toString();
   }
 
   String _getSubcommands() {

--- a/packages/lex_gen/lib/src/commands/types/lex_root_command.dart
+++ b/packages/lex_gen/lib/src/commands/types/lex_root_command.dart
@@ -9,7 +9,10 @@ final class LexRootCommand {
   const LexRootCommand(this.commands);
 
   String format() {
-    final importPaths = _getImportPaths();
+    final importPaths = getCommandImports(
+      commands.map((command) => command.lexiconId.toString()),
+      getRelativePathForRoot,
+    );
     final commandNames = _getParentCommandNames();
 
     return '''$kHeaderHint
@@ -29,19 +32,6 @@ List<Command<void>> get lexCommands => [
     $commandNames
 ];
 ''';
-  }
-
-  String _getImportPaths() {
-    final buffer = StringBuffer();
-
-    for (final command in commands) {
-      final relativePath = getRelativePathForRoot(command.lexiconId.toString());
-      final fileName = getFileName(command.lexiconId.toString());
-
-      buffer.writeln("import '$relativePath/$fileName.dart';");
-    }
-
-    return buffer.toString();
   }
 
   String _getParentCommandNames() {

--- a/packages/lex_gen/lib/src/services/fmt/lex_property_generator.dart
+++ b/packages/lex_gen/lib/src/services/fmt/lex_property_generator.dart
@@ -8,7 +8,9 @@ import 'package:lexicon/lexicon.dart' as lex;
 // Project imports:
 import '../../dart_type.dart';
 import '../gen_context.dart';
+import '../object/lex_known_values.dart';
 import '../object/lex_property.dart';
+import '../object/lex_union.dart';
 import '../rule.dart' as rule;
 import 'lex_known_values_generator.dart';
 import 'lex_union_generator.dart';
@@ -97,29 +99,7 @@ String? _getDefaultValue(
     case lex.ULexPrimitiveString string:
       final value = string.data.defaultValue;
       if (value == null) return null;
-
-      // A string with `knownValues` is generated as an enum-backed wrapper
-      // union with a converter (e.g. `LabelValueDefinitionDefaultSetting`).
-      // Emit a const wrapper value so a field with a spec `default` (e.g.
-      // labelValueDefinition's `default: "warn"`) keeps that default instead
-      // of degrading to a nullable field that reports `null` (G-18).
-      final knownValues = type.knownValues;
-      if (knownValues != null && !type.isArray) {
-        final wrapper = type.name;
-        // A `#`-prefixed known value is a token reference stored as
-        // `<lexiconId>#<token>`; a plain `default` cannot match it, so only
-        // treat non-token values as known members.
-        final isKnownMember =
-            !value.contains('#') && knownValues.values.contains(value);
-        if (isKnownMember) {
-          final member = rule.getLexKnownValuesElementName(value);
-          return '$wrapper.knownValue(data: Known$wrapper.$member)';
-        }
-
-        return "$wrapper.unknown(data: '${_escapeDartString(value)}')";
-      }
-
-      return "'${_escapeDartString(value)}'";
+      return _getStringDefaultValue(value, type);
     case lex.ULexPrimitiveInteger integer:
       final value = integer.data.defaultValue;
       return value != null ? '$value' : null;
@@ -129,6 +109,33 @@ String? _getDefaultValue(
     default:
       return null;
   }
+}
+
+/// Formats the Dart literal for a string primitive's `default` [value].
+///
+/// A string with `knownValues` is generated as an enum-backed wrapper union
+/// with a converter (e.g. `LabelValueDefinitionDefaultSetting`). Emit a const
+/// wrapper value so a field with a spec `default` (e.g. labelValueDefinition's
+/// `default: "warn"`) keeps that default instead of degrading to a nullable
+/// field that reports `null` (G-18). Plain strings become quoted literals.
+String _getStringDefaultValue(final String value, final DartType type) {
+  final knownValues = type.knownValues;
+  if (knownValues != null && !type.isArray) {
+    final wrapper = type.name;
+    // A `#`-prefixed known value is a token reference stored as
+    // `<lexiconId>#<token>`; a plain `default` cannot match it, so only
+    // treat non-token values as known members.
+    final isKnownMember =
+        !value.contains('#') && knownValues.values.contains(value);
+    if (isKnownMember) {
+      final member = rule.getLexKnownValuesElementName(value);
+      return '$wrapper.knownValue(data: Known$wrapper.$member)';
+    }
+
+    return "$wrapper.unknown(data: '${_escapeDartString(value)}')";
+  }
+
+  return "'${_escapeDartString(value)}'";
 }
 
 /// Escapes a raw string so it can be embedded inside single-quoted Dart source
@@ -179,16 +186,14 @@ DartType _getDartType(
             property.key,
             primitive.data,
           );
-          return DartType.array(
+          return _arrayOf(
+            type,
             lexiconId: type.lexiconId,
-            type: type.name,
-            packagePath: type.packagePath,
             // `iso8601` operates on a scalar `DateTime`, so it must not be
             // attached to a `List<DateTime>` field. The element-wise UTC
             // normalization for datetime arrays is intentionally left to the
             // default serializer (rare in practice).
             annotation: type.name == 'DateTime' ? null : type.annotation,
-            description: type.description,
             knownValues: type.knownValues,
           );
 
@@ -196,21 +201,14 @@ DartType _getDartType(
           // Arrays of blobs previously fell through to `List<Object>`. Map
           // them to `List<Blob>` with the blob converter applied per element.
           final type = DartType.blob(description: blob.data.description);
-          return DartType.array(
-            type: type.name,
-            packagePath: type.packagePath,
-            annotation: type.annotation,
-            description: type.description,
-          );
+          return _arrayOf(type, annotation: type.annotation);
 
         case lex.ULexArrayItemIpld ipld:
           final type = _getIpldType(ipld.data);
-          return DartType.array(
+          return _arrayOf(
+            type,
             lexiconId: type.lexiconId,
-            type: type.name,
-            packagePath: type.packagePath,
             annotation: type.annotation,
-            description: type.description,
           );
 
         case lex.ULexArrayRefVariant refVariant:
@@ -223,16 +221,13 @@ DartType _getDartType(
             mainVariants,
             isSingleProp,
           );
-
-          return DartType.array(
-            type: type.name,
+          return _arrayOf(
+            type,
             lexiconId: type.lexiconId,
             ref: type.ref,
             defName: type.defName,
             fieldName: type.fieldName,
-            packagePath: type.packagePath,
             annotation: type.annotation,
-            description: type.description,
             union: type.union,
           );
         default:
@@ -254,6 +249,34 @@ DartType _getDartType(
       return DartType.json();
   }
 }
+
+/// Wraps a resolved array-element [item] type into the matching `List<...>`
+/// `DartType`, copying the fields every element kind shares (element name,
+/// package path, description). The element [annotation] and any per-kind
+/// extras ([lexiconId], [ref], [defName], [fieldName], [union],
+/// [knownValues]) are supplied explicitly by the caller, since they differ
+/// between primitive, blob, IPLD and ref-variant elements.
+DartType _arrayOf(
+  final DartType item, {
+  final String? annotation,
+  final String? lexiconId,
+  final String? ref,
+  final String? defName,
+  final String? fieldName,
+  final LexUnion? union,
+  final LexKnownValues? knownValues,
+}) => DartType.array(
+  type: item.name,
+  packagePath: item.packagePath,
+  description: item.description,
+  annotation: annotation,
+  lexiconId: lexiconId,
+  ref: ref,
+  defName: defName,
+  fieldName: fieldName,
+  union: union,
+  knownValues: knownValues,
+);
 
 DartType _getLexPrimitiveType(
   final lex.NSID lexiconId,
@@ -370,12 +393,17 @@ DartType _getLexRefVariantType(
         mainVariants,
       );
 
+      // Resolve the union/record/plain distinction once so the wrapper type
+      // name and its converter annotation stay in sync (a union prefixes `U`,
+      // a record suffixes `Record`).
+      final (typeName, annotation) = isUnion
+          ? ('U$name', '@U${name}Converter()')
+          : isRecord
+          ? ('${name}Record', '@${name}RecordConverter()')
+          : (name, '@${name}Converter()');
+
       return DartType(
-        name: isUnion
-            ? 'U$name'
-            : isRecord
-            ? '${name}Record'
-            : name,
+        name: typeName,
         lexiconId: lexiconId.toString(),
         fieldName: isUnion ? fieldName : '',
         ref: ref.data.ref!,
@@ -385,11 +413,7 @@ DartType _getLexRefVariantType(
           ref.data.ref!,
           isUnion: isUnion,
         ),
-        annotation: isUnion
-            ? '@U${name}Converter()'
-            : isRecord
-            ? '@${name}RecordConverter()'
-            : '@${name}Converter()',
+        annotation: annotation,
         description: ref.data.description,
         isArray: isArray,
         isUnion: isUnion,

--- a/packages/lex_gen/lib/src/services/lex_service_generator.dart
+++ b/packages/lex_gen/lib/src/services/lex_service_generator.dart
@@ -9,15 +9,14 @@ import 'dart:io';
 import 'package:lexicon/lexicon.dart';
 
 // Project imports:
-import '../model/lex_def_kind.dart';
 import '../model/nsid.dart';
 import '../utils.dart';
 import 'fmt/lex_packages_generator.dart';
 import 'gen_context.dart';
-import 'object/lex_package.dart';
 import 'object/lex_service.dart';
 import 'object/lex_type.dart';
 import 'rule.dart' as rule;
+import 'services_common.dart';
 
 void generateLexServices(
   final GenContext ctx,
@@ -51,7 +50,7 @@ final class _LexServiceGenerator {
     for (final entry in docsByService.entries) {
       final apis = <LexApi>[];
       for (final doc in entry.value) {
-        final apiDef = _getApiDef(doc).entries.first.value;
+        final apiDef = firstApiDef(doc);
         final api = apiDef.whenOrNull(
           xrpcQuery: (data) => data,
           xrpcProcedure: (data) => data,
@@ -76,7 +75,7 @@ final class _LexServiceGenerator {
             inputType: inputType,
             returnType: returnType,
             rkey: api is LexRecord ? api.key : null,
-            kind: _kindOf(doc),
+            kind: apiKindOf(doc),
           ),
         );
       }
@@ -96,7 +95,7 @@ final class _LexServiceGenerator {
         ..writeAsStringSync(service.format(ctx));
     }
 
-    _generateLexPackages(services);
+    writeLexPackages(generateLexPackagesForService(ctx, services));
   }
 
   List<LexiconDoc> _filterLexicons(final List<LexiconDoc> docs) {
@@ -113,7 +112,7 @@ final class _LexServiceGenerator {
     final result = <String, List<LexiconDoc>>{};
 
     for (final doc in docs) {
-      if (!_isApi(doc)) continue;
+      if (!isApiDoc(doc)) continue;
       if (rule.isDeprecated(doc.description)) continue;
 
       final key = Nsid(doc.id.toString()).serviceId;
@@ -122,49 +121,6 @@ final class _LexServiceGenerator {
     }
 
     return result;
-  }
-
-  bool _isApi(final LexiconDoc doc) {
-    return _isQuery(doc) ||
-        _isProcedure(doc) ||
-        _isSubscription(doc) ||
-        _isRecord(doc);
-  }
-
-  /// Resolves the API kind of [doc], keeping the historical dispatch priority
-  /// (query, then procedure, then subscription, then record) so that a doc
-  /// carrying more than one API def resolves exactly as the old boolean chain.
-  LexDefKind _kindOf(final LexiconDoc doc) {
-    if (_isQuery(doc)) return LexDefKind.query;
-    if (_isProcedure(doc)) return LexDefKind.procedure;
-    if (_isSubscription(doc)) return LexDefKind.subscription;
-    return LexDefKind.record;
-  }
-
-  bool _isQuery(final LexiconDoc doc) {
-    return _isDocA<ULexUserTypeXrpcQuery>(doc);
-  }
-
-  bool _isProcedure(final LexiconDoc doc) {
-    return _isDocA<ULexUserTypeXrpcProcedure>(doc);
-  }
-
-  bool _isSubscription(final LexiconDoc doc) {
-    return _isDocA<ULexUserTypeXrpcSubscription>(doc);
-  }
-
-  bool _isRecord(final LexiconDoc doc) {
-    return _isDocA<ULexUserTypeRecord>(doc);
-  }
-
-  bool _isDocA<T>(final LexiconDoc doc) {
-    for (final def in doc.defs.entries) {
-      if (def.value is T) {
-        return true;
-      }
-    }
-
-    return false;
   }
 
   GeneratableType? _getRelatedType(
@@ -205,19 +161,6 @@ final class _LexServiceGenerator {
     return null;
   }
 
-  Map<String, LexUserType> _getApiDef(final LexiconDoc doc) {
-    for (final def in doc.defs.entries) {
-      if (def.value is ULexUserTypeXrpcQuery ||
-          def.value is ULexUserTypeXrpcProcedure ||
-          def.value is ULexUserTypeXrpcSubscription ||
-          def.value is ULexUserTypeRecord) {
-        return Map.fromEntries([def]);
-      }
-    }
-
-    throw StateError('API definition does not exist');
-  }
-
   String? _getApiDescription(final Object data) {
     switch (data) {
       case LexXrpcQuery query:
@@ -231,37 +174,5 @@ final class _LexServiceGenerator {
       default:
         return null;
     }
-  }
-
-  void _generateLexPackages(final List<LexService> services) {
-    final packages = generateLexPackagesForService(ctx, services);
-    final basePackages = _getBasePackages(packages);
-
-    for (final package in packages) {
-      File('packages/${package.root}/lib/${package.name}.dart')
-        ..createSync(recursive: true)
-        ..writeAsStringSync(package.exportableDependencies);
-
-      if (package.root != 'atproto') {
-        for (final base in basePackages) {
-          File('packages/${package.root}/lib/${base.name}.dart')
-            ..createSync(recursive: true)
-            ..writeAsStringSync(base.exportableDependencies);
-        }
-      }
-    }
-  }
-
-  List<LexPackage> _getBasePackages(final List<LexPackage> packages) {
-    if (packages.isEmpty) return const [];
-
-    final result = <LexPackage>[];
-    for (final package in packages) {
-      if (package.root == 'atproto') {
-        result.add(package);
-      }
-    }
-
-    return result;
   }
 }

--- a/packages/lex_gen/lib/src/services/lex_tools_generator.dart
+++ b/packages/lex_gen/lib/src/services/lex_tools_generator.dart
@@ -13,6 +13,7 @@ import 'gen_context.dart';
 import 'object/at_uri_extension.dart';
 import 'object/repo_commit_handler.dart';
 import 'rule.dart';
+import 'services_common.dart';
 
 void generateLexTools(final GenContext ctx, final List<LexiconDoc> docs) {
   return _LexToolsGenerator(ctx, docs).execute();
@@ -41,25 +42,11 @@ final class _LexToolsGenerator {
     final recordLexiconIds = <String>[];
 
     for (final doc in docs) {
-      if (_isRecord(doc)) {
+      if (isRecordDoc(doc)) {
         recordLexiconIds.add(doc.id.toString());
       }
     }
 
     return recordLexiconIds;
-  }
-
-  bool _isRecord(final LexiconDoc doc) {
-    return _isDocA<ULexUserTypeRecord>(doc);
-  }
-
-  bool _isDocA<T>(final LexiconDoc doc) {
-    for (final def in doc.defs.entries) {
-      if (def.value is T) {
-        return true;
-      }
-    }
-
-    return false;
   }
 }

--- a/packages/lex_gen/lib/src/services/lex_type_generator.dart
+++ b/packages/lex_gen/lib/src/services/lex_type_generator.dart
@@ -11,7 +11,6 @@ import 'package:lexicon/lexicon.dart' as lex;
 // Project imports:
 import '../model/nsid.dart';
 import 'fmt/lex_known_values_generator.dart';
-import 'gen_context.dart';
 import 'fmt/lex_object_generator.dart';
 import 'fmt/lex_packages_generator.dart';
 import 'fmt/lex_record_generator.dart';
@@ -19,6 +18,7 @@ import 'fmt/lex_union_generator.dart';
 import 'fmt/lex_xrpc_procedure_generator.dart';
 import 'fmt/lex_xrpc_query_generator.dart';
 import 'fmt/lex_xrpc_subscription_generator.dart';
+import 'gen_context.dart';
 import 'object/lex_type.dart';
 import 'services_common.dart';
 
@@ -56,13 +56,7 @@ final class _LexTypeGenerator {
           case lex.ULexUserTypeObject():
             _aggregateTypes(
               types,
-              generateLexObject(
-                ctx,
-                doc.id,
-                def.key,
-                value.data,
-                mainVariants,
-              ),
+              generateLexObject(ctx, doc.id, def.key, value.data, mainVariants),
             );
           case lex.ULexUserTypeArray():
             final data = value.data;
@@ -82,13 +76,7 @@ final class _LexTypeGenerator {
           case lex.ULexUserTypeRecord():
             _aggregateTypes(
               types,
-              generateLexRecord(
-                ctx,
-                doc.id,
-                def.key,
-                value.data,
-                mainVariants,
-              ),
+              generateLexRecord(ctx, doc.id, def.key, value.data, mainVariants),
             );
           case lex.ULexUserTypeString():
             final string = value.data;

--- a/packages/lex_gen/lib/src/services/lex_type_generator.dart
+++ b/packages/lex_gen/lib/src/services/lex_type_generator.dart
@@ -19,8 +19,8 @@ import 'fmt/lex_union_generator.dart';
 import 'fmt/lex_xrpc_procedure_generator.dart';
 import 'fmt/lex_xrpc_query_generator.dart';
 import 'fmt/lex_xrpc_subscription_generator.dart';
-import 'object/lex_package.dart';
 import 'object/lex_type.dart';
+import 'services_common.dart';
 
 List<GeneratableType> generateLexTypes(
   final GenContext ctx,
@@ -51,93 +51,91 @@ final class _LexTypeGenerator {
     for (final doc in filteredLexicons) {
       // Generate LexObjects for each definition in the lexicon
       for (final def in doc.defs.entries) {
-        if (def.value is lex.ULexUserTypeObject) {
-          _aggregateTypes(
-            types,
-            generateLexObject(
-              ctx,
-              doc.id,
-              def.key,
-              def.value.data as lex.LexObject,
-              mainVariants,
-            ),
-          );
-        } else if (def.value is lex.ULexUserTypeArray) {
-          final data = def.value.data as lex.LexArray;
+        final value = def.value;
+        switch (value) {
+          case lex.ULexUserTypeObject():
+            _aggregateTypes(
+              types,
+              generateLexObject(
+                ctx,
+                doc.id,
+                def.key,
+                value.data,
+                mainVariants,
+              ),
+            );
+          case lex.ULexUserTypeArray():
+            final data = value.data;
 
-          final refVariant = data.items.whenOrNull(refVariant: (data) => data);
-          if (refVariant == null) continue;
+            final refVariant = data.items.whenOrNull(
+              refVariant: (data) => data,
+            );
+            if (refVariant == null) continue;
 
-          final refUnion = refVariant.whenOrNull(refUnion: (data) => data);
-          if (refUnion == null) continue;
+            final refUnion = refVariant.whenOrNull(refUnion: (data) => data);
+            if (refUnion == null) continue;
 
-          _aggregateTypes(
-            types,
-            generateLexUnion(doc.id, def.key, '', refUnion, mainVariants),
-          );
-        } else if (def.value is lex.ULexUserTypeRecord) {
-          _aggregateTypes(
-            types,
-            generateLexRecord(
-              ctx,
-              doc.id,
-              def.key,
-              def.value.data as lex.LexRecord,
-              mainVariants,
-            ),
-          );
-        } else if (def.value is lex.ULexUserTypeString) {
-          final string = def.value.data as lex.LexString;
-          // A top-level string def without `knownValues` would generate an
-          // enum with no members, which does not compile. Such defs carry no
-          // closed value set to model, so skip them.
-          if (string.knownValues == null || string.knownValues!.isEmpty) {
-            continue;
-          }
+            _aggregateTypes(
+              types,
+              generateLexUnion(doc.id, def.key, '', refUnion, mainVariants),
+            );
+          case lex.ULexUserTypeRecord():
+            _aggregateTypes(
+              types,
+              generateLexRecord(
+                ctx,
+                doc.id,
+                def.key,
+                value.data,
+                mainVariants,
+              ),
+            );
+          case lex.ULexUserTypeString():
+            final string = value.data;
+            // A top-level string def without `knownValues` would generate an
+            // enum with no members, which does not compile. Such defs carry no
+            // closed value set to model, so skip them.
+            if (string.knownValues == null || string.knownValues!.isEmpty) {
+              continue;
+            }
 
-          _aggregateTypes(
-            types,
-            generateLexKnownValues(doc.id, def.key, string, mainVariants),
-          );
-        } else if (def.value is lex.ULexUserTypeXrpcQuery) {
-          final type = generateLexXrpcQuery(
-            ctx,
-            doc.id,
-            def.key,
-            def.value.data as lex.LexXrpcQuery,
-            mainVariants,
-          );
-
-          if (type == null) continue;
-
-          _aggregateTypes(types, type.$1);
-          _aggregateTypes(types, type.$2);
-        } else if (def.value is lex.ULexUserTypeXrpcProcedure) {
-          final type = generateLexXrpcProcedure(
-            ctx,
-            doc.id,
-            def.key,
-            def.value.data as lex.LexXrpcProcedure,
-            mainVariants,
-          );
-
-          if (type == null) continue;
-
-          _aggregateTypes(types, type.$1);
-          _aggregateTypes(types, type.$2);
-        } else if (def.value is lex.ULexUserTypeXrpcSubscription) {
-          final type = generateLexXrpcSubscription(
-            ctx,
-            doc.id,
-            def.key,
-            def.value.data as lex.LexXrpcSubscription,
-            mainVariants,
-          );
-
-          if (type == null) continue;
-
-          _aggregateTypes(types, type.$1);
-          _aggregateTypes(types, type.$2);
+            _aggregateTypes(
+              types,
+              generateLexKnownValues(doc.id, def.key, string, mainVariants),
+            );
+          case lex.ULexUserTypeXrpcQuery():
+            _aggregateApiPair(
+              types,
+              generateLexXrpcQuery(
+                ctx,
+                doc.id,
+                def.key,
+                value.data,
+                mainVariants,
+              ),
+            );
+          case lex.ULexUserTypeXrpcProcedure():
+            _aggregateApiPair(
+              types,
+              generateLexXrpcProcedure(
+                ctx,
+                doc.id,
+                def.key,
+                value.data,
+                mainVariants,
+              ),
+            );
+          case lex.ULexUserTypeXrpcSubscription():
+            _aggregateApiPair(
+              types,
+              generateLexXrpcSubscription(
+                ctx,
+                doc.id,
+                def.key,
+                value.data,
+                mainVariants,
+              ),
+            );
         }
       }
     }
@@ -150,7 +148,7 @@ final class _LexTypeGenerator {
         ..writeAsStringSync(type.format(ctx));
     }
 
-    _generateLexPackages(types);
+    writeLexPackages(generateLexPackages(ctx, types));
 
     return types;
   }
@@ -186,38 +184,6 @@ final class _LexTypeGenerator {
     }).toList();
   }
 
-  void _generateLexPackages(final List<GeneratableType> type) {
-    final packages = generateLexPackages(ctx, type);
-    final basePackages = _getBasePackages(packages);
-
-    for (final package in packages) {
-      File('packages/${package.root}/lib/${package.name}.dart')
-        ..createSync(recursive: true)
-        ..writeAsStringSync(package.exportableDependencies);
-
-      if (package.root != 'atproto') {
-        for (final base in basePackages) {
-          File('packages/${package.root}/lib/${base.name}.dart')
-            ..createSync(recursive: true)
-            ..writeAsStringSync(base.exportableDependencies);
-        }
-      }
-    }
-  }
-
-  List<LexPackage> _getBasePackages(final List<LexPackage> packages) {
-    if (packages.isEmpty) return const [];
-
-    final result = <LexPackage>[];
-    for (final package in packages) {
-      if (package.root == 'atproto') {
-        result.add(package);
-      }
-    }
-
-    return result;
-  }
-
   List<String> _checkMainVariants(final List<lex.LexiconDoc> lexicons) {
     final mainVariants = <String>{};
     for (final doc in lexicons) {
@@ -233,6 +199,18 @@ final class _LexTypeGenerator {
     }
 
     return mainVariants.toList();
+  }
+
+  /// Aggregates both members of an XRPC generator result (input/output or
+  /// input/message). A `null` [pair] means the def yields no type at all.
+  void _aggregateApiPair(
+    final List<GeneratableType> types,
+    final (LexType?, LexType?)? pair,
+  ) {
+    if (pair == null) return;
+
+    _aggregateTypes(types, pair.$1);
+    _aggregateTypes(types, pair.$2);
   }
 
   void _aggregateTypes(final List<GeneratableType> types, final LexType? type) {

--- a/packages/lex_gen/lib/src/services/object/lex_input.dart
+++ b/packages/lex_gen/lib/src/services/object/lex_input.dart
@@ -4,20 +4,10 @@
 
 // Project imports:
 import '../gen_context.dart';
-import 'lex_property.dart';
 import 'lex_type.dart';
 import 'utils.dart';
 
-final class LexInput extends GeneratableType {
-  @override
-  final String lexiconId;
-  @override
-  final String defName;
-
-  final String name;
-  final String? description;
-  final List<LexProperty> properties;
-
+final class LexInput extends FreezedModel {
   final bool bytes;
   final String? encoding;
 
@@ -27,11 +17,11 @@ final class LexInput extends GeneratableType {
   LexTypeState get state => LexTypeState.input;
 
   const LexInput({
-    required this.lexiconId,
-    required this.defName,
-    required this.name,
-    this.description,
-    required this.properties,
+    required super.lexiconId,
+    required super.defName,
+    required super.name,
+    super.description,
+    required super.properties,
     this.bytes = false,
     this.ref,
     this.encoding,
@@ -50,11 +40,6 @@ final class LexInput extends GeneratableType {
   @override
   bool isBytes() {
     return bytes;
-  }
-
-  @override
-  List<LexProperty> getProperties() {
-    return properties;
   }
 
   @override

--- a/packages/lex_gen/lib/src/services/object/lex_known_values.dart
+++ b/packages/lex_gen/lib/src/services/object/lex_known_values.dart
@@ -7,6 +7,7 @@ import '../../utils.dart';
 import '../gen_context.dart';
 import '../rule.dart' as rule;
 import 'lex_type.dart';
+import 'utils.dart';
 
 final class LexKnownValues extends GeneratableType {
   @override
@@ -59,21 +60,7 @@ final class LexKnownValues extends GeneratableType {
 
   @override
   String format(final GenContext ctx) {
-    final elements = values
-        .map((e) {
-          final buffer = StringBuffer();
-          if (e.startsWith('#')) {
-            buffer.writeln("@JsonValue('$lexiconId$e')");
-            buffer.write(
-              "${rule.getLexKnownValuesElementName(e, lexiconId: lexiconId)}('$lexiconId$e'),",
-            );
-          } else {
-            buffer.writeln("@JsonValue('$e')");
-            buffer.write("${rule.getLexKnownValuesElementName(e)}('$e'),");
-          }
-          return buffer.toString();
-        })
-        .join('\n');
+    final elements = _getElements();
 
     final fileName = getFileName();
 
@@ -168,23 +155,41 @@ enum Known$name implements Serializable{
 ''';
   }
 
+  String _getElements() {
+    return values
+        .map((e) {
+          final buffer = StringBuffer();
+          if (e.startsWith('#')) {
+            buffer.writeln("@JsonValue('$lexiconId$e')");
+            buffer.write(
+              "${rule.getLexKnownValuesElementName(e, lexiconId: lexiconId)}('$lexiconId$e'),",
+            );
+          } else {
+            buffer.writeln("@JsonValue('$e')");
+            buffer.write("${rule.getLexKnownValuesElementName(e)}('$e'),");
+          }
+          return buffer.toString();
+        })
+        .join('\n');
+  }
+
   String _getExtensions() {
     final buffer = StringBuffer();
 
-    buffer.writeln('bool get isKnownValue => isA<${name}KnownValue>(this);');
-    buffer.writeln('bool get isNotKnownValue => !isKnownValue;');
-
-    buffer.writeln(
-      'Known$name? get knownValue => '
-      'isKnownValue ? data as Known$name : null;',
+    writeIsAExtensionGetters(
+      buffer,
+      isName: 'KnownValue',
+      typeName: '${name}KnownValue',
+      castGetter: 'knownValue',
+      castType: 'Known$name',
     );
 
-    buffer.writeln('bool get isUnknown => isA<${name}Unknown>(this);');
-    buffer.writeln('bool get isNotUnknown => !isUnknown;');
-
-    buffer.writeln(
-      'String? get unknown => '
-      'isUnknown ? data as String : null;',
+    writeIsAExtensionGetters(
+      buffer,
+      isName: 'Unknown',
+      typeName: '${name}Unknown',
+      castGetter: 'unknown',
+      castType: 'String',
     );
 
     return buffer.toString();

--- a/packages/lex_gen/lib/src/services/object/lex_object.dart
+++ b/packages/lex_gen/lib/src/services/object/lex_object.dart
@@ -3,38 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 // Project imports:
-import '../../model/nsid.dart';
 import '../gen_context.dart';
 import '../rule.dart' as rule;
-import 'lex_property.dart';
 import 'lex_type.dart';
 import 'utils.dart';
 
-final class LexObject extends GeneratableType {
-  @override
-  final String lexiconId;
-  @override
-  final String defName;
-
-  final String name;
-  final String? description;
-  final List<LexProperty> properties;
-
-  @override
-  LexTypeState get state => LexTypeState.object;
-
+final class LexObject extends FreezedModel {
   const LexObject({
-    required this.lexiconId,
-    required this.defName,
-    required this.name,
-    this.description,
-    required this.properties,
+    required super.lexiconId,
+    required super.defName,
+    required super.name,
+    super.description,
+    required super.properties,
   });
 
   @override
-  List<LexProperty> getProperties() {
-    return properties;
-  }
+  LexTypeState get state => LexTypeState.object;
 
   @override
   String getTypeName() {
@@ -52,26 +36,11 @@ final class LexObject extends GeneratableType {
       description: description,
       properties: properties,
       typeDefaultId: id,
-      validateMethod: _getValidateMethod(id),
+      validateMethod: buildValidateMethod(
+        id,
+        includeSubscription: true,
+        includeMainAlias: true,
+      ),
     );
-  }
-
-  String _getValidateMethod(final String id) {
-    final buffer = StringBuffer();
-    buffer.writeln('static bool validate(final Map<String, dynamic> object) {');
-    if (Nsid(lexiconId).method.startsWith('subscribe')) {
-      buffer.writeln("  if (!object.containsKey('t')) return false;");
-      buffer.writeln("  return object['t'] == '#$defName'");
-    } else {
-      buffer.writeln("  if (!object.containsKey('\\\$type')) return false;");
-      buffer.writeln("  return object['\\\$type'] == '$id'");
-      if (defName == 'main') {
-        buffer.writeln("  || object['\\\$type'] == '$lexiconId#main'");
-      }
-    }
-    buffer.writeln(';');
-    buffer.writeln('}');
-
-    return buffer.toString();
   }
 }

--- a/packages/lex_gen/lib/src/services/object/lex_output.dart
+++ b/packages/lex_gen/lib/src/services/object/lex_output.dart
@@ -4,20 +4,10 @@
 
 // Project imports:
 import '../gen_context.dart';
-import 'lex_property.dart';
 import 'lex_type.dart';
 import 'utils.dart';
 
-final class LexOutput extends GeneratableType {
-  @override
-  final String lexiconId;
-  @override
-  final String defName;
-
-  final String name;
-  final String? description;
-  final List<LexProperty> properties;
-
+final class LexOutput extends FreezedModel {
   final String? ref;
 
   final bool bytes;
@@ -26,11 +16,11 @@ final class LexOutput extends GeneratableType {
   LexTypeState get state => LexTypeState.output;
 
   const LexOutput({
-    required this.lexiconId,
-    required this.defName,
-    required this.name,
-    this.description,
-    required this.properties,
+    required super.lexiconId,
+    required super.defName,
+    required super.name,
+    super.description,
+    required super.properties,
     this.ref,
     this.bytes = false,
   });
@@ -62,11 +52,6 @@ final class LexOutput extends GeneratableType {
   @override
   bool isBytes() {
     return bytes;
-  }
-
-  @override
-  List<LexProperty> getProperties() {
-    return properties;
   }
 
   @override

--- a/packages/lex_gen/lib/src/services/object/lex_record.dart
+++ b/packages/lex_gen/lib/src/services/object/lex_record.dart
@@ -5,35 +5,20 @@
 // Project imports:
 import '../gen_context.dart';
 import '../rule.dart' as rule;
-import 'lex_property.dart';
 import 'lex_type.dart';
 import 'utils.dart';
 
-final class LexRecord extends GeneratableType {
-  @override
-  final String lexiconId;
-  @override
-  final String defName;
-
-  final String name;
-  final String? description;
-  final List<LexProperty> properties;
-
-  @override
-  List<LexProperty> getProperties() {
-    return properties;
-  }
+final class LexRecord extends FreezedModel {
+  const LexRecord({
+    required super.lexiconId,
+    required super.defName,
+    required super.name,
+    super.description,
+    required super.properties,
+  });
 
   @override
   LexTypeState get state => LexTypeState.record;
-
-  const LexRecord({
-    required this.lexiconId,
-    required this.defName,
-    required this.name,
-    this.description,
-    required this.properties,
-  });
 
   @override
   String getTypeName() {
@@ -51,17 +36,11 @@ final class LexRecord extends GeneratableType {
       description: description,
       properties: properties,
       typeDefaultId: id,
-      validateMethod: _getValidateMethod(id),
+      validateMethod: buildValidateMethod(
+        id,
+        includeSubscription: false,
+        includeMainAlias: false,
+      ),
     );
-  }
-
-  String _getValidateMethod(final String id) {
-    final buffer = StringBuffer();
-    buffer.writeln('static bool validate(final Map<String, dynamic> object) {');
-    buffer.writeln("  if (!object.containsKey('\\\$type')) return false;");
-    buffer.writeln("  return object['\\\$type'] == '$id';");
-    buffer.writeln('}');
-
-    return buffer.toString();
   }
 }

--- a/packages/lex_gen/lib/src/services/object/lex_service.dart
+++ b/packages/lex_gen/lib/src/services/object/lex_service.dart
@@ -42,65 +42,58 @@ final class LexService {
     return false;
   }
 
+  /// Resolves the import line a single input [parameter] contributes, or
+  /// `null` when it needs no dedicated import.
+  String? _importLineForParameter(
+    final GenContext ctx,
+    final LexParameter parameter,
+  ) {
+    final type = parameter.type;
+    if (type.lexiconId == null) return null;
+    if (type.packagePath == null) return null;
+
+    if (type.isUnion) {
+      if (type.fieldName == null) return null;
+
+      // Prefer the ref's own lexicon id when present, otherwise fall back to
+      // the parameter's; both resolve the same union file afterwards.
+      final ref = type.ref;
+      final lexiconId = ref != null ? ref.split('#').first : type.lexiconId!;
+
+      final relativePath = Nsid(lexiconId).dirAfterAuthority;
+      final fileName = rule.getFileNameForUnion(
+        lexiconId,
+        type.defName,
+        type.fieldName!,
+      );
+
+      return "import '$relativePath/$fileName.dart';";
+    } else if (type.isKnownValues) {
+      final relativePath = Nsid(type.knownValues!.lexiconId).dirAfterAuthority;
+      final fileName = type.knownValues!.getFileName();
+
+      return "import '$relativePath/$fileName.dart';";
+    } else {
+      if (type.ref == null) return null;
+
+      final packagePath = rule.getLexObjectPackagePathFromRefForService(
+        ctx,
+        type.lexiconId!,
+        type.ref!,
+      );
+
+      return "import '$packagePath';";
+    }
+  }
+
   String _getPackagePaths(final GenContext ctx) {
     final importPaths = <String>[];
+    final hasRecordApi = _hasRecordApi();
+
     for (final api in apis) {
-      final parameters = api.inputType == null
-          ? const <LexParameter>[]
-          : api.inputType!
-                .getProperties()
-                .map((e) => e.toLexParameter())
-                .toList();
-
-      for (final parameter in parameters) {
-        if (parameter.type.lexiconId == null) continue;
-        if (parameter.type.packagePath == null) continue;
-
-        if (parameter.type.isUnion) {
-          if (parameter.type.fieldName == null) continue;
-
-          final ref = parameter.type.ref;
-          if (ref != null) {
-            final lexiconId = ref.split('#').first;
-
-            final relativePath = Nsid(lexiconId).dirAfterAuthority;
-            final fileName = rule.getFileNameForUnion(
-              lexiconId,
-              parameter.type.defName,
-              parameter.type.fieldName!,
-            );
-
-            importPaths.add("import '$relativePath/$fileName.dart';");
-          } else {
-            final relativePath = Nsid(
-              parameter.type.lexiconId!,
-            ).dirAfterAuthority;
-            final fileName = rule.getFileNameForUnion(
-              parameter.type.lexiconId!,
-              parameter.type.defName,
-              parameter.type.fieldName!,
-            );
-
-            importPaths.add("import '$relativePath/$fileName.dart';");
-          }
-        } else if (parameter.type.isKnownValues) {
-          final relativePath = Nsid(
-            parameter.type.knownValues!.lexiconId,
-          ).dirAfterAuthority;
-          final fileName = parameter.type.knownValues!.getFileName();
-
-          importPaths.add("import '$relativePath/$fileName.dart';");
-        } else {
-          if (parameter.type.ref == null) continue;
-
-          final packagePath = rule.getLexObjectPackagePathFromRefForService(
-            ctx,
-            parameter.type.lexiconId!,
-            parameter.type.ref!,
-          );
-
-          importPaths.add("import '$packagePath';");
-        }
+      for (final parameter in api._parameters) {
+        final importLine = _importLineForParameter(ctx, parameter);
+        if (importLine != null) importPaths.add(importLine);
       }
 
       if (api.returnType != null &&
@@ -112,7 +105,7 @@ final class LexService {
         importPaths.add("import '$fileDir/$fileName.dart';");
       }
 
-      if (_hasRecordApi()) {
+      if (hasRecordApi) {
         importPaths.add(
           "import 'package:atproto/com_atproto_repo_createrecord.dart';",
         );
@@ -200,131 +193,131 @@ $recordAccessors
   String _getRecordAccessors(final List<LexApi> recordApis) {
     if (recordApis.isEmpty) return '';
 
-    final buffer = StringBuffer();
-
-    for (final api in recordApis) {
-      final name = rule.getRecordTypeName(api.lexiconId);
-      final id = rule.getNamespaceIdForApi(api.lexiconId);
-
-      final parameters = api._parameters;
-
-      buffer.writeln('final class ${name}RecordAccessor {');
-      buffer.writeln('  final ServiceContext ctx;');
-      buffer.writeln();
-      buffer.writeln('  const ${name}RecordAccessor(this.ctx);');
-      buffer.writeln();
-      buffer.writeln('  Future<XRPCResponse<RepoGetRecordOutput>> get({');
-      buffer.writeln('    required String repo,');
-      buffer.writeln(_rkeyParam(api, '    required String rkey,'));
-      buffer.writeln('    String? cid,');
-      buffer.writeln('    Map<String, String>? \$headers,');
-      buffer.writeln('    Map<String, String>? \$unknown,');
-      buffer.writeln('  }) async => await comAtprotoRepoGetRecord(');
-      buffer.writeln('    repo: repo,');
-      buffer.writeln('    collection: ids.$id,');
-      buffer.writeln('    rkey: rkey,');
-      buffer.writeln('    cid: cid,');
-      buffer.writeln('    \$ctx: ctx,');
-      buffer.writeln('    \$headers: \$headers,');
-      buffer.writeln('    \$unknown: \$unknown,');
-      buffer.writeln('  );');
-      buffer.writeln();
-      buffer.writeln('  Future<XRPCResponse<RepoListRecordsOutput>> list({');
-      buffer.writeln('    required String repo,');
-      buffer.writeln('    int? limit,');
-      buffer.writeln('    String? cursor,');
-      buffer.writeln('    bool? reverse,');
-      buffer.writeln('    Map<String, String>? \$headers,');
-      buffer.writeln('    Map<String, String>? \$unknown,');
-      buffer.writeln('  }) async => await comAtprotoRepoListRecords(');
-      buffer.writeln('    repo: repo,');
-      buffer.writeln('    collection: ids.$id,');
-      buffer.writeln('    limit: limit,');
-      buffer.writeln('    cursor: cursor,');
-      buffer.writeln('    reverse: reverse,');
-      buffer.writeln('    \$ctx: ctx,');
-      buffer.writeln('    \$headers: \$headers,');
-      buffer.writeln('    \$unknown: \$unknown,');
-      buffer.writeln('  );');
-      buffer.writeln();
-      buffer.writeln('  Future<XRPCResponse<RepoCreateRecordOutput>> create({');
-      for (final parameter in parameters) {
-        buffer.writeln(
-          parameter.getParams(ignoreRequired: parameter.name == 'createdAt'),
-        );
-      }
-      buffer.writeln(_rkeyParam(api, '    String? rkey,'));
-      buffer.writeln('    bool? validate,');
-      buffer.writeln('    String? swapCommit,');
-      buffer.writeln('    Map<String, String>? \$headers,');
-      buffer.writeln('    Map<String, String>? \$unknown,');
-      buffer.writeln('  }) async => await comAtprotoRepoCreateRecord(');
-      buffer.writeln('    repo: ctx.repo,');
-      buffer.writeln('    collection: ids.$id,');
-      buffer.writeln('    rkey: rkey,');
-      buffer.writeln('    validate: validate,');
-      buffer.writeln('    record: {');
-      buffer.writeln("      r'\$type': '${api.lexiconId}',");
-      buffer.writeln('      ...?\$unknown,');
-      for (final parameter in parameters) {
-        buffer.writeln(parameter.getParamsRecord());
-      }
-      buffer.writeln('    },');
-      buffer.writeln('    swapCommit: swapCommit,');
-      buffer.writeln('    \$ctx: ctx,');
-      buffer.writeln('    \$headers: \$headers,');
-      buffer.writeln('  );');
-      buffer.writeln();
-      buffer.writeln('  Future<XRPCResponse<RepoPutRecordOutput>> put({');
-      for (final parameter in parameters) {
-        buffer.writeln(
-          parameter.getParams(ignoreRequired: parameter.name == 'createdAt'),
-        );
-      }
-      buffer.writeln(_rkeyParam(api, '    required String rkey,'));
-      buffer.writeln('    bool? validate,');
-      buffer.writeln('    String? swapRecord,');
-      buffer.writeln('    String? swapCommit,');
-      buffer.writeln('    Map<String, String>? \$headers,');
-      buffer.writeln('    Map<String, String>? \$unknown,');
-      buffer.writeln('  }) async => await comAtprotoRepoPutRecord(');
-      buffer.writeln('    repo: ctx.repo,');
-      buffer.writeln('    collection: ids.$id,');
-      buffer.writeln('    rkey: rkey,');
-      buffer.writeln('    validate: validate,');
-      buffer.writeln('    record: {');
-      buffer.writeln("      r'\$type': '${api.lexiconId}',");
-      buffer.writeln('      ...?\$unknown,');
-      for (final parameter in parameters) {
-        buffer.writeln(parameter.getParamsRecord());
-      }
-      buffer.writeln('    },');
-      buffer.writeln('    swapRecord: swapRecord,');
-      buffer.writeln('    swapCommit: swapCommit,');
-      buffer.writeln('    \$ctx: ctx,');
-      buffer.writeln('    \$headers: \$headers,');
-      buffer.writeln('  );');
-      buffer.writeln('');
-      buffer.writeln('  Future<XRPCResponse<RepoDeleteRecordOutput>> delete({');
-      buffer.writeln(_rkeyParam(api, '    required String rkey,'));
-      buffer.writeln('    String? swapRecord,');
-      buffer.writeln('    String? swapCommit,');
-      buffer.writeln('    Map<String, String>? \$headers,');
-      buffer.writeln('    Map<String, String>? \$unknown,');
-      buffer.writeln('  }) async => await comAtprotoRepoDeleteRecord(');
-      buffer.writeln('    repo: ctx.repo,');
-      buffer.writeln('    collection: ids.$id,');
-      buffer.writeln('    rkey: rkey,');
-      buffer.writeln('    swapRecord: swapRecord,');
-      buffer.writeln('    swapCommit: swapCommit,');
-      buffer.writeln('    \$ctx: ctx,');
-      buffer.writeln('    \$headers: \$headers,');
-      buffer.writeln('  );');
-      buffer.writeln('}');
-    }
-
-    return buffer.toString();
+    return recordApis.map(_recordAccessorClass).join();
   }
+
+  /// Emits the whole `XxxRecordAccessor` class (get/list/create/put/delete)
+  /// for a single record [api].
+  String _recordAccessorClass(final LexApi api) {
+    final name = rule.getRecordTypeName(api.lexiconId);
+    final id = rule.getNamespaceIdForApi(api.lexiconId);
+
+    return '''
+final class ${name}RecordAccessor {
+  final ServiceContext ctx;
+
+  const ${name}RecordAccessor(this.ctx);
+
+  ${_recordGet(api, id)}
+
+  ${_recordList(id)}
+
+  ${_recordMutation(api, id, output: 'RepoCreateRecordOutput', method: 'create', rkeyParam: _rkeyParam(api, '    String? rkey,'), xrpcFn: 'comAtprotoRepoCreateRecord', extraParams: '  String? swapCommit,', extraArgs: '  swapCommit: swapCommit,')}
+
+  ${_recordMutation(api, id, output: 'RepoPutRecordOutput', method: 'put', rkeyParam: _rkeyParam(api, '    required String rkey,'), xrpcFn: 'comAtprotoRepoPutRecord', extraParams: '  String? swapRecord,\n  String? swapCommit,', extraArgs: '  swapRecord: swapRecord,\n  swapCommit: swapCommit,')}
+
+  ${_recordDelete(api, id)}
+}
+''';
+  }
+
+  String _recordGet(final LexApi api, final String id) =>
+      '''
+Future<XRPCResponse<RepoGetRecordOutput>> get({
+  required String repo,
+${_rkeyParam(api, '    required String rkey,')}
+  String? cid,
+  Map<String, String>? \$headers,
+  Map<String, String>? \$unknown,
+}) async => await comAtprotoRepoGetRecord(
+  repo: repo,
+  collection: ids.$id,
+  rkey: rkey,
+  cid: cid,
+  \$ctx: ctx,
+  \$headers: \$headers,
+  \$unknown: \$unknown,
+);''';
+
+  String _recordList(final String id) =>
+      '''
+Future<XRPCResponse<RepoListRecordsOutput>> list({
+  required String repo,
+  int? limit,
+  String? cursor,
+  bool? reverse,
+  Map<String, String>? \$headers,
+  Map<String, String>? \$unknown,
+}) async => await comAtprotoRepoListRecords(
+  repo: repo,
+  collection: ids.$id,
+  limit: limit,
+  cursor: cursor,
+  reverse: reverse,
+  \$ctx: ctx,
+  \$headers: \$headers,
+  \$unknown: \$unknown,
+);''';
+
+  /// Emits `create` and `put`, which are identical except for the output type,
+  /// method name, rkey requiredness, XRPC entrypoint and their swap parameters.
+  String _recordMutation(
+    final LexApi api,
+    final String id, {
+    required final String output,
+    required final String method,
+    required final String rkeyParam,
+    required final String xrpcFn,
+    required final String extraParams,
+    required final String extraArgs,
+  }) {
+    final parameters = api._parameters;
+    final paramsDecl = parameters
+        .map((e) => e.getParams(ignoreRequired: e.name == 'createdAt'))
+        .join('\n');
+    final recordEntries = parameters.map((e) => e.getParamsRecord()).join('\n');
+
+    return '''
+Future<XRPCResponse<$output>> $method({
+$paramsDecl
+$rkeyParam
+  bool? validate,
+$extraParams
+  Map<String, String>? \$headers,
+  Map<String, String>? \$unknown,
+}) async => await $xrpcFn(
+  repo: ctx.repo,
+  collection: ids.$id,
+  rkey: rkey,
+  validate: validate,
+  record: {
+    r'\$type': '${api.lexiconId}',
+    ...?\$unknown,
+$recordEntries
+  },
+$extraArgs
+  \$ctx: ctx,
+  \$headers: \$headers,
+);''';
+  }
+
+  String _recordDelete(final LexApi api, final String id) =>
+      '''
+Future<XRPCResponse<RepoDeleteRecordOutput>> delete({
+${_rkeyParam(api, '    required String rkey,')}
+  String? swapRecord,
+  String? swapCommit,
+  Map<String, String>? \$headers,
+  Map<String, String>? \$unknown,
+}) async => await comAtprotoRepoDeleteRecord(
+  repo: ctx.repo,
+  collection: ids.$id,
+  rkey: rkey,
+  swapRecord: swapRecord,
+  swapCommit: swapCommit,
+  \$ctx: ctx,
+  \$headers: \$headers,
+);''';
 
   String _getRecordAccessorsFields(final List<LexApi> recordApis) {
     if (recordApis.isEmpty) return '';
@@ -404,240 +397,217 @@ final class LexApi {
     };
   }
 
+  /// The leading `/// ...` doc comment line shared by every emitter, or an
+  /// empty string when the api has no description.
+  String get _doc => description != null ? '/// $description\n' : '';
+
+  /// Renders the parameter declaration lines for a `({...})` signature.
+  String _paramDecls(final List<LexParameter> parameters) =>
+      parameters.map((e) => e.getParams()).join('\n');
+
+  /// Renders the `'name': value,` entries for a parameters/body map literal.
+  String _paramRecords(final List<LexParameter> parameters) =>
+      parameters.map((e) => e.getParamsRecord()).join('\n');
+
+  /// Renders the `name: name,` argument-forwarding lines used by wrapper
+  /// methods that delegate to their standalone function.
+  String _paramForwards(final List<LexParameter> parameters) =>
+      parameters.map((e) => '  ${e.name}: ${e.name},').join('\n');
+
   String _getQueryFunction(final List<LexParameter> parameters) {
     final ns = rule.getNamespaceIdForApi(lexiconId);
     final returnType = _getReturnType();
 
-    final buffer = StringBuffer();
-    if (description != null) {
-      buffer.writeln('/// $description');
-    }
-    buffer.writeln('Future<XRPCResponse<$returnType>> $ns({');
-    for (final parameter in parameters) {
-      buffer.writeln(parameter.getParams());
-    }
-    buffer.writeln('  required ServiceContext \$ctx,');
-    buffer.writeln('  String? \$service,');
-    buffer.writeln('  Map<String, String>? \$headers,');
-    buffer.writeln('  Map<String, String>? \$unknown,');
-    buffer.writeln('}) async =>');
-    buffer.writeln('  await \$ctx.get(');
-    buffer.writeln('    ns.$ns,');
-    buffer.writeln('    service: \$service,');
-    buffer.writeln('    headers: \$headers,');
-    buffer.writeln('    parameters: {');
-    buffer.writeln('      ...?\$unknown,');
-    for (final parameter in parameters) {
-      buffer.writeln(parameter.getParamsRecord());
-    }
-    buffer.writeln('    },');
-    if (this.returnType != null && !(this.returnType?.isBytes() ?? true)) {
-      buffer.writeln('    to: const ${returnType}Converter().fromJson,');
-    }
-    buffer.writeln('  );');
+    final to = this.returnType != null && !(this.returnType?.isBytes() ?? true)
+        ? '    to: const ${returnType}Converter().fromJson,\n'
+        : '';
 
-    return buffer.toString();
+    return '''
+${_doc}Future<XRPCResponse<$returnType>> $ns({
+${_paramDecls(parameters)}
+  required ServiceContext \$ctx,
+  String? \$service,
+  Map<String, String>? \$headers,
+  Map<String, String>? \$unknown,
+}) async =>
+  await \$ctx.get(
+    ns.$ns,
+    service: \$service,
+    headers: \$headers,
+    parameters: {
+      ...?\$unknown,
+${_paramRecords(parameters)}
+    },
+$to  );
+''';
   }
 
   String _getQueryMethod(final List<LexParameter> parameters) {
     final ns = rule.getNamespaceIdForApi(lexiconId);
     final returnType = _getReturnType();
 
-    final buffer = StringBuffer();
-    if (description != null) {
-      buffer.writeln('/// $description');
-    }
-    buffer.writeln('Future<XRPCResponse<$returnType>> $name({');
-    for (final parameter in parameters) {
-      buffer.writeln(parameter.getParams());
-    }
-    buffer.writeln('  String? \$service,');
-    buffer.writeln('  Map<String, String>? \$headers,');
-    buffer.writeln('  Map<String, String>? \$unknown,');
-    buffer.writeln('}) async =>');
-    buffer.writeln('  await $ns(');
-    for (final parameter in parameters) {
-      final paramName = parameter.name;
-      buffer.writeln('  $paramName: $paramName,');
-    }
-    buffer.writeln('    \$ctx: ctx,');
-    buffer.writeln('    \$service: \$service,');
-    buffer.writeln('    \$headers: \$headers,');
-    buffer.writeln('    \$unknown: \$unknown,');
-    buffer.writeln('  );');
-
-    return buffer.toString();
+    return '''
+${_doc}Future<XRPCResponse<$returnType>> $name({
+${_paramDecls(parameters)}
+  String? \$service,
+  Map<String, String>? \$headers,
+  Map<String, String>? \$unknown,
+}) async =>
+  await $ns(
+${_paramForwards(parameters)}
+    \$ctx: ctx,
+    \$service: \$service,
+    \$headers: \$headers,
+    \$unknown: \$unknown,
+  );
+''';
   }
 
   String _getProcedureFunction(List<LexParameter> parameters) {
     final ns = rule.getNamespaceIdForApi(lexiconId);
     final returnType = _getReturnType();
+    final isBytes = inputType?.isBytes() ?? false;
 
-    final buffer = StringBuffer();
-    if (description != null) {
-      buffer.writeln('/// $description');
-    }
-
-    if (inputType?.isBytes() ?? false) {
-      buffer.writeln('Future<XRPCResponse<$returnType>> $ns({');
-      buffer.writeln('  required Uint8List bytes,');
-      buffer.writeln('  required ServiceContext \$ctx,');
-      buffer.writeln('  String? \$service,');
-      buffer.writeln('  Map<String, String>? \$headers,');
-      buffer.writeln('  Map<String, String>? \$parameters,');
+    final String signatureParams;
+    final String body;
+    if (isBytes) {
+      signatureParams = '''
+  required Uint8List bytes,
+  required ServiceContext \$ctx,
+  String? \$service,
+  Map<String, String>? \$headers,
+  Map<String, String>? \$parameters,''';
+      body = '''
+    parameters: \$parameters,
+    body: bytes,''';
     } else {
-      buffer.writeln('Future<XRPCResponse<$returnType>> $ns({');
-      for (final parameter in parameters) {
-        buffer.writeln(parameter.getParams());
-      }
-      buffer.writeln('  required ServiceContext \$ctx,');
-      buffer.writeln('  String? \$service,');
-      buffer.writeln('  Map<String, String>? \$headers,');
-      if (parameters.isNotEmpty) {
-        buffer.writeln('  Map<String, String>? \$unknown,');
-      }
-    }
-    buffer.writeln('}) async =>');
-    buffer.writeln('  await \$ctx.post(');
-    buffer.writeln('    ns.$ns,');
-    buffer.writeln('    service: \$service,');
-    buffer.writeln('    headers: {');
-    if (inputType != null) {
-      buffer.writeln("      'Content-type': '${inputType?.getEncoding()}',");
-    }
-    buffer.writeln('      ...?\$headers,');
-    buffer.writeln('    },');
-    if (inputType?.isBytes() ?? false) {
-      buffer.writeln('    parameters: \$parameters,');
-      buffer.writeln('    body: bytes,');
-    } else {
-      if (parameters.isNotEmpty) {
-        buffer.writeln('    body: {');
-        buffer.writeln('      ...?\$unknown,');
-        for (final parameter in parameters) {
-          buffer.writeln(parameter.getParamsRecord());
-        }
-        buffer.writeln('    },');
-      }
+      final unknownParam = parameters.isNotEmpty
+          ? '\n  Map<String, String>? \$unknown,'
+          : '';
+      signatureParams =
+          '''
+${_paramDecls(parameters)}
+  required ServiceContext \$ctx,
+  String? \$service,
+  Map<String, String>? \$headers,$unknownParam''';
+      body = parameters.isNotEmpty
+          ? '''
+    body: {
+      ...?\$unknown,
+${_paramRecords(parameters)}
+    },'''
+          : '';
     }
 
-    if (this.returnType != null) {
-      buffer.writeln('    to: const ${returnType}Converter().fromJson,');
-    }
-    buffer.writeln('  );');
+    final contentType = inputType != null
+        ? "\n      'Content-type': '${inputType?.getEncoding()}',"
+        : '';
+    final to = this.returnType != null
+        ? '    to: const ${returnType}Converter().fromJson,'
+        : '';
 
-    return buffer.toString();
+    final callBody = [
+      '    ns.$ns,',
+      '    service: \$service,',
+      '    headers: {$contentType\n      ...?\$headers,\n    },',
+      if (body.isNotEmpty) body,
+      if (to.isNotEmpty) to,
+    ].join('\n');
+
+    return '''
+${_doc}Future<XRPCResponse<$returnType>> $ns({
+$signatureParams
+}) async =>
+  await \$ctx.post(
+$callBody
+  );
+''';
   }
 
   String _getProcedureMethod(List<LexParameter> parameters) {
     final ns = rule.getNamespaceIdForApi(lexiconId);
     final returnType = _getReturnType();
+    final isBytes = inputType?.isBytes() ?? false;
 
-    final buffer = StringBuffer();
-    if (description != null) {
-      buffer.writeln('/// $description');
-    }
-
-    if (inputType?.isBytes() ?? false) {
-      buffer.writeln('Future<XRPCResponse<$returnType>> $name({');
-      buffer.writeln('  required Uint8List bytes,');
-      buffer.writeln('  String? \$service,');
-      buffer.writeln('  Map<String, String>? \$headers,');
-      buffer.writeln('  Map<String, String>? \$parameters,');
+    final String signatureParams;
+    final String forwards;
+    if (isBytes) {
+      signatureParams = '''
+  required Uint8List bytes,
+  String? \$service,
+  Map<String, String>? \$headers,
+  Map<String, String>? \$parameters,''';
+      forwards = '''
+     bytes: bytes,
+     \$parameters: \$parameters,
+     \$ctx: ctx,
+     \$service: \$service,
+     \$headers: \$headers,''';
     } else {
-      buffer.writeln('Future<XRPCResponse<$returnType>> $name({');
-      for (final parameter in parameters) {
-        buffer.writeln(parameter.getParams());
-      }
-      buffer.writeln('  String? \$service,');
-      buffer.writeln('  Map<String, String>? \$headers,');
-      if (parameters.isNotEmpty) {
-        buffer.writeln('  Map<String, String>? \$unknown,');
-      }
+      final unknownParam = parameters.isNotEmpty
+          ? '\n  Map<String, String>? \$unknown,'
+          : '';
+      signatureParams =
+          '''
+${_paramDecls(parameters)}
+  String? \$service,
+  Map<String, String>? \$headers,$unknownParam''';
+      final unknownArg = parameters.isNotEmpty
+          ? '\n     \$unknown: \$unknown,'
+          : '';
+      forwards =
+          '''
+${_paramForwards(parameters)}
+     \$ctx: ctx,
+     \$service: \$service,
+     \$headers: \$headers,$unknownArg''';
     }
-    buffer.writeln('}) async =>');
-    buffer.writeln('  await $ns(');
-    if (inputType?.isBytes() ?? false) {
-      buffer.writeln('     bytes: bytes,');
-      buffer.writeln('     \$parameters: \$parameters,');
-      buffer.writeln('     \$ctx: ctx,');
-      buffer.writeln('     \$service: \$service,');
-      buffer.writeln('     \$headers: \$headers,');
-    } else {
-      for (final parameter in parameters) {
-        final paramName = parameter.name;
-        buffer.writeln('  $paramName: $paramName,');
-      }
-      buffer.writeln('     \$ctx: ctx,');
-      buffer.writeln('     \$service: \$service,');
-      buffer.writeln('     \$headers: \$headers,');
-      if (parameters.isNotEmpty) {
-        buffer.writeln('     \$unknown: \$unknown,');
-      }
-    }
-    buffer.writeln('  );');
 
-    return buffer.toString();
+    return '''
+${_doc}Future<XRPCResponse<$returnType>> $name({
+$signatureParams
+}) async =>
+  await $ns(
+$forwards
+  );
+''';
   }
 
   String _getSubscriptionFunction(List<LexParameter> parameters) {
     final ns = rule.getNamespaceIdForApi(lexiconId);
 
-    final buffer = StringBuffer();
-    if (description != null) {
-      buffer.writeln('/// $description');
-    }
-    buffer.writeln('Future<XRPCResponse<Subscription<Uint8List>>> $ns({');
-    for (final parameter in parameters) {
-      buffer.writeln(parameter.getParams());
-    }
-    buffer.writeln('  required ServiceContext \$ctx,');
-    buffer.writeln('}) async =>');
-    buffer.writeln('  await \$ctx.stream(');
-    buffer.writeln('    ns.$ns,');
-    buffer.writeln('    parameters: {');
-    for (final parameter in parameters) {
-      buffer.writeln(parameter.getParamsRecord());
-    }
-    buffer.writeln('    },');
-    buffer.writeln('  );');
-
-    return buffer.toString();
+    return '''
+${_doc}Future<XRPCResponse<Subscription<Uint8List>>> $ns({
+${_paramDecls(parameters)}
+  required ServiceContext \$ctx,
+}) async =>
+  await \$ctx.stream(
+    ns.$ns,
+    parameters: {
+${_paramRecords(parameters)}
+    },
+  );
+''';
   }
 
   String _getSubscriptionMethod(List<LexParameter> parameters) {
     final ns = rule.getNamespaceIdForApi(lexiconId);
 
-    final buffer = StringBuffer();
-    if (description != null) {
-      buffer.writeln('/// $description');
-    }
-    buffer.writeln('Future<XRPCResponse<Subscription<Uint8List>>> $name({');
-    for (final parameter in parameters) {
-      buffer.writeln(parameter.getParams());
-    }
-    buffer.writeln('}) async =>');
-    buffer.writeln('  await $ns(');
-    for (final parameter in parameters) {
-      final paramName = parameter.name;
-      buffer.writeln('   $paramName: $paramName,');
-    }
-    buffer.writeln('     \$ctx: ctx,');
-    buffer.writeln('  );');
-
-    return buffer.toString();
+    return '''
+${_doc}Future<XRPCResponse<Subscription<Uint8List>>> $name({
+${_paramDecls(parameters)}
+}) async =>
+  await $ns(
+${_paramForwards(parameters)}
+     \$ctx: ctx,
+  );
+''';
   }
 
   String _getRecordMethod(List<LexParameter> parameters) {
-    final buffer = StringBuffer();
-    if (description != null) {
-      buffer.writeln('/// $description');
-    }
-
     final name = rule.getRecordTypeName(lexiconId);
-    buffer.writeln('${name}RecordAccessor get ${this.name} => _${this.name};');
 
-    return buffer.toString();
+    return '$_doc${name}RecordAccessor get ${this.name} => _${this.name};\n';
   }
 
   String _getReturnType() {

--- a/packages/lex_gen/lib/src/services/object/lex_type.dart
+++ b/packages/lex_gen/lib/src/services/object/lex_type.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 // Project imports:
+import '../../model/nsid.dart';
 import '../gen_context.dart';
 import '../rule.dart' as rule;
 import 'lex_property.dart';
@@ -82,4 +83,65 @@ abstract class GeneratableType extends LexType {
   String getTypeName();
 
   String format(final GenContext ctx);
+}
+
+/// A [GeneratableType] emitted as a freezed data class through
+/// `renderFreezedDataClass`.
+///
+/// `LexObject`, `LexRecord`, `LexInput` and `LexOutput` all carry the same core
+/// fields ([name], [description], [properties]) and differ only in the `suffix`
+/// / `partBaseName` they render with, so those fields — and the shared
+/// `validate` guard emitter — live here instead of being duplicated four times.
+abstract base class FreezedModel extends GeneratableType {
+  @override
+  final String lexiconId;
+  @override
+  final String defName;
+
+  final String name;
+  final String? description;
+  final List<LexProperty> properties;
+
+  const FreezedModel({
+    required this.lexiconId,
+    required this.defName,
+    required this.name,
+    this.description,
+    required this.properties,
+  });
+
+  @override
+  List<LexProperty> getProperties() {
+    return properties;
+  }
+
+  /// Builds the `static bool validate(...)` guard shared by object/record
+  /// types.
+  ///
+  /// When [includeSubscription] is set and the lexicon method is a
+  /// `subscribe*`, the guard matches on the `t` discriminator; otherwise it
+  /// matches on `$type` against [id]. When [includeMainAlias] is set, a `main`
+  /// def additionally accepts the bare `<lexiconId>#main` id.
+  String buildValidateMethod(
+    final String id, {
+    required final bool includeSubscription,
+    required final bool includeMainAlias,
+  }) {
+    final buffer = StringBuffer();
+    buffer.writeln('static bool validate(final Map<String, dynamic> object) {');
+    if (includeSubscription && Nsid(lexiconId).method.startsWith('subscribe')) {
+      buffer.writeln("  if (!object.containsKey('t')) return false;");
+      buffer.writeln("  return object['t'] == '#$defName'");
+    } else {
+      buffer.writeln("  if (!object.containsKey('\\\$type')) return false;");
+      buffer.writeln("  return object['\\\$type'] == '$id'");
+      if (includeMainAlias && defName == 'main') {
+        buffer.writeln("  || object['\\\$type'] == '$lexiconId#main'");
+      }
+    }
+    buffer.writeln(';');
+    buffer.writeln('}');
+
+    return buffer.toString();
+  }
 }

--- a/packages/lex_gen/lib/src/services/object/lex_union.dart
+++ b/packages/lex_gen/lib/src/services/object/lex_union.dart
@@ -3,6 +3,7 @@ import '../../utils.dart';
 import '../gen_context.dart';
 import '../rule.dart' as rule;
 import 'lex_type.dart';
+import 'utils.dart';
 
 final class LexUnion extends GeneratableType {
   @override
@@ -136,21 +137,21 @@ final class ${name}Converter implements JsonConverter<$name, Map<String, dynamic
     final buffer = StringBuffer();
 
     for (final objectName in objectNames) {
-      buffer.writeln('bool get is$objectName => isA<$name$objectName>(this);');
-      buffer.writeln('bool get isNot$objectName => !is$objectName;');
-
-      buffer.writeln(
-        '$objectName? get ${toFirstLowerCase(objectName)} => '
-        'is$objectName ? data as $objectName : null;',
+      writeIsAExtensionGetters(
+        buffer,
+        isName: objectName,
+        typeName: '$name$objectName',
+        castGetter: toFirstLowerCase(objectName),
+        castType: objectName,
       );
     }
 
-    buffer.writeln('bool get isUnknown => isA<${name}Unknown>(this);');
-    buffer.writeln('bool get isNotUnknown => !isUnknown;');
-
-    buffer.writeln(
-      'Map<String, dynamic>? get unknown => '
-      'isUnknown ? data as Map<String, dynamic> : null;',
+    writeIsAExtensionGetters(
+      buffer,
+      isName: 'Unknown',
+      typeName: '${name}Unknown',
+      castGetter: 'unknown',
+      castType: 'Map<String, dynamic>',
     );
 
     return buffer.toString();

--- a/packages/lex_gen/lib/src/services/object/repo_commit_handler.dart
+++ b/packages/lex_gen/lib/src/services/object/repo_commit_handler.dart
@@ -188,7 +188,9 @@ $dtos
     final String verb, {
     required final bool withCreatedAt,
   }) {
-    final createdAtParam = withCreatedAt ? '\n    required this.createdAt,' : '';
+    final createdAtParam = withCreatedAt
+        ? '\n    required this.createdAt,'
+        : '';
     final createdAtField = withCreatedAt
         ? '\n\n  /// The date and time this event was created.'
               '\n  final DateTime createdAt;'

--- a/packages/lex_gen/lib/src/services/object/repo_commit_handler.dart
+++ b/packages/lex_gen/lib/src/services/object/repo_commit_handler.dart
@@ -19,9 +19,9 @@ final class RepoCommitHandler {
     // below, instead of re-deriving it in each builder (was six passes).
     final typeNames = [for (final id in lexiconIds) getRecordTypeName(id)];
 
-    final fields = _getFields(typeNames);
-    final constructorArgs = _getConstructorArgs(typeNames);
-    final constructorArgsSetter = _getConstructorArgsSetter(typeNames);
+    final (:fields, :constructorArgs, :setters) = _getMemberDecls(typeNames);
+
+    final dtos = _getDtoClasses();
 
     final onCreateEvent = _getMutationEvent(
       typeNames,
@@ -69,7 +69,7 @@ final class RepoCommitHandler {
     final RepoCommitOnCreate<Map<String, dynamic>>? onCreateUnknown,
     final RepoCommitOnUpdate<Map<String, dynamic>>? onUpdateUnknown,
     final RepoCommitOnDelete? onDeleteUnknown,
-  }) : $constructorArgsSetter
+  }) : $setters
       _onCreateUnknown = onCreateUnknown,
       _onUpdateUnknown = onUpdateUnknown,
       _onDeleteUnknown = onDeleteUnknown;
@@ -108,152 +108,7 @@ final class RepoCommitHandler {
   }
 }
 
-final class RepoCommitCreate<T> {
-  /// Returns the new instance of [RepoCommitCreate].
-  const RepoCommitCreate({
-    required this.record,
-    required this.uri,
-    required this.cid,
-    required this.author,
-    required this.cursor,
-  });
-
-  /// The created data.
-  final T record;
-
-  /// The AT URI of this [record].
-  final AtUri uri;
-
-  /// CID of this [record].
-  final String? cid;
-
-  /// The author of this event.
-  final String author;
-
-  /// The current cursor.
-  final int cursor;
-
-  @override
-  String toString() =>
-      'RepoCommitCreate(record: \$record, uri: \$uri, cid: \$cid, '
-      'author: \$author, cursor: \$cursor)';
-
-  @override
-  bool operator ==(covariant RepoCommitCreate<T> other) {
-    if (identical(this, other)) return true;
-
-    return other.record == record &&
-        other.uri == uri &&
-        other.cid == cid &&
-        other.author == author &&
-        other.cursor == cursor;
-  }
-
-  @override
-  int get hashCode =>
-      record.hashCode ^
-      uri.hashCode ^
-      cid.hashCode ^
-      author.hashCode ^
-      cursor.hashCode;
-}
-
-final class RepoCommitUpdate<T> {
-  /// Returns the new instance of [RepoCommitUpdate].
-  const RepoCommitUpdate({
-    required this.record,
-    required this.uri,
-    required this.cid,
-    required this.author,
-    required this.cursor,
-    required this.createdAt,
-  });
-
-  /// The created data.
-  final T record;
-
-  /// The AT URI of this [record].
-  final AtUri uri;
-
-  /// CID of this [record].
-  final String? cid;
-
-  /// The author of this event.
-  final String author;
-
-  /// The current cursor.
-  final int cursor;
-
-  /// The date and time this event was created.
-  final DateTime createdAt;
-
-  @override
-  String toString() =>
-      'RepoCommitUpdate(record: \$record, uri: \$uri, cid: \$cid, '
-      'author: \$author, cursor: \$cursor, createdAt: \$createdAt)';
-
-  @override
-  bool operator ==(covariant RepoCommitUpdate<T> other) {
-    if (identical(this, other)) return true;
-
-    return other.record == record &&
-        other.uri == uri &&
-        other.cid == cid &&
-        other.author == author &&
-        other.cursor == cursor &&
-        other.createdAt == createdAt;
-  }
-
-  @override
-  int get hashCode =>
-      record.hashCode ^
-      uri.hashCode ^
-      cid.hashCode ^
-      author.hashCode ^
-      cursor.hashCode ^
-      createdAt.hashCode;
-}
-
-final class RepoCommitDelete {
-  /// Returns the new instance of [RepoCommitDelete].
-  const RepoCommitDelete({
-    required this.uri,
-    required this.author,
-    required this.cursor,
-    required this.createdAt,
-  });
-
-  /// The AT URI of this event.
-  final AtUri uri;
-
-  /// The author of this event.
-  final String author;
-
-  /// The current cursor.
-  final int cursor;
-
-  /// The date and time this event was created.
-  final DateTime createdAt;
-
-  @override
-  String toString() =>
-      'RepoCommitDelete(uri: \$uri, author: \$author, cursor: \$cursor, '
-      'createdAt: \$createdAt)';
-
-  @override
-  bool operator ==(covariant RepoCommitDelete other) {
-    if (identical(this, other)) return true;
-
-    return other.uri == uri &&
-        other.author == author &&
-        other.cursor == cursor &&
-        other.createdAt == createdAt;
-  }
-
-  @override
-  int get hashCode =>
-      uri.hashCode ^ author.hashCode ^ cursor.hashCode ^ createdAt.hashCode;
-}
+$dtos
 ''';
   }
 
@@ -278,48 +133,121 @@ final class RepoCommitDelete {
     return imports.toString();
   }
 
-  String _getFields(final List<String> typeNames) {
-    final buffer = StringBuffer();
+  /// Builds the three per-record member sections in a single pass: the private
+  /// [fields], the [constructorArgs] parameters, and their initializer-list
+  /// [setters]. Each record contributes a create/update/delete triple to all
+  /// three sections.
+  ({String fields, String constructorArgs, String setters}) _getMemberDecls(
+    final List<String> typeNames,
+  ) {
+    final fields = StringBuffer();
+    final constructorArgs = StringBuffer();
+    final setters = StringBuffer();
 
     for (final typeName in typeNames) {
-      buffer.writeln(
+      fields.writeln(
         'final RepoCommitOnCreate<${typeName}Record>? _onCreate$typeName;',
       );
-      buffer.writeln(
+      fields.writeln(
         'final RepoCommitOnUpdate<${typeName}Record>? _onUpdate$typeName;',
       );
-      buffer.writeln('final RepoCommitOnDelete? _onDelete$typeName;');
-    }
+      fields.writeln('final RepoCommitOnDelete? _onDelete$typeName;');
 
-    return buffer.toString();
-  }
-
-  String _getConstructorArgs(final List<String> typeNames) {
-    final buffer = StringBuffer();
-
-    for (final typeName in typeNames) {
-      buffer.writeln(
+      constructorArgs.writeln(
         'final RepoCommitOnCreate<${typeName}Record>? onCreate$typeName,',
       );
-      buffer.writeln(
+      constructorArgs.writeln(
         'final RepoCommitOnUpdate<${typeName}Record>? onUpdate$typeName,',
       );
-      buffer.writeln('final RepoCommitOnDelete? onDelete$typeName,');
+      constructorArgs.writeln('final RepoCommitOnDelete? onDelete$typeName,');
+
+      setters.writeln('_onCreate$typeName = onCreate$typeName,');
+      setters.writeln('_onUpdate$typeName = onUpdate$typeName,');
+      setters.writeln('_onDelete$typeName = onDelete$typeName,');
     }
 
-    return buffer.toString();
+    return (
+      fields: fields.toString(),
+      constructorArgs: constructorArgs.toString(),
+      setters: setters.toString(),
+    );
   }
 
-  String _getConstructorArgsSetter(final List<String> typeNames) {
-    final buffer = StringBuffer();
+  /// Assembles the three DTO classes emitted alongside the handler: the
+  /// `RepoCommitCreate` / `RepoCommitUpdate` mutation pair (which differ only
+  /// by `Update`'s extra `createdAt`) plus the static `RepoCommitDelete`.
+  String _getDtoClasses() =>
+      '${_getMutationDto('Create', withCreatedAt: false)}\n\n'
+      '${_getMutationDto('Update', withCreatedAt: true)}\n\n'
+      '$_repoCommitDeleteDto';
 
-    for (final typeName in typeNames) {
-      buffer.writeln('_onCreate$typeName = onCreate$typeName,');
-      buffer.writeln('_onUpdate$typeName = onUpdate$typeName,');
-      buffer.writeln('_onDelete$typeName = onDelete$typeName,');
-    }
+  /// Emits the `RepoCommitCreate` / `RepoCommitUpdate` DTO for [verb]. They are
+  /// identical except that `Update` ([withCreatedAt]) also carries a
+  /// `createdAt` field.
+  String _getMutationDto(
+    final String verb, {
+    required final bool withCreatedAt,
+  }) {
+    final createdAtParam = withCreatedAt ? '\n    required this.createdAt,' : '';
+    final createdAtField = withCreatedAt
+        ? '\n\n  /// The date and time this event was created.'
+              '\n  final DateTime createdAt;'
+        : '';
+    final createdAtToString = withCreatedAt ? ', createdAt: \$createdAt' : '';
+    final createdAtEquals = withCreatedAt
+        ? ' &&\n        other.createdAt == createdAt'
+        : '';
+    final createdAtHash = withCreatedAt ? ' ^\n      createdAt.hashCode' : '';
 
-    return buffer.toString();
+    return '''final class RepoCommit$verb<T> {
+  /// Returns the new instance of [RepoCommit$verb].
+  const RepoCommit$verb({
+    required this.record,
+    required this.uri,
+    required this.cid,
+    required this.author,
+    required this.cursor,$createdAtParam
+  });
+
+  /// The created data.
+  final T record;
+
+  /// The AT URI of this [record].
+  final AtUri uri;
+
+  /// CID of this [record].
+  final String? cid;
+
+  /// The author of this event.
+  final String author;
+
+  /// The current cursor.
+  final int cursor;$createdAtField
+
+  @override
+  String toString() =>
+      'RepoCommit$verb(record: \$record, uri: \$uri, cid: \$cid, '
+      'author: \$author, cursor: \$cursor$createdAtToString)';
+
+  @override
+  bool operator ==(covariant RepoCommit$verb<T> other) {
+    if (identical(this, other)) return true;
+
+    return other.record == record &&
+        other.uri == uri &&
+        other.cid == cid &&
+        other.author == author &&
+        other.cursor == cursor$createdAtEquals;
+  }
+
+  @override
+  int get hashCode =>
+      record.hashCode ^
+      uri.hashCode ^
+      cid.hashCode ^
+      author.hashCode ^
+      cursor.hashCode$createdAtHash;
+}''';
   }
 
   /// Renders the `_onCreate` / `_onUpdate` firehose handler, which differ only
@@ -405,3 +333,46 @@ final class RepoCommitDelete {
 ''';
   }
 }
+
+/// The static `RepoCommitDelete` DTO. Unlike the create/update mutations it has
+/// no generic record payload, so it is emitted verbatim.
+const _repoCommitDeleteDto = r'''final class RepoCommitDelete {
+  /// Returns the new instance of [RepoCommitDelete].
+  const RepoCommitDelete({
+    required this.uri,
+    required this.author,
+    required this.cursor,
+    required this.createdAt,
+  });
+
+  /// The AT URI of this event.
+  final AtUri uri;
+
+  /// The author of this event.
+  final String author;
+
+  /// The current cursor.
+  final int cursor;
+
+  /// The date and time this event was created.
+  final DateTime createdAt;
+
+  @override
+  String toString() =>
+      'RepoCommitDelete(uri: $uri, author: $author, cursor: $cursor, '
+      'createdAt: $createdAt)';
+
+  @override
+  bool operator ==(covariant RepoCommitDelete other) {
+    if (identical(this, other)) return true;
+
+    return other.uri == uri &&
+        other.author == author &&
+        other.cursor == cursor &&
+        other.createdAt == createdAt;
+  }
+
+  @override
+  int get hashCode =>
+      uri.hashCode ^ author.hashCode ^ cursor.hashCode ^ createdAt.hashCode;
+}''';

--- a/packages/lex_gen/lib/src/services/object/utils.dart
+++ b/packages/lex_gen/lib/src/services/object/utils.dart
@@ -118,6 +118,33 @@ String getObjectConverter(final String name, {String suffix = ''}) {
 ''';
 }
 
+/// Appends the recurring `is<Name>` / `isNot<Name>` / cast-getter triple used
+/// by the union and known-values extension emitters, e.g.
+///
+/// ```dart
+/// bool get isFoo => isA<BarFoo>(this);
+/// bool get isNotFoo => !isFoo;
+/// Foo? get foo => isFoo ? data as Foo : null;
+/// ```
+///
+/// [isName] is the `is<isName>` suffix, [typeName] the concrete type passed to
+/// `isA<...>`, [castGetter] the cast getter name and [castType] its return type
+/// (also the `data as <castType>` cast target).
+void writeIsAExtensionGetters(
+  final StringBuffer buffer, {
+  required final String isName,
+  required final String typeName,
+  required final String castGetter,
+  required final String castType,
+}) {
+  buffer.writeln('bool get is$isName => isA<$typeName>(this);');
+  buffer.writeln('bool get isNot$isName => !is$isName;');
+  buffer.writeln(
+    '$castType? get $castGetter => '
+    'is$isName ? data as $castType : null;',
+  );
+}
+
 String getExtensions(
   final String name,
   final List<LexProperty> properties, {

--- a/packages/lex_gen/lib/src/services/rule.dart
+++ b/packages/lex_gen/lib/src/services/rule.dart
@@ -268,7 +268,8 @@ String getPackageRelativePath(
 }
 
 bool _isInTheSamePackage(final String lexiconId, final String ref) {
-  if (ref.startsWith('#')) return true;
+  // A local ref (`#def`) always resolves within the current lexicon's package.
+  if (LexRef.parse(ref) is LocalRef) return true;
   return _getServiceFromLexiconId(lexiconId) == _getServiceFromLexiconId(ref);
 }
 
@@ -301,7 +302,7 @@ String getLexObjectAbsolutePath(
   final String lexiconId,
   final String fileName,
 ) {
-  return '${_getHomeDirForExport(ctx, lexiconId)}/${_getFileDir(lexiconId)}/$fileName.dart';
+  return _exportAbsolutePath(ctx, lexiconId, _getFileDir(lexiconId), fileName);
 }
 
 String getLexObjectAbsolutePathForService(
@@ -309,8 +310,24 @@ String getLexObjectAbsolutePathForService(
   final String lexiconId,
   final String fileName,
 ) {
-  final root = Nsid(lexiconId).serviceDir;
-  return '${_getHomeDirForExport(ctx, lexiconId)}/$root/$fileName.dart';
+  return _exportAbsolutePath(
+    ctx,
+    lexiconId,
+    Nsid(lexiconId).serviceDir,
+    fileName,
+  );
+}
+
+/// Builds `<export home>/<dir>/<fileName>.dart`, shared by the absolute-path
+/// helpers that differ only in which sub-directory (`fileDir` vs `serviceDir`)
+/// they place the file under.
+String _exportAbsolutePath(
+  final GenContext ctx,
+  final String lexiconId,
+  final String dir,
+  final String fileName,
+) {
+  return '${_getHomeDirForExport(ctx, lexiconId)}/$dir/$fileName.dart';
 }
 
 String getLexKnownValuesElementName(

--- a/packages/lex_gen/lib/src/services/services_common.dart
+++ b/packages/lex_gen/lib/src/services/services_common.dart
@@ -1,0 +1,104 @@
+// Copyright (c) 2023-2025, Shinya Kato.
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// Dart imports:
+import 'dart:io';
+
+// Package imports:
+import 'package:lexicon/lexicon.dart';
+
+// Project imports:
+import '../model/lex_def_kind.dart';
+import 'object/lex_package.dart';
+
+/// Whether [doc] declares at least one definition whose value is the [T]
+/// user-type variant (e.g. `ULexUserTypeRecord`).
+bool docDefinesType<T>(final LexiconDoc doc) {
+  for (final def in doc.defs.entries) {
+    if (def.value is T) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+bool isXrpcQueryDoc(final LexiconDoc doc) =>
+    docDefinesType<ULexUserTypeXrpcQuery>(doc);
+
+bool isXrpcProcedureDoc(final LexiconDoc doc) =>
+    docDefinesType<ULexUserTypeXrpcProcedure>(doc);
+
+bool isXrpcSubscriptionDoc(final LexiconDoc doc) =>
+    docDefinesType<ULexUserTypeXrpcSubscription>(doc);
+
+bool isRecordDoc(final LexiconDoc doc) =>
+    docDefinesType<ULexUserTypeRecord>(doc);
+
+/// Whether [doc] exposes any of the four API-bearing definition kinds
+/// (query, procedure, subscription or record).
+bool isApiDoc(final LexiconDoc doc) =>
+    isXrpcQueryDoc(doc) ||
+    isXrpcProcedureDoc(doc) ||
+    isXrpcSubscriptionDoc(doc) ||
+    isRecordDoc(doc);
+
+/// Resolves the API kind of [doc], keeping the historical dispatch priority
+/// (query, then procedure, then subscription, then record) so that a doc
+/// carrying more than one API def resolves exactly as the old boolean chain.
+LexDefKind apiKindOf(final LexiconDoc doc) {
+  if (isXrpcQueryDoc(doc)) return LexDefKind.query;
+  if (isXrpcProcedureDoc(doc)) return LexDefKind.procedure;
+  if (isXrpcSubscriptionDoc(doc)) return LexDefKind.subscription;
+  return LexDefKind.record;
+}
+
+/// Returns the first API-bearing definition of [doc], preserving the original
+/// declaration order. Throws a [StateError] when [doc] declares none.
+LexUserType firstApiDef(final LexiconDoc doc) {
+  for (final def in doc.defs.entries) {
+    final value = def.value;
+    if (value is ULexUserTypeXrpcQuery ||
+        value is ULexUserTypeXrpcProcedure ||
+        value is ULexUserTypeXrpcSubscription ||
+        value is ULexUserTypeRecord) {
+      return value;
+    }
+  }
+
+  throw StateError('API definition does not exist');
+}
+
+/// Writes the given [packages] barrels to disk, re-exporting the `atproto`
+/// base packages from every non-`atproto` root.
+void writeLexPackages(final List<LexPackage> packages) {
+  final basePackages = _getBasePackages(packages);
+
+  for (final package in packages) {
+    File('packages/${package.root}/lib/${package.name}.dart')
+      ..createSync(recursive: true)
+      ..writeAsStringSync(package.exportableDependencies);
+
+    if (package.root != 'atproto') {
+      for (final base in basePackages) {
+        File('packages/${package.root}/lib/${base.name}.dart')
+          ..createSync(recursive: true)
+          ..writeAsStringSync(base.exportableDependencies);
+      }
+    }
+  }
+}
+
+List<LexPackage> _getBasePackages(final List<LexPackage> packages) {
+  if (packages.isEmpty) return const [];
+
+  final result = <LexPackage>[];
+  for (final package in packages) {
+    if (package.root == 'atproto') {
+      result.add(package);
+    }
+  }
+
+  return result;
+}

--- a/packages/lex_gen/test/src/commands/lex_command_test.dart
+++ b/packages/lex_gen/test/src/commands/lex_command_test.dart
@@ -17,8 +17,8 @@ void main() {
       NSID('app.bsky.feed.post'),
       'A declaration of a post.',
       [
-        LexParameter('text', 'The primary text.', true, null, type: 'string'),
-        LexParameter(
+        LexCliParameter('text', 'The primary text.', true, null, type: 'string'),
+        LexCliParameter(
           'facets',
           null,
           false,
@@ -102,7 +102,7 @@ void main() {
     final command = LexCommand(
       NSID('app.bsky.feed.getTimeline'),
       'Get a timeline.',
-      [LexParameter('limit', null, false, '50', type: 'integer')],
+      [LexCliParameter('limit', null, false, '50', type: 'integer')],
       kind: LexCommandKind.query,
     );
 

--- a/packages/lex_gen/test/src/commands/lex_command_test.dart
+++ b/packages/lex_gen/test/src/commands/lex_command_test.dart
@@ -17,7 +17,13 @@ void main() {
       NSID('app.bsky.feed.post'),
       'A declaration of a post.',
       [
-        LexCliParameter('text', 'The primary text.', true, null, type: 'string'),
+        LexCliParameter(
+          'text',
+          'The primary text.',
+          true,
+          null,
+          type: 'string',
+        ),
         LexCliParameter(
           'facets',
           null,

--- a/packages/lex_gen/test/src/commands/lex_parameter_test.dart
+++ b/packages/lex_gen/test/src/commands/lex_parameter_test.dart
@@ -9,9 +9,9 @@ import 'package:test/test.dart';
 import 'package:lex_gen/src/commands/types/lex_parameter.dart';
 
 void main() {
-  group('LexParameter.getParam (L-15) — validated parsing', () {
+  group('LexCliParameter.getParam (L-15) — validated parsing', () {
     test('integer parses via int.tryParse and raises usageException', () {
-      final param = LexParameter('limit', null, true, null, type: 'integer');
+      final param = LexCliParameter('limit', null, true, null, type: 'integer');
 
       expect(
         param.getParam(),
@@ -21,13 +21,13 @@ void main() {
     });
 
     test('a JSON scalar decodes through the _decodeJson helper', () {
-      final param = LexParameter('reply', null, true, null, type: 'ref');
+      final param = LexCliParameter('reply', null, true, null, type: 'ref');
 
       expect(param.getParam(), '"reply": _decodeJson("reply"),');
     });
 
     test('a required JSON array validates non-emptiness and decodes items', () {
-      final param = LexParameter(
+      final param = LexCliParameter(
         'writes',
         null,
         true,
@@ -45,7 +45,7 @@ void main() {
     });
 
     test('a required integer array validates and parses each element', () {
-      final param = LexParameter(
+      final param = LexCliParameter(
         'nums',
         null,
         true,
@@ -67,7 +67,7 @@ void main() {
     test(
       'an optional array keeps the wasParsed guard (no empty array sent)',
       () {
-        final param = LexParameter(
+        final param = LexCliParameter(
           'langs',
           null,
           false,

--- a/packages/lex_gen/test/src/golden/feed_post_golden_test.dart
+++ b/packages/lex_gen/test/src/golden/feed_post_golden_test.dart
@@ -8,7 +8,6 @@ import 'package:test/test.dart';
 
 // Project imports:
 import 'package:lex_gen/src/services/fmt/lex_record_generator.dart';
-
 import '../test_context.dart';
 
 /// End-to-end golden: a fixture Lexicon document is parsed and run through the

--- a/packages/lex_gen/test/src/services/fmt/lex_property_generator_test.dart
+++ b/packages/lex_gen/test/src/services/fmt/lex_property_generator_test.dart
@@ -9,7 +9,6 @@ import 'package:test/test.dart';
 // Project imports:
 import 'package:lex_gen/src/services/fmt/lex_property_generator.dart';
 import 'package:lex_gen/src/services/object/lex_property.dart';
-
 import '../../test_context.dart';
 
 /// Builds a `{name: LexObjectProperty}` map from raw fixture JSON, mirroring how

--- a/packages/lex_gen/test/src/services/object/lex_object_test.dart
+++ b/packages/lex_gen/test/src/services/object/lex_object_test.dart
@@ -9,7 +9,6 @@ import 'package:test/test.dart';
 import 'package:lex_gen/src/dart_type.dart';
 import 'package:lex_gen/src/services/object/lex_object.dart';
 import 'package:lex_gen/src/services/object/lex_property.dart';
-
 import '../../test_context.dart';
 
 void main() {

--- a/packages/lex_gen/test/src/services/object/lex_service_test.dart
+++ b/packages/lex_gen/test/src/services/object/lex_service_test.dart
@@ -11,7 +11,6 @@ import 'package:lex_gen/src/model/lex_def_kind.dart';
 import 'package:lex_gen/src/services/object/lex_property.dart';
 import 'package:lex_gen/src/services/object/lex_record.dart';
 import 'package:lex_gen/src/services/object/lex_service.dart';
-
 import '../../test_context.dart';
 
 void main() {

--- a/packages/lex_gen/test/src/services/object/lex_union_test.dart
+++ b/packages/lex_gen/test/src/services/object/lex_union_test.dart
@@ -7,7 +7,6 @@ import 'package:test/test.dart';
 
 // Project imports:
 import 'package:lex_gen/src/services/object/lex_union.dart';
-
 import '../../test_context.dart';
 
 void main() {

--- a/scripts/verify_gen_unchanged.sh
+++ b/scripts/verify_gen_unchanged.sh
@@ -14,8 +14,13 @@
 #   full      Tier B (ground truth, minutes): run the real codegen pipeline
 #             (gen_codes -> build_runner -> dart fix -> melos fmt) and assert
 #             `git diff --exit-code` on the 3 codegen dirs is empty.
+#   srccheck  Guards the lex_gen SOURCE itself (not the generated output): runs
+#             import_sorter + `dart analyze` on packages/lex_gen and asserts they
+#             leave it clean, then restores. Catches emitter templates whose
+#             `import '...';'''` shape import_sorter mis-hoists (which `check`
+#             cannot see, since it only compares generated output).
 #
-# Usage: scripts/verify_gen_unchanged.sh {baseline|check|full}
+# Usage: scripts/verify_gen_unchanged.sh {baseline|check|full|srccheck}
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -91,9 +96,33 @@ cmd_full() {
   fi
 }
 
+cmd_srccheck() {
+  echo ">> srccheck: import_sorter + analyze on lex_gen source"
+  (cd packages/lex_gen && dart run import_sorter:main >/dev/null 2>&1)
+  local rc=0
+  if ! git diff --quiet --exit-code -- packages/lex_gen; then
+    echo "!! import_sorter changed lex_gen source (not at fmt fixed-point):" >&2
+    git diff --stat -- packages/lex_gen >&2
+    rc=1
+  fi
+  if ! dart analyze packages/lex_gen >/tmp/lex_gen_srccheck_analyze.txt 2>&1; then
+    echo "!! dart analyze failed on lex_gen source (import_sorter likely corrupted a template):" >&2
+    tail -20 /tmp/lex_gen_srccheck_analyze.txt >&2
+    rc=1
+  fi
+  git checkout -- packages/lex_gen
+  if [[ $rc -eq 0 ]]; then
+    echo ">> srccheck PASS: lex_gen source is import_sorter-stable and analyzes clean"
+  else
+    echo ">> srccheck FAIL" >&2
+  fi
+  return $rc
+}
+
 case "${1:-}" in
   baseline) cmd_baseline ;;
   check)    cmd_check ;;
   full)     cmd_full ;;
-  *) echo "usage: $0 {baseline|check|full}" >&2; exit 64 ;;
+  srccheck) cmd_srccheck ;;
+  *) echo "usage: $0 {baseline|check|full|srccheck}" >&2; exit 64 ;;
 esac

--- a/scripts/verify_gen_unchanged.sh
+++ b/scripts/verify_gen_unchanged.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Verify that a lex_gen refactor does not change generated output.
+#
+# Invariant (per docs/superpowers/specs/2026-07-15-lex-gen-structural-refactor-design.md):
+#   the FINAL committed (formatted + import-sorted) generated files stay byte-identical.
+#
+# Two tiers:
+#   baseline  Capture the reference: gen_codes -> `dart format` the 3 codegen dirs,
+#             snapshot them, then restore the working tree. Run once on the
+#             pre-refactor source.
+#   check     Tier A (fast, ~seconds): gen_codes -> `dart format` -> diff against the
+#             captured baseline. Catches semantic changes without build_runner.
+#             Restores the working tree afterwards.
+#   full      Tier B (ground truth, minutes): run the real codegen pipeline
+#             (gen_codes -> build_runner -> dart fix -> melos fmt) and assert
+#             `git diff --exit-code` on the 3 codegen dirs is empty.
+#
+# Usage: scripts/verify_gen_unchanged.sh {baseline|check|full}
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+CODEGEN_DIRS=(
+  "packages/atproto/lib/src/services/codegen"
+  "packages/bluesky/lib/src/services/codegen"
+  "packages/bluesky_cli/lib/src/commands/codegen"
+)
+BASELINE_DIR="${LEX_GEN_BASELINE_DIR:-$REPO_ROOT/.lex_gen_baseline}"
+
+restore_tree() {
+  git checkout -- "${CODEGEN_DIRS[@]}"
+}
+
+gen_and_format() {
+  dart run ./scripts/gen_codes.dart >/dev/null
+  dart format "${CODEGEN_DIRS[@]}" >/dev/null
+}
+
+cmd_baseline() {
+  echo ">> capturing Tier A baseline into $BASELINE_DIR"
+  gen_and_format
+  rm -rf "$BASELINE_DIR"
+  mkdir -p "$BASELINE_DIR"
+  for d in "${CODEGEN_DIRS[@]}"; do
+    mkdir -p "$BASELINE_DIR/$(dirname "$d")"
+    cp -R "$d" "$BASELINE_DIR/$d"
+  done
+  restore_tree
+  echo ">> baseline captured; working tree restored"
+}
+
+cmd_check() {
+  if [[ ! -d "$BASELINE_DIR" ]]; then
+    echo "!! no baseline at $BASELINE_DIR; run 'baseline' first" >&2
+    exit 2
+  fi
+  echo ">> Tier A check against $BASELINE_DIR"
+  gen_and_format
+  local rc=0
+  for d in "${CODEGEN_DIRS[@]}"; do
+    if ! diff -rq "$BASELINE_DIR/$d" "$d" >/tmp/lex_gen_check_diff.txt 2>&1; then
+      rc=1
+      echo "!! DIFF in $d:" >&2
+      head -50 /tmp/lex_gen_check_diff.txt >&2
+    fi
+  done
+  restore_tree
+  if [[ $rc -eq 0 ]]; then
+    echo ">> Tier A PASS: generated output unchanged (formatted)"
+  else
+    echo ">> Tier A FAIL: generated output changed" >&2
+  fi
+  return $rc
+}
+
+cmd_full() {
+  echo ">> Tier B full pipeline (build_runner + dart fix + melos fmt)"
+  dart run ./scripts/gen_codes.dart
+  (cd packages/atproto && dart run build_runner build --delete-conflicting-outputs && dart fix --apply)
+  (cd packages/bluesky && dart run build_runner build --delete-conflicting-outputs && dart fix --apply)
+  (cd packages/bluesky_cli && dart fix --apply)
+  melos fmt
+  echo ">> asserting empty git diff on codegen dirs"
+  if git diff --quiet --exit-code -- "${CODEGEN_DIRS[@]}"; then
+    echo ">> Tier B PASS: committed generated output byte-identical"
+  else
+    echo "!! Tier B FAIL: committed generated output changed" >&2
+    git diff --stat -- "${CODEGEN_DIRS[@]}" >&2
+    exit 1
+  fi
+}
+
+case "${1:-}" in
+  baseline) cmd_baseline ;;
+  check)    cmd_check ;;
+  full)     cmd_full ;;
+  *) echo "usage: $0 {baseline|check|full}" >&2; exit 64 ;;
+esac


### PR DESCRIPTION
## Summary

Structural / readability refactor of `packages/lex_gen` (the Lexicon → Dart code generator), continuing the work from #2434. **Generated output is byte-for-byte identical** — this PR changes only the generator's internal structure, never what it emits or the public API.

The invariant here is **the final committed (formatted + import-sorted) generated files stay identical**, verified mechanically against the current `main`'s committed codegen.

## What changed

Split into 10 focused, independently-verified workstreams:

| Area | File(s) | Improvement |
|---|---|---|
| Emitters | `object/lex_service.dart` (648→618) | Collapsed the ~100-`writeln` record-accessor block into per-method emitters; unified the `create`/`put` and the query/procedure/subscription function↔method pairs; extracted the import collector |
| Emitters | `object/repo_commit_handler.dart` (407→378) | Lifted the constant DTO block out of `format()`; unified the `Create`/`Update` DTOs (differ only by `createdAt`); single-pass member emission |
| Emitters | `commands/types/lex_command.dart` (652→611) | Extracted the repeated name/header preamble; deduped the 3 procedure templates; centralized invocation strings |
| Model builder | `fmt/lex_property_generator.dart` | Removed the 4× duplicated `DartType.array(...)` construction; replaced the double 3-way ternary with a single resolved ref-variant |
| Models | `object/lex_{object,record,input,output}.dart` + `lex_type.dart` | Extracted a shared `FreezedModel` base for the common fields + `validate` emitter |
| Orchestrators | `services/lex_type_generator.dart`, `lex_service_generator.dart`, `lex_tools_generator.dart` + new `services_common.dart` | Flattened the `is ULexUserType*` ladder into a `switch`; extracted the duplicated package-writer and doc-type classifier |
| Naming | `services/rule.dart` | Deduped the `*ForService`/absolute-path helper twins (internal only, public API unchanged) |
| Commands | `commands/lex_command_generator.dart`, `types/lex_{parent,root}_command.dart` | Flattened the def-dispatch loop into a classifier; deduped the parent/root import emitters |
| Emitters | `object/{utils,lex_union,lex_known_values,at_uri_extension}.dart` | Shared `isA`-extension-getter helper (5 call sites); named `_getElements()` helper |
| Hygiene | `commands/types/lex_parameter.dart` (+refs) | Renamed the commands-world `LexParameter` → `LexCliParameter` to remove the collision with the services-world `LexParameter` (opposite meaning, zero shared code) |

Net: **22 lib files, −51 lines**, with duplication consolidated into the new `services_common.dart` module and the `FreezedModel` base rather than copied.

## Verification

A new dev harness, `scripts/verify_gen_unchanged.sh`, enforces the invariant in two tiers:

- **Tier A** (`check`, ~9s): `gen_codes` → `dart format` → diff against a captured baseline. A sound per-change gate (can over-report import reordering, never under-reports content changes).
- **Tier B** (`full`): the real pipeline (`gen_codes` → `build_runner` → `dart fix` → `import_sorter` → `dart format`) then asserts an empty `git diff` on the three codegen dirs.
- **`srccheck`**: asserts the lex_gen *source* itself is import_sorter-stable and analyzes clean (see below).

Results on this branch, against the current `main`:
- ✅ **Tier A PASS** (generated output byte-identical)
- ✅ **Tier B PASS** (full pipeline → empty git diff)
- ✅ `dart analyze packages/lex_gen` clean, **70/70 tests pass**, `srccheck` PASS

## Notable finding

`import_sorter` (part of `melos fmt`) mis-hoists an `import '...';` that sits flush against a triple-quoted string's closing `'''` (i.e. a source line reading `import 'x';'''`), corrupting the file — even though the generated output is unchanged and `dart analyze`/tests pass. This slipped past output-only checks and was caught by the Tier B pipeline. Fixed by splitting that one trailing import into a concatenated literal (emitted content unchanged), and the harness gained the `srccheck` mode to catch this class of regression per-change.

## Scope / non-goals

- No change to generated code, public generator API, or the `package:code_builder` migration (out of scope).
- The documented `getLexObjectName` collision (TODO G-5) is untouched — fixing it would change output.

Design doc: `docs/superpowers/specs/2026-07-15-lex-gen-structural-refactor-design.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
