### PR TITLE
docs(oauth): update atproto_oauth README to the new pluggable OAuth API

### DIFF
--- a/packages/atproto_oauth/README.md
+++ b/packages/atproto_oauth/README.md
@@ -18,7 +18,7 @@ Add the following dependencies to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  atproto_oauth: ^0.0.1  # Replace with actual version
+  atproto_oauth: ^0.5.0  # Replace with actual version
   flutter_web_auth_2: ^4.0.1
   flutter_secure_storage: ^9.2.2
 ```
@@ -27,16 +27,24 @@ Or if you would like to use this feature on Bluesky:
 
 ```yaml
 dependencies:
-  bluesky: ^0.18.0  # Replace with actual version
+  bluesky: ^2.0.0  # Replace with actual version
   flutter_web_auth_2: ^4.0.1
   flutter_secure_storage: ^9.2.2
 ```
+
+> **Note:** AT Protocol OAuth tokens are opaque — this library never decodes
+> them as JWTs. Every stage of the flow is pluggable: inject your own
+> `OAuthStateStore`, `OAuthSessionStore`, `DPoPNonceCache`, `IdentityResolver`,
+> or `DPoPSigner` into `OAuthClient` (each has an in-memory / HTTP / pointycastle
+> default). The example below manages session persistence explicitly instead.
 
 ## Basic Usage
 
 Here's how to implement AT Protocol OAuth authentication in your Flutter app:
 
 ```dart
+import 'dart:convert';
+
 import 'package:atproto_oauth/atproto_oauth.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_web_auth_2/flutter_web_auth_2.dart';
