### PR TITLE
fix: make melos publish scripts non-interactive (--yes/--force)

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -84,18 +84,21 @@ melos:
     # a built-in melos command — a script named `publish` would shadow it and
     # recurse when the script body calls `melos publish`.
     publish_dry:
-      run: melos publish
+      run: melos publish --yes
       description: >-
         Dry-run publish for all Dart workspace packages. `melos publish`
-        defaults to a dry run, so this validates the release without
-        publishing. Run this first.
+        defaults to a dry run, so this only validates the release. `--yes` skips
+        the Y/n confirmation so it runs non-interactively — nested inside
+        `melos run` (or any non-TTY shell) there is no terminal to answer the
+        prompt, which otherwise fails with `CancelledException`. Run this first.
 
     publish_live:
-      run: melos publish --no-dry-run --git-tag-version
+      run: melos publish --no-dry-run --git-tag-version --yes
       description: >-
         Publish all Dart workspace packages to pub.dev and create the git
-        version tags locally (`--git-tag-version`). Run `publish_dry` first,
-        then `publish_tags` to push the tags.
+        version tags locally (`--git-tag-version`). `--yes` skips the
+        confirmation prompt so it runs non-interactively; validate with
+        `publish_dry` first, then run `publish_tags` to push the tags.
 
     publish_tags:
       run: git push origin --tags
@@ -114,10 +117,11 @@ melos:
     flutter_publish_live:
       run: |
         cd packages/bluesky_text_flutter
-        flutter pub publish
+        flutter pub publish --force
       description: >-
-        Publish the Flutter package (bluesky_text_flutter) to pub.dev. Run
-        `flutter_publish_dry` first; append `--force` to skip the prompt.
+        Publish the Flutter package (bluesky_text_flutter) to pub.dev. `--force`
+        skips the confirmation prompt so it runs non-interactively; validate
+        with `flutter_publish_dry` first.
 
     flutter_publish_tags:
       run: |


### PR DESCRIPTION
## Summary

The melos publish scripts fail with `CancelledException: Operation was canceled`
when run non-interactively. `melos publish` always shows a Y/n confirmation
prompt — even in dry-run — and when a publish script runs nested inside
`melos run` (or in any shell without an interactive TTY, e.g. an IDE run button
or CI), there is no terminal to answer the prompt, so it aborts.

Reproduction (`melos publish_dry`):

```
The following packages will be validated only (dry run):
Package Name    Registry    Local
bluesky         1.7.1       1.7.2
ERROR: CancelledException: Operation was canceled.
```

## Fix

Add the prompt-skip flags so the scripts run to completion:

- `publish_dry`  → `melos publish --yes`
- `publish_live` → `melos publish --no-dry-run --git-tag-version --yes`
- `flutter_publish_live` → `flutter pub publish --force`

The `*_dry` scripts (`publish_dry` / `flutter_publish_dry`) remain the safety
gate — validate first, then run the live step. (`flutter pub publish --dry-run`
does not prompt, so `flutter_publish_dry` is unchanged.)

## Verification

- `melos publish_dry` now runs the dry-run validation to completion with a
  non-interactive stdin (previously `CancelledException`); confirmed via the
  stack trace pointing at `promptBool` / `_promptWithTerminal` in
  `melos/src/commands/publish.dart`.
- `dart run melos publish --yes` validates all packages successfully.
- YAML validated.

Only `pubspec.yaml` is changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