@@ -68,17 +76,19 @@ class _BlueskyAuthState extends State<BlueskyAuth> {
 
   Future<void> _startAuth() async {
     try {
-      // Get authorization URL for user's handle
-      final (authUrl, ctx) = await _client.authorize('shinyakato.dev');
+      // Resolve the account and get the authorization URL. The per-request
+      // context is stored inside the client's OAuthStateStore (keyed by the
+      // `state` value), so `callback` below does not need it passed back.
+      final authUrl = await _client.authorize('shinyakato.dev');
 
       // Launch OAuth flow in browser
       final result = await FlutterWebAuth2.authenticate(
-        url: authUrl,
+        url: authUrl.toString(),
         callbackUrlScheme: 'your-app-scheme',
       );
 
-      // Handle the OAuth callback
-      final session = await _client.callback(result, ctx);
+      // Handle the OAuth callback (single argument)
+      final session = await _client.callback(result);
 
       // Store the session securely
       await _saveSession(session);
@@ -96,52 +106,22 @@ class _BlueskyAuthState extends State<BlueskyAuth> {
   }
 
   Future<void> _saveSession(OAuthSession session) async {
-    // Securely store all session data
-    await _storage.write(key: 'access_token', value: session.accessToken);
-    await _storage.write(key: 'refresh_token', value: session.refreshToken);
-    await _storage.write(key: 'dpop_nonce', value: session.$dPoPNonce);
-    await _storage.write(key: 'public_key', value: session.$publicKey);
-    await _storage.write(key: 'private_key', value: session.$privateKey);
+    // OAuthSession serializes to/from JSON. It contains the DPoP private key
+    // and the access/refresh tokens, so only persist it into secure,
+    // access-controlled storage — never plaintext.
     await _storage.write(
-      key: 'expires_at',
-      value: session.expiresAt.toIso8601String(),
+      key: 'oauth_session',
+      value: jsonEncode(session.toJson()),
     );
   }
 
   Future<OAuthSession?> _loadSession() async {
-    final accessToken = await _storage.read(key: 'access_token');
-    if (accessToken == null) return null;
+    final raw = await _storage.read(key: 'oauth_session');
+    if (raw == null) return null;
 
-    return OAuthSession(
-      accessToken: accessToken,
-      refreshToken: await _storage.read(key: 'refresh_token') ?? '',
-      tokenType: 'DPoP',
-      expiresAt: DateTime.parse(
-        await _storage.read(key: 'expires_at') ?? '',
-      ),
-      $dPoPNonce: await _storage.read(key: 'dpop_nonce') ?? '',
-      $publicKey: await _storage.read(key: 'public_key') ?? '',
-      $privateKey: await _storage.read(key: 'private_key') ?? '',
-    );
-  }
-
-  Future<OAuthSession?> _refreshTokenIfNeeded() async {
-    final session = await _loadSession();
-    if (session == null) return null;
-
-    // Check if token needs refresh (e.g., 5 minutes before expiration)
-    if (session.expiresAt.isBefore(DateTime.now().add(Duration(minutes: 5)))) {
-      try {
-        final newSession = await _client.refresh(session);
-        await _saveSession(newSession);
-        return newSession;
-      } catch (e) {
-        // If refresh fails, clear stored session
-        await _storage.deleteAll();
-        return null;
-      }
-    }
-    return session;
+    // Sessions saved by atproto_oauth <= 0.4.x used a different shape; restore
+    // those with `OAuthSession.fromLegacyJson(json, issuer: ..., pds: ...)`.
+    return OAuthSession.fromJson(jsonDecode(raw) as Map<String, dynamic>);
   }
 
   @override
@@ -164,19 +144,36 @@ See docs on [flutter_web_auth_2](https://github.com/ThexXTURBOXx/flutter_web_aut
 
 ## Using [Bluesky Client](https://pub.dev/packages/bluesky)
 
-Once authenticated, you can use the session for API requests with [bluesky client](https://pub.dev/packages/bluesky)
+Once authenticated, wrap the session in an `OAuthSessionManager` and hand it to
+the [bluesky client](https://pub.dev/packages/bluesky). The manager builds the
+DPoP proof for every request and refreshes the access token automatically —
+proactively just before it expires and reactively on a `401` — so you no longer
+refresh by hand. Listen to `onSessionUpdated` to persist the rotated session.
 
 ```dart
-Future<void> _makeAuthenticatedRequest() async {
-  final session = await _refreshTokenIfNeeded();
+Future<Bluesky?> _authenticatedBluesky() async {
+  final session = await _loadSession();
   if (session == null) {
     // Handle unauthenticated state
-    return;
+    return null;
   }
 
-  final bsky = Bluesky.fromOAuthSession(session);
+  // Pass the client so the manager can refresh; persist rotations.
+  final manager = OAuthSessionManager.fromSession(session, client: _client);
+  manager.onSessionUpdated.listen(_saveSession);
+
+  return Bluesky.fromOAuth(manager);
+}
+
+Future<void> _makeAuthenticatedRequest() async {
+  final bsky = await _authenticatedBluesky();
+  if (bsky == null) return;
 
   // Anyway you want it    !
   final record = await bsky.feed.post(text: 'Nice DPoP proof');
 }
 ```
+
+> If a refresh fails because the session was revoked, the manager surfaces an
+> `OAuthSessionRevokedException` and clears it from the session store — route the
+> user back through `authorize` in that case.


### PR DESCRIPTION
## What & why

Follow-up doc fix to #2447 (customizable OAuth, #2060/#1982). That PR updated the runnable `example.dart` files but the `atproto_oauth` **README** still showed the pre-0.5.0 OAuth API, so copy-pasting it no longer compiles.

## Changes (`packages/atproto_oauth/README.md` only)

Rewrote the Flutter OAuth walkthrough to the new API:

- `authorize()` now returns a `Uri` (was a `(Uri, OAuthContext)` tuple); `callback()` takes a single URL (the per-request context is recovered from the `OAuthStateStore` via `state`).
- Session persistence uses `jsonEncode(session.toJson())` / `OAuthSession.fromJson(...)` instead of hand-writing the removed `$dPoPNonce` / `$publicKey` / `$privateKey` fields (with a note pointing to `fromLegacyJson` for ≤0.4.x payloads).
- Replaced the manual refresh helper with `OAuthSessionManager.fromSession(session, client: _client)` (automatic proactive + on-401 refresh), `onSessionUpdated` for persisting rotations, and `Bluesky.fromOAuth(manager)`.
- Added notes on opaque tokens, the pluggable stores/resolver/signer, and `OAuthSessionRevokedException`; bumped the dependency version hints to `^0.5.0` / `^2.0.0`.

Docs-only; no code or tests affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
