### PR TITLE
chore: format workspace (fix dart format drift)

### DIFF
--- a/packages/atproto/lib/src/atproto.dart
+++ b/packages/atproto/lib/src/atproto.dart
@@ -247,7 +247,8 @@ final class _ATProto implements ATProto {
   core.Session? get session => _ctx.session;
 
   @override
-  oauth.OAuthSessionManager? get oAuthSessionManager => _ctx.oAuthSessionManager;
+  oauth.OAuthSessionManager? get oAuthSessionManager =>
+      _ctx.oAuthSessionManager;
 
   @override
   String get service => _ctx.service;

--- a/packages/atproto_core/lib/src/clients/service_context.dart
+++ b/packages/atproto_core/lib/src/clients/service_context.dart
@@ -219,8 +219,8 @@ base class ServiceContext {
   /// used as the DPoP `htu` and for per-endpoint nonce reporting.
   Uri _endpointFor(final String service, final NSID methodId) =>
       _protocol == xrpc.Protocol.http
-          ? Uri.http(service, '/xrpc/$methodId')
-          : Uri.https(service, '/xrpc/$methodId');
+      ? Uri.http(service, '/xrpc/$methodId')
+      : Uri.https(service, '/xrpc/$methodId');
 
   /// Returns the OAuth DPoP auth headers for [endpoint]/[method], or an empty
   /// map when this context is not OAuth-authenticated.

--- a/packages/atproto_core/test/src/clients/service_context_oauth_test.dart
+++ b/packages/atproto_core/test/src/clients/service_context_oauth_test.dart
@@ -2,17 +2,17 @@ import 'package:atproto_core/atproto_core.dart';
 import 'package:test/test.dart';
 
 OAuthSession _session() => OAuthSession(
-      accessToken: 'access-1',
-      refreshToken: 'refresh-1',
-      scope: 'atproto',
-      expiresAt: DateTime.utc(2999),
-      sub: 'did:plc:abc',
-      issuer: 'https://bsky.social',
-      pds: 'https://pds.example',
-      clientId: 'cid',
-      dpopPublicKey: 'PUB',
-      dpopPrivateKey: 'PRIV',
-    );
+  accessToken: 'access-1',
+  refreshToken: 'refresh-1',
+  scope: 'atproto',
+  expiresAt: DateTime.utc(2999),
+  sub: 'did:plc:abc',
+  issuer: 'https://bsky.social',
+  pds: 'https://pds.example',
+  clientId: 'cid',
+  dpopPublicKey: 'PUB',
+  dpopPrivateKey: 'PRIV',
+);
 
 void main() {
   test('service defaults to the OAuth session PDS host', () {

--- a/packages/atproto_oauth/lib/src/dpop/dpop_signer.dart
+++ b/packages/atproto_oauth/lib/src/dpop/dpop_signer.dart
@@ -47,14 +47,13 @@ final class PointyCastleDPoPSigner implements DPoPSigner {
     required final DPoPKeyPair keyPair,
     final String? nonce,
     final String? accessToken,
-  }) async =>
-      getDPoPHeader(
-        clientId: '', // ignored by getDPoPHeader; no client_id claim is emitted
-        endpoint: htu,
-        method: htm,
-        dPoPNonce: nonce,
-        accessToken: accessToken,
-        publicKey: keyPair.publicKey,
-        privateKey: keyPair.privateKey,
-      );
+  }) async => getDPoPHeader(
+    clientId: '', // ignored by getDPoPHeader; no client_id claim is emitted
+    endpoint: htu,
+    method: htm,
+    dPoPNonce: nonce,
+    accessToken: accessToken,
+    publicKey: keyPair.publicKey,
+    privateKey: keyPair.privateKey,
+  );
 }

--- a/packages/atproto_oauth/lib/src/identity/identity_resolver.dart
+++ b/packages/atproto_oauth/lib/src/identity/identity_resolver.dart
@@ -63,10 +63,11 @@ final class HttpIdentityResolver implements IdentityResolver {
 
     if (handle != null) {
       final alsoKnownAs = didDocument['alsoKnownAs'];
-      final claimsHandle = alsoKnownAs is List &&
+      final claimsHandle =
+          alsoKnownAs is List &&
           alsoKnownAs.whereType<String>().any(
-                (final aka) => aka.toLowerCase() == 'at://$handle',
-              );
+            (final aka) => aka.toLowerCase() == 'at://$handle',
+          );
       if (!claimsHandle) {
         throw OAuthException(
           'Bidirectional handle verification failed: the DID document for '
@@ -83,10 +84,13 @@ final class HttpIdentityResolver implements IdentityResolver {
   }
 
   Future<String> _resolveHandle(final String handle) async {
-    final origin =
-        _normalizeHttpOrigin(handleResolver, what: 'handle resolver URL');
-    final uri = Uri.parse('$origin/xrpc/com.atproto.identity.resolveHandle')
-        .replace(queryParameters: {'handle': handle});
+    final origin = _normalizeHttpOrigin(
+      handleResolver,
+      what: 'handle resolver URL',
+    );
+    final uri = Uri.parse(
+      '$origin/xrpc/com.atproto.identity.resolveHandle',
+    ).replace(queryParameters: {'handle': handle});
     final response = await _get(uri);
     if (response.statusCode != 200) {
       throw OAuthException(
@@ -107,8 +111,10 @@ final class HttpIdentityResolver implements IdentityResolver {
   Future<Map<String, dynamic>> _resolveDidDocument(final String did) async {
     final Uri uri;
     if (did.startsWith('did:plc:')) {
-      final origin =
-          _normalizeHttpOrigin(plcDirectory, what: 'PLC directory URL');
+      final origin = _normalizeHttpOrigin(
+        plcDirectory,
+        what: 'PLC directory URL',
+      );
       uri = Uri.parse('$origin/$did');
     } else if (did.startsWith('did:web:')) {
       uri = _didWebDocumentUri(did);
@@ -186,10 +192,7 @@ String _extractPdsEndpoint(
 /// Normalizes a user-supplied host or URL to an `https`/`http` origin
 /// (`scheme://host[:port]`, no trailing slash). A bare hostname is treated as
 /// `https://<host>`.
-String _normalizeHttpOrigin(
-  final String input, {
-  required final String what,
-}) {
+String _normalizeHttpOrigin(final String input, {required final String what}) {
   var value = input.trim();
   if (value.isEmpty) {
     throw OAuthException('$what must not be empty');

--- a/packages/atproto_oauth/lib/src/oauth_client.dart
+++ b/packages/atproto_oauth/lib/src/oauth_client.dart
@@ -145,13 +145,13 @@ final class OAuthClient {
     final DPoPNonceCache? nonceCache,
     final DPoPSigner? signer,
     final http.Client? httpClient,
-  })  : _identityResolver =
-            identityResolver ?? HttpIdentityResolver(httpClient: httpClient),
-        _stateStore = stateStore ?? InMemoryOAuthStateStore(),
-        _sessionStore = sessionStore ?? InMemoryOAuthSessionStore(),
-        _nonceCache = nonceCache ?? InMemoryDPoPNonceCache(),
-        _signer = signer ?? const PointyCastleDPoPSigner(),
-        _httpClient = httpClient;
+  }) : _identityResolver =
+           identityResolver ?? HttpIdentityResolver(httpClient: httpClient),
+       _stateStore = stateStore ?? InMemoryOAuthStateStore(),
+       _sessionStore = sessionStore ?? InMemoryOAuthSessionStore(),
+       _nonceCache = nonceCache ?? InMemoryDPoPNonceCache(),
+       _signer = signer ?? const PointyCastleDPoPSigner(),
+       _httpClient = httpClient;
 
   /// Client metadata to be used during authentication.
   final OAuthClientMetadata metadata;
@@ -322,7 +322,11 @@ final class OAuthClient {
   ///   token exchange.
   Future<OAuthSession> callback(final String callbackUrl) async {
     if (callbackUrl.isEmpty) {
-      throw ArgumentError.value(callbackUrl, 'callbackUrl', 'must not be empty');
+      throw ArgumentError.value(
+        callbackUrl,
+        'callbackUrl',
+        'must not be empty',
+      );
     }
 
     final callbackUri = Uri.tryParse(callbackUrl);
@@ -763,12 +767,12 @@ final class OAuthClient {
   /// Returns [endpoint] as a string with the query and fragment stripped,
   /// for use as the DPoP `htu` claim (RFC 9449 §4.2).
   static String _htuFor(final Uri endpoint) => Uri(
-        scheme: endpoint.scheme,
-        userInfo: endpoint.userInfo.isEmpty ? null : endpoint.userInfo,
-        host: endpoint.host,
-        port: endpoint.hasPort ? endpoint.port : null,
-        path: endpoint.path,
-      ).toString();
+    scheme: endpoint.scheme,
+    userInfo: endpoint.userInfo.isEmpty ? null : endpoint.userInfo,
+    host: endpoint.host,
+    port: endpoint.hasPort ? endpoint.port : null,
+    path: endpoint.path,
+  ).toString();
 
   /// Builds an [OAuthSession] from a successful token response, validating
   /// the members required by the atproto OAuth profile.

--- a/packages/atproto_oauth/lib/src/oauth_session_manager.dart
+++ b/packages/atproto_oauth/lib/src/oauth_session_manager.dart
@@ -21,9 +21,9 @@ final class OAuthSessionManager {
     required final String sub,
     final DPoPSigner? signer,
     final DPoPNonceCache? nonceCache,
-  })  : _sub = sub,
-        _signer = signer ?? const PointyCastleDPoPSigner(),
-        _nonceCache = nonceCache ?? InMemoryDPoPNonceCache();
+  }) : _sub = sub,
+       _signer = signer ?? const PointyCastleDPoPSigner(),
+       _nonceCache = nonceCache ?? InMemoryDPoPNonceCache();
 
   factory OAuthSessionManager.fromSession(
     final OAuthSession session, {
@@ -83,10 +83,7 @@ final class OAuthSessionManager {
       nonce: await _nonceCache.find(endpoint.origin),
       accessToken: session.accessToken,
     );
-    return {
-      'Authorization': 'DPoP ${session.accessToken}',
-      'DPoP': proof,
-    };
+    return {'Authorization': 'DPoP ${session.accessToken}', 'DPoP': proof};
   }
 
   Future<void> reportDpopNonce(final Uri endpoint, final String nonce) async =>
@@ -106,11 +103,14 @@ final class OAuthSessionManager {
   Future<OAuthSession> _refresh(final OAuthSession current) {
     if (_inflightRefresh != null) return _inflightRefresh!;
     final client = _client!;
-    _inflightRefresh = client.refresh(current).then((refreshed) {
-      _session = refreshed;
-      _updates.add(refreshed);
-      return refreshed;
-    }).whenComplete(() => _inflightRefresh = null);
+    _inflightRefresh = client
+        .refresh(current)
+        .then((refreshed) {
+          _session = refreshed;
+          _updates.add(refreshed);
+          return refreshed;
+        })
+        .whenComplete(() => _inflightRefresh = null);
     return _inflightRefresh!;
   }
 

--- a/packages/atproto_oauth/lib/src/types/resolved_identity.dart
+++ b/packages/atproto_oauth/lib/src/types/resolved_identity.dart
@@ -4,11 +4,7 @@
 
 /// The outcome of resolving a handle or DID to its atproto identity.
 final class ResolvedIdentity {
-  const ResolvedIdentity({
-    required this.did,
-    required this.pds,
-    this.handle,
-  });
+  const ResolvedIdentity({required this.did, required this.pds, this.handle});
 
   /// The account DID.
   final String did;

--- a/packages/atproto_oauth/lib/src/types/session.dart
+++ b/packages/atproto_oauth/lib/src/types/session.dart
@@ -72,7 +72,8 @@ final class OAuthSession {
     required this.dpopPrivateKey,
   });
 
-  factory OAuthSession.fromJson(final Map<String, dynamic> json) => OAuthSession(
+  factory OAuthSession.fromJson(final Map<String, dynamic> json) =>
+      OAuthSession(
         accessToken: json['access_token'] as String,
         refreshToken: json['refresh_token'] as String?,
         tokenType: (json['token_type'] as String?) ?? 'DPoP',
@@ -97,20 +98,20 @@ final class OAuthSession {
     required final String issuer,
     required final String pds,
   }) => OAuthSession(
-        accessToken: json['access_token'] as String,
-        refreshToken: json['refresh_token'] as String?,
-        tokenType: (json['token_type'] as String?) ?? 'DPoP',
-        scope: (json['scope'] as String?) ?? '',
-        expiresAt: json['expires_at'] == null
-            ? null
-            : DateTime.parse(json['expires_at'] as String).toUtc(),
-        sub: json['sub'] as String,
-        issuer: issuer,
-        pds: pds,
-        clientId: json['client_id'] as String,
-        dpopPublicKey: json['public_key'] as String,
-        dpopPrivateKey: json['private_key'] as String,
-      );
+    accessToken: json['access_token'] as String,
+    refreshToken: json['refresh_token'] as String?,
+    tokenType: (json['token_type'] as String?) ?? 'DPoP',
+    scope: (json['scope'] as String?) ?? '',
+    expiresAt: json['expires_at'] == null
+        ? null
+        : DateTime.parse(json['expires_at'] as String).toUtc(),
+    sub: json['sub'] as String,
+    issuer: issuer,
+    pds: pds,
+    clientId: json['client_id'] as String,
+    dpopPublicKey: json['public_key'] as String,
+    dpopPrivateKey: json['private_key'] as String,
+  );
 
   final String accessToken;
   final String? refreshToken;
@@ -130,17 +131,16 @@ final class OAuthSession {
   final String dpopPrivateKey;
 
   Map<String, dynamic> toJson() => {
-        'access_token': accessToken,
-        if (refreshToken != null) 'refresh_token': refreshToken,
-        'token_type': tokenType,
-        'scope': scope,
-        if (expiresAt != null)
-          'expires_at': expiresAt!.toUtc().toIso8601String(),
-        'sub': sub,
-        'issuer': issuer,
-        'pds': pds,
-        'client_id': clientId,
-        'dpop_public_key': dpopPublicKey,
-        'dpop_private_key': dpopPrivateKey,
-      };
+    'access_token': accessToken,
+    if (refreshToken != null) 'refresh_token': refreshToken,
+    'token_type': tokenType,
+    'scope': scope,
+    if (expiresAt != null) 'expires_at': expiresAt!.toUtc().toIso8601String(),
+    'sub': sub,
+    'issuer': issuer,
+    'pds': pds,
+    'client_id': clientId,
+    'dpop_public_key': dpopPublicKey,
+    'dpop_private_key': dpopPrivateKey,
+  };
 }

--- a/packages/atproto_oauth/test/src/dpop/dpop_signer_test.dart
+++ b/packages/atproto_oauth/test/src/dpop/dpop_signer_test.dart
@@ -7,44 +7,49 @@ Map<String, dynamic> _decodeSegment(final String seg) =>
         as Map<String, dynamic>;
 
 void main() {
-  test('createProof emits a well-formed dpop+jwt with only spec claims',
-      () async {
-    final signer = PointyCastleDPoPSigner();
-    final kp = await signer.generateKeyPair();
+  test(
+    'createProof emits a well-formed dpop+jwt with only spec claims',
+    () async {
+      final signer = PointyCastleDPoPSigner();
+      final kp = await signer.generateKeyPair();
 
-    final proof = await signer.createProof(
-      htm: 'POST',
-      htu: 'https://bsky.social/oauth/token',
-      keyPair: kp,
-      nonce: 'server-nonce',
-      accessToken: 'access-token',
-    );
+      final proof = await signer.createProof(
+        htm: 'POST',
+        htu: 'https://bsky.social/oauth/token',
+        keyPair: kp,
+        nonce: 'server-nonce',
+        accessToken: 'access-token',
+      );
 
-    final parts = proof.split('.');
-    expect(parts, hasLength(3));
+      final parts = proof.split('.');
+      expect(parts, hasLength(3));
 
-    final header = _decodeSegment(parts[0]);
-    expect(header['typ'], 'dpop+jwt');
-    expect(header['alg'], 'ES256');
-    expect((header['jwk'] as Map)['crv'], 'P-256');
+      final header = _decodeSegment(parts[0]);
+      expect(header['typ'], 'dpop+jwt');
+      expect(header['alg'], 'ES256');
+      expect((header['jwk'] as Map)['crv'], 'P-256');
 
-    final payload = _decodeSegment(parts[1]);
-    expect(payload['htm'], 'POST');
-    expect(payload['htu'], 'https://bsky.social/oauth/token');
-    expect(payload['nonce'], 'server-nonce');
-    expect(payload.containsKey('ath'), isTrue);
-    expect(payload.containsKey('jti'), isTrue);
-    expect(payload.containsKey('iat'), isTrue);
-    expect(payload.containsKey('iss'), isFalse);
-    expect(payload.containsKey('sub'), isFalse);
-    expect(payload.containsKey('client_id'), isFalse);
-  });
+      final payload = _decodeSegment(parts[1]);
+      expect(payload['htm'], 'POST');
+      expect(payload['htu'], 'https://bsky.social/oauth/token');
+      expect(payload['nonce'], 'server-nonce');
+      expect(payload.containsKey('ath'), isTrue);
+      expect(payload.containsKey('jti'), isTrue);
+      expect(payload.containsKey('iat'), isTrue);
+      expect(payload.containsKey('iss'), isFalse);
+      expect(payload.containsKey('sub'), isFalse);
+      expect(payload.containsKey('client_id'), isFalse);
+    },
+  );
 
   test('createProof omits nonce and ath when not provided', () async {
     final signer = PointyCastleDPoPSigner();
     final kp = await signer.generateKeyPair();
-    final proof =
-        await signer.createProof(htm: 'GET', htu: 'https://x.example', keyPair: kp);
+    final proof = await signer.createProof(
+      htm: 'GET',
+      htu: 'https://x.example',
+      keyPair: kp,
+    );
     final payload = _decodeSegment(proof.split('.')[1]);
     expect(payload.containsKey('nonce'), isFalse);
     expect(payload.containsKey('ath'), isFalse);

--- a/packages/atproto_oauth/test/src/identity/http_identity_resolver_test.dart
+++ b/packages/atproto_oauth/test/src/identity/http_identity_resolver_test.dart
@@ -8,39 +8,43 @@ const _did = 'did:plc:abcdefghijklmnopqrstuvwx';
 const _handle = 'alice.example';
 const _pds = 'https://pds.example';
 
-http.Response _json(final Object body) =>
-    http.Response(jsonEncode(body), 200,
-        headers: {'content-type': 'application/json'});
+http.Response _json(final Object body) => http.Response(
+  jsonEncode(body),
+  200,
+  headers: {'content-type': 'application/json'},
+);
 
 void main() {
-  test('resolves a handle to did + pds with bidirectional verification',
-      () async {
-    final client = MockClient((request) async {
-      if (request.url.path == '/xrpc/com.atproto.identity.resolveHandle') {
-        return _json({'did': _did});
-      }
-      if (request.url.path == '/$_did') {
-        return _json({
-          'alsoKnownAs': ['at://$_handle'],
-          'service': [
-            {
-              'id': '#atproto_pds',
-              'type': 'AtprotoPersonalDataServer',
-              'serviceEndpoint': _pds,
-            }
-          ],
-        });
-      }
-      return http.Response('not found', 404);
-    });
+  test(
+    'resolves a handle to did + pds with bidirectional verification',
+    () async {
+      final client = MockClient((request) async {
+        if (request.url.path == '/xrpc/com.atproto.identity.resolveHandle') {
+          return _json({'did': _did});
+        }
+        if (request.url.path == '/$_did') {
+          return _json({
+            'alsoKnownAs': ['at://$_handle'],
+            'service': [
+              {
+                'id': '#atproto_pds',
+                'type': 'AtprotoPersonalDataServer',
+                'serviceEndpoint': _pds,
+              },
+            ],
+          });
+        }
+        return http.Response('not found', 404);
+      });
 
-    final resolver = HttpIdentityResolver(httpClient: client);
-    final id = await resolver.resolve(_handle);
+      final resolver = HttpIdentityResolver(httpClient: client);
+      final id = await resolver.resolve(_handle);
 
-    expect(id.did, _did);
-    expect(id.pds, _pds);
-    expect(id.handle, _handle);
-  });
+      expect(id.did, _did);
+      expect(id.pds, _pds);
+      expect(id.handle, _handle);
+    },
+  );
 
   test('throws when alsoKnownAs does not claim the handle back', () async {
     final client = MockClient((request) async {
@@ -54,7 +58,7 @@ void main() {
             'id': '#atproto_pds',
             'type': 'AtprotoPersonalDataServer',
             'serviceEndpoint': _pds,
-          }
+          },
         ],
       });
     });

--- a/packages/atproto_oauth/test/src/oauth_client_test.dart
+++ b/packages/atproto_oauth/test/src/oauth_client_test.dart
@@ -104,7 +104,9 @@ http.Response? _identityRoute(final http.Request r) {
   }
   if (r.url.host == 'pds.example' &&
       r.url.path == '/.well-known/oauth-protected-resource') {
-    return _json({'authorization_servers': [_origin]});
+    return _json({
+      'authorization_servers': [_origin],
+    });
   }
   return null;
 }
@@ -650,35 +652,54 @@ void main() {
       final stateStore = InMemoryOAuthStateStore();
       final sessionStore = InMemoryOAuthSessionStore();
       const state = 'state-xyz';
-      await stateStore.set(state, const OAuthContext(
-        codeVerifier: 'verifier', state: state,
-        issuer: 'https://bsky.social',
-        tokenEndpoint: 'https://bsky.social/oauth/token',
-        dpopPublicKey: 'PUB', dpopPrivateKey: 'PRIV',
-        pds: 'https://pds.example',
-        expectedSub: 'did:plc:abcdefghijklmnopqrstuvwx',
-      ));
+      await stateStore.set(
+        state,
+        const OAuthContext(
+          codeVerifier: 'verifier',
+          state: state,
+          issuer: 'https://bsky.social',
+          tokenEndpoint: 'https://bsky.social/oauth/token',
+          dpopPublicKey: 'PUB',
+          dpopPrivateKey: 'PRIV',
+          pds: 'https://pds.example',
+          expectedSub: 'did:plc:abcdefghijklmnopqrstuvwx',
+        ),
+      );
       final client = MockClient((r) async {
         if (r.url.path == '/.well-known/oauth-authorization-server') {
-          return _json({'issuer': 'https://bsky.social',
-            'token_endpoint': 'https://bsky.social/oauth/token'});
+          return _json({
+            'issuer': 'https://bsky.social',
+            'token_endpoint': 'https://bsky.social/oauth/token',
+          });
         }
         if (r.url.path == '/oauth/token') {
-          return _json({'access_token': 'opaque~not~a~jwt', 'token_type': 'DPoP',
-            'refresh_token': 'refresh-1', 'scope': 'atproto', 'expires_in': 3600,
-            'sub': 'did:plc:abcdefghijklmnopqrstuvwx'});
+          return _json({
+            'access_token': 'opaque~not~a~jwt',
+            'token_type': 'DPoP',
+            'refresh_token': 'refresh-1',
+            'scope': 'atproto',
+            'expires_in': 3600,
+            'sub': 'did:plc:abcdefghijklmnopqrstuvwx',
+          });
         }
         return http.Response('nope', 404);
       });
-      final oauth = OAuthClient(_metadata(),
-          stateStore: stateStore, sessionStore: sessionStore,
-          signer: _StubSigner(), httpClient: client);
+      final oauth = OAuthClient(
+        _metadata(),
+        stateStore: stateStore,
+        sessionStore: sessionStore,
+        signer: _StubSigner(),
+        httpClient: client,
+      );
       final session = await oauth.callback(
-        'https://client.example/callback?iss=https://bsky.social&state=$state&code=abc');
+        'https://client.example/callback?iss=https://bsky.social&state=$state&code=abc',
+      );
       expect(session.accessToken, 'opaque~not~a~jwt');
       expect(session.pds, 'https://pds.example');
-      expect(await sessionStore.find('did:plc:abcdefghijklmnopqrstuvwx'),
-          isNotNull);
+      expect(
+        await sessionStore.find('did:plc:abcdefghijklmnopqrstuvwx'),
+        isNotNull,
+      );
     });
   });
 

--- a/packages/atproto_oauth/test/src/oauth_session_manager_test.dart
+++ b/packages/atproto_oauth/test/src/oauth_session_manager_test.dart
@@ -11,64 +11,79 @@ OAuthSession _session({
   String dpopPublicKey = 'PUB',
   String dpopPrivateKey = 'PRIV',
 }) => OAuthSession(
-      accessToken: 'access-1',
-      refreshToken: 'refresh-1',
-      scope: 'atproto',
-      expiresAt: expiresAt,
-      sub: 'did:plc:abc',
-      issuer: 'https://bsky.social',
-      pds: 'https://pds.example',
-      clientId: 'cid',
-      dpopPublicKey: dpopPublicKey,
-      dpopPrivateKey: dpopPrivateKey,
-    );
+  accessToken: 'access-1',
+  refreshToken: 'refresh-1',
+  scope: 'atproto',
+  expiresAt: expiresAt,
+  sub: 'did:plc:abc',
+  issuer: 'https://bsky.social',
+  pds: 'https://pds.example',
+  clientId: 'cid',
+  dpopPublicKey: dpopPublicKey,
+  dpopPrivateKey: dpopPrivateKey,
+);
 
 void main() {
-  test('buildAuthHeaders emits DPoP Authorization + DPoP proof headers',
-      () async {
-    // The default signer performs real EC crypto, so it needs a real key
-    // pair rather than the placeholder 'PUB'/'PRIV' used elsewhere in this
-    // file (those are only safe with a stub/recording signer).
-    final keyPair = await const PointyCastleDPoPSigner().generateKeyPair();
-    final mgr = OAuthSessionManager.fromSession(_session(
-      dpopPublicKey: keyPair.publicKey,
-      dpopPrivateKey: keyPair.privateKey,
-    ));
-    final headers = await mgr.buildAuthHeaders(
-      Uri.parse('https://pds.example/xrpc/app.bsky.actor.getProfile'),
-      'GET',
-    );
-    expect(headers['Authorization'], 'DPoP access-1');
-    expect(headers['DPoP'], isNotEmpty);
-  });
+  test(
+    'buildAuthHeaders emits DPoP Authorization + DPoP proof headers',
+    () async {
+      // The default signer performs real EC crypto, so it needs a real key
+      // pair rather than the placeholder 'PUB'/'PRIV' used elsewhere in this
+      // file (those are only safe with a stub/recording signer).
+      final keyPair = await const PointyCastleDPoPSigner().generateKeyPair();
+      final mgr = OAuthSessionManager.fromSession(
+        _session(
+          dpopPublicKey: keyPair.publicKey,
+          dpopPrivateKey: keyPair.privateKey,
+        ),
+      );
+      final headers = await mgr.buildAuthHeaders(
+        Uri.parse('https://pds.example/xrpc/app.bsky.actor.getProfile'),
+        'GET',
+      );
+      expect(headers['Authorization'], 'DPoP access-1');
+      expect(headers['DPoP'], isNotEmpty);
+    },
+  );
 
-  test('fromSession without client returns the same session and cannot refresh',
-      () async {
-    final mgr = OAuthSessionManager.fromSession(_session());
-    expect((await mgr.getSession()).accessToken, 'access-1');
-    expect(await mgr.refreshOnUnauthorized(), isFalse);
-    expect(mgr.currentSub, 'did:plc:abc');
-    expect(mgr.currentPdsHost, 'pds.example');
-  });
+  test(
+    'fromSession without client returns the same session and cannot refresh',
+    () async {
+      final mgr = OAuthSessionManager.fromSession(_session());
+      expect((await mgr.getSession()).accessToken, 'access-1');
+      expect(await mgr.refreshOnUnauthorized(), isFalse);
+      expect(mgr.currentSub, 'did:plc:abc');
+      expect(mgr.currentPdsHost, 'pds.example');
+    },
+  );
 
-  test('reportDpopNonce then buildAuthHeaders passes that nonce to the signer',
-      () async {
-    final signer = _RecordingSigner();
-    final mgr = OAuthSessionManager.fromSession(_session(), signer: signer);
-    final ep = Uri.parse('https://pds.example/xrpc/app.bsky.actor.getProfile');
-    await mgr.reportDpopNonce(ep, 'nonce-xyz');
-    await mgr.buildAuthHeaders(ep, 'GET');
-    expect(signer.lastNonce, 'nonce-xyz');
-  });
+  test(
+    'reportDpopNonce then buildAuthHeaders passes that nonce to the signer',
+    () async {
+      final signer = _RecordingSigner();
+      final mgr = OAuthSessionManager.fromSession(_session(), signer: signer);
+      final ep = Uri.parse(
+        'https://pds.example/xrpc/app.bsky.actor.getProfile',
+      );
+      await mgr.reportDpopNonce(ep, 'nonce-xyz');
+      await mgr.buildAuthHeaders(ep, 'GET');
+      expect(signer.lastNonce, 'nonce-xyz');
+    },
+  );
 
   test('buildAuthHeaders strips query/fragment from the DPoP htu', () async {
     final signer = _RecordingSigner();
     final mgr = OAuthSessionManager.fromSession(_session(), signer: signer);
     await mgr.buildAuthHeaders(
-      Uri.parse('https://pds.example/xrpc/app.bsky.actor.getProfile?actor=x#frag'),
+      Uri.parse(
+        'https://pds.example/xrpc/app.bsky.actor.getProfile?actor=x#frag',
+      ),
       'GET',
     );
-    expect(signer.lastHtu, 'https://pds.example/xrpc/app.bsky.actor.getProfile');
+    expect(
+      signer.lastHtu,
+      'https://pds.example/xrpc/app.bsky.actor.getProfile',
+    );
     expect(signer.lastHtu!.contains('?'), isFalse);
     expect(signer.lastHtu!.contains('#'), isFalse);
   });
@@ -81,8 +96,13 @@ class _RecordingSigner implements DPoPSigner {
   Future<DPoPKeyPair> generateKeyPair() async =>
       const DPoPKeyPair(publicKey: 'PUB', privateKey: 'PRIV');
   @override
-  Future<String> createProof({required String htm, required String htu,
-      required DPoPKeyPair keyPair, String? nonce, String? accessToken}) async {
+  Future<String> createProof({
+    required String htm,
+    required String htu,
+    required DPoPKeyPair keyPair,
+    String? nonce,
+    String? accessToken,
+  }) async {
     lastNonce = nonce;
     lastHtu = htu;
     return 'proof';

--- a/packages/atproto_oauth/test/src/types/session_test.dart
+++ b/packages/atproto_oauth/test/src/types/session_test.dart
@@ -6,17 +6,17 @@ import 'package:atproto_oauth/atproto_oauth.dart';
 import 'package:test/test.dart';
 
 OAuthSession _session() => OAuthSession(
-      accessToken: 'access',
-      refreshToken: 'refresh',
-      scope: 'atproto transition:generic',
-      expiresAt: DateTime.utc(2030, 1, 1, 0, 0, 0),
-      sub: 'did:plc:abc',
-      issuer: 'https://bsky.social',
-      pds: 'https://pds.example',
-      clientId: 'https://client.example/client-metadata.json',
-      dpopPublicKey: 'PUB',
-      dpopPrivateKey: 'PRIV',
-    );
+  accessToken: 'access',
+  refreshToken: 'refresh',
+  scope: 'atproto transition:generic',
+  expiresAt: DateTime.utc(2030, 1, 1, 0, 0, 0),
+  sub: 'did:plc:abc',
+  issuer: 'https://bsky.social',
+  pds: 'https://pds.example',
+  clientId: 'https://client.example/client-metadata.json',
+  dpopPublicKey: 'PUB',
+  dpopPrivateKey: 'PRIV',
+);
 
 void main() {
   test('toJson/fromJson round-trips including issuer and pds', () {
@@ -31,9 +31,14 @@ void main() {
 
   test('toJson omits expires_at when null', () {
     final s = OAuthSession(
-      accessToken: 'a', scope: 'atproto', sub: 'did:plc:abc',
-      issuer: 'https://bsky.social', pds: 'https://pds.example',
-      clientId: 'cid', dpopPublicKey: 'PUB', dpopPrivateKey: 'PRIV',
+      accessToken: 'a',
+      scope: 'atproto',
+      sub: 'did:plc:abc',
+      issuer: 'https://bsky.social',
+      pds: 'https://pds.example',
+      clientId: 'cid',
+      dpopPublicKey: 'PUB',
+      dpopPrivateKey: 'PRIV',
     );
     expect(s.toJson().containsKey('expires_at'), isFalse);
     expect(OAuthSession.fromJson(s.toJson()).expiresAt, isNull);
@@ -41,14 +46,22 @@ void main() {
 
   test('fromLegacyJson maps old keys and injects issuer/pds', () {
     final legacy = {
-      'access_token': 'access', 'refresh_token': 'refresh',
-      'token_type': 'DPoP', 'scope': 'atproto',
-      'expires_at': '2030-01-01T00:00:00.000Z', 'sub': 'did:plc:abc',
-      'client_id': 'cid', 'dpop_nonce': 'discard-me',
-      'public_key': 'PUB', 'private_key': 'PRIV',
+      'access_token': 'access',
+      'refresh_token': 'refresh',
+      'token_type': 'DPoP',
+      'scope': 'atproto',
+      'expires_at': '2030-01-01T00:00:00.000Z',
+      'sub': 'did:plc:abc',
+      'client_id': 'cid',
+      'dpop_nonce': 'discard-me',
+      'public_key': 'PUB',
+      'private_key': 'PRIV',
     };
-    final s = OAuthSession.fromLegacyJson(legacy,
-        issuer: 'https://bsky.social', pds: 'https://pds.example');
+    final s = OAuthSession.fromLegacyJson(
+      legacy,
+      issuer: 'https://bsky.social',
+      pds: 'https://pds.example',
+    );
     expect(s.dpopPublicKey, 'PUB');
     expect(s.dpopPrivateKey, 'PRIV');
     expect(s.issuer, 'https://bsky.social');

--- a/packages/bluesky/lib/src/bluesky.dart
+++ b/packages/bluesky/lib/src/bluesky.dart
@@ -241,7 +241,8 @@ final class _Bluesky implements Bluesky {
   core.Session? get session => _ctx.session;
 
   @override
-  oauth.OAuthSessionManager? get oAuthSessionManager => _ctx.oAuthSessionManager;
+  oauth.OAuthSessionManager? get oAuthSessionManager =>
+      _ctx.oAuthSessionManager;
 
   @override
   String get service => _ctx.service;

--- a/packages/bluesky/lib/src/bluesky_chat.dart
+++ b/packages/bluesky/lib/src/bluesky_chat.dart
@@ -173,7 +173,8 @@ final class _BlueskyChat implements BlueskyChat {
   core.Session? get session => _ctx.session;
 
   @override
-  oauth.OAuthSessionManager? get oAuthSessionManager => _ctx.oAuthSessionManager;
+  oauth.OAuthSessionManager? get oAuthSessionManager =>
+      _ctx.oAuthSessionManager;
 
   @override
   String get service => _ctx.service;

--- a/packages/bluesky/lib/src/ozone_tool.dart
+++ b/packages/bluesky/lib/src/ozone_tool.dart
@@ -211,7 +211,8 @@ final class _OzoneTool implements OzoneTool {
   core.Session? get session => _ctx.session;
 
   @override
-  oauth.OAuthSessionManager? get oAuthSessionManager => _ctx.oAuthSessionManager;
+  oauth.OAuthSessionManager? get oAuthSessionManager =>
+      _ctx.oAuthSessionManager;
 
   @override
   String get service => _ctx.service;

--- a/scripts/gen_changelog.dart
+++ b/scripts/gen_changelog.dart
@@ -44,8 +44,10 @@ Map<String, Version> readCurrentVersions() {
     final pubspec = File('${dir.path}/pubspec.yaml');
     if (!pubspec.existsSync()) continue;
     final name = dir.path.split(Platform.pathSeparator).last;
-    final match = RegExp(r'^version:\s*(\S+)', multiLine: true)
-        .firstMatch(pubspec.readAsStringSync());
+    final match = RegExp(
+      r'^version:\s*(\S+)',
+      multiLine: true,
+    ).firstMatch(pubspec.readAsStringSync());
     if (match != null) {
       try {
         versions[name] = Version.parse(match.group(1)!);
@@ -66,7 +68,8 @@ Set<String> directDependencyNames(String pubspecContent) {
   var inDeps = false;
   for (final raw in pubspecContent.split('\n')) {
     // A non-indented, non-blank line starts a new top-level section.
-    final isTopLevel = raw.isNotEmpty && !raw.startsWith(' ') && !raw.startsWith('#');
+    final isTopLevel =
+        raw.isNotEmpty && !raw.startsWith(' ') && !raw.startsWith('#');
     if (isTopLevel) {
       inDeps = raw.trimRight() == 'dependencies:';
       continue;
@@ -107,7 +110,8 @@ String? _argValue(List<String> args, String flag) {
 }
 
 void main(List<String> args) {
-  final base = _argValue(args, '--base') ??
+  final base =
+      _argValue(args, '--base') ??
       Platform.environment['CHANGELOG_BASE_REF'] ??
       'HEAD~1';
 

--- a/scripts/gen_changelog/change_classifier.dart
+++ b/scripts/gen_changelog/change_classifier.dart
@@ -17,8 +17,7 @@ String _ref(LexChange c) {
 ClassifiedChange classify(LexChange change) {
   final ref = _ref(change);
   return switch (change.kind) {
-    LexChangeKind.defAdded ||
-    LexChangeKind.propertyAdded => ClassifiedChange(
+    LexChangeKind.defAdded || LexChangeKind.propertyAdded => ClassifiedChange(
       change: change,
       level: BumpLevel.patch,
       changelogLine: 'feat: added $ref',

--- a/scripts/gen_changelog/change_classifier_test.dart
+++ b/scripts/gen_changelog/change_classifier_test.dart
@@ -7,25 +7,59 @@ import 'change_classifier.dart';
 
 void main() {
   test('property added -> feat/patch', () {
-    final c = classify(const LexChange(nsid: 'app.bsky.feed.post', defName: 'main', field: 'langs', kind: LexChangeKind.propertyAdded));
+    final c = classify(
+      const LexChange(
+        nsid: 'app.bsky.feed.post',
+        defName: 'main',
+        field: 'langs',
+        kind: LexChangeKind.propertyAdded,
+      ),
+    );
     expect(c.level, BumpLevel.patch);
     expect(c.changelogLine, 'feat: added `app.bsky.feed.post.langs`');
   });
 
   test('property removed -> fix!/minor with BREAKING', () {
-    final c = classify(const LexChange(nsid: 'app.bsky.feed.post', defName: 'main', field: 'entities', kind: LexChangeKind.propertyRemoved));
+    final c = classify(
+      const LexChange(
+        nsid: 'app.bsky.feed.post',
+        defName: 'main',
+        field: 'entities',
+        kind: LexChangeKind.propertyRemoved,
+      ),
+    );
     expect(c.level, BumpLevel.minor);
-    expect(c.changelogLine, 'fix!: removed `app.bsky.feed.post.entities` (BREAKING)');
+    expect(
+      c.changelogLine,
+      'fix!: removed `app.bsky.feed.post.entities` (BREAKING)',
+    );
   });
 
   test('non-main def uses #def ref', () {
-    final c = classify(const LexChange(nsid: 'tools.ozone.report.defs', defName: 'reportView', kind: LexChangeKind.defAdded));
+    final c = classify(
+      const LexChange(
+        nsid: 'tools.ozone.report.defs',
+        defName: 'reportView',
+        kind: LexChangeKind.defAdded,
+      ),
+    );
     expect(c.changelogLine, 'feat: added `tools.ozone.report.defs#reportView`');
   });
 
   test('type change includes detail', () {
-    final c = classify(const LexChange(nsid: 'x.y.z', defName: 'main', field: 'a', kind: LexChangeKind.propertyTypeChanged, detail: 'string -> integer'));
+    final c = classify(
+      const LexChange(
+        nsid: 'x.y.z',
+        defName: 'main',
+        field: 'a',
+        kind: LexChangeKind.propertyTypeChanged,
+        detail: 'string -> integer',
+      ),
+    );
     expect(c.level, BumpLevel.minor);
-    expect(c.changelogLine, 'fix!: `x.y.z.a` changed type (string -> integer) (BREAKING)');
+    expect(
+      c.changelogLine,
+      'fix!: `x.y.z.a` changed type (string -> integer) (BREAKING)',
+    );
   });
 }

--- a/scripts/gen_changelog/lexicon_diff.dart
+++ b/scripts/gen_changelog/lexicon_diff.dart
@@ -19,13 +19,17 @@ List<LexChange> diffSnapshots(Snapshot old, Snapshot updated) {
 
     if (oldDefs == null) {
       for (final def in newDefs!.keys) {
-        changes.add(LexChange(nsid: nsid, defName: def, kind: LexChangeKind.defAdded));
+        changes.add(
+          LexChange(nsid: nsid, defName: def, kind: LexChangeKind.defAdded),
+        );
       }
       continue;
     }
     if (newDefs == null) {
       for (final def in oldDefs.keys) {
-        changes.add(LexChange(nsid: nsid, defName: def, kind: LexChangeKind.defRemoved));
+        changes.add(
+          LexChange(nsid: nsid, defName: def, kind: LexChangeKind.defRemoved),
+        );
       }
       continue;
     }
@@ -34,11 +38,22 @@ List<LexChange> diffSnapshots(Snapshot old, Snapshot updated) {
       final oldDef = oldDefs[def];
       final newDef = newDefs[def];
       if (oldDef == null) {
-        changes.add(LexChange(nsid: nsid, defName: def, kind: LexChangeKind.defAdded));
+        changes.add(
+          LexChange(nsid: nsid, defName: def, kind: LexChangeKind.defAdded),
+        );
       } else if (newDef == null) {
-        changes.add(LexChange(nsid: nsid, defName: def, kind: LexChangeKind.defRemoved));
+        changes.add(
+          LexChange(nsid: nsid, defName: def, kind: LexChangeKind.defRemoved),
+        );
       } else {
-        changes.addAll(_diffDef(nsid, def, oldDef as Map<String, dynamic>, newDef as Map<String, dynamic>));
+        changes.addAll(
+          _diffDef(
+            nsid,
+            def,
+            oldDef as Map<String, dynamic>,
+            newDef as Map<String, dynamic>,
+          ),
+        );
       }
     }
   }
@@ -60,44 +75,98 @@ Map<String, dynamic> _schemaOf(Map<String, dynamic> def) {
   return def;
 }
 
-List<LexChange> _diffDef(String nsid, String def, Map<String, dynamic> oldDef, Map<String, dynamic> newDef) {
+List<LexChange> _diffDef(
+  String nsid,
+  String def,
+  Map<String, dynamic> oldDef,
+  Map<String, dynamic> newDef,
+) {
   final changes = <LexChange>[];
   final oldSchema = _schemaOf(oldDef);
   final newSchema = _schemaOf(newDef);
 
-  final oldProps = (oldSchema['properties'] as Map<String, dynamic>?) ?? const {};
-  final newProps = (newSchema['properties'] as Map<String, dynamic>?) ?? const {};
-  final oldRequired = ((oldSchema['required'] as List?) ?? const []).cast<String>().toSet();
-  final newRequired = ((newSchema['required'] as List?) ?? const []).cast<String>().toSet();
+  final oldProps =
+      (oldSchema['properties'] as Map<String, dynamic>?) ?? const {};
+  final newProps =
+      (newSchema['properties'] as Map<String, dynamic>?) ?? const {};
+  final oldRequired = ((oldSchema['required'] as List?) ?? const [])
+      .cast<String>()
+      .toSet();
+  final newRequired = ((newSchema['required'] as List?) ?? const [])
+      .cast<String>()
+      .toSet();
 
   for (final prop in {...oldProps.keys, ...newProps.keys}) {
     final oldProp = oldProps[prop];
     final newProp = newProps[prop];
 
     if (oldProp == null) {
-      changes.add(LexChange(nsid: nsid, defName: def, field: prop, kind: LexChangeKind.propertyAdded));
+      changes.add(
+        LexChange(
+          nsid: nsid,
+          defName: def,
+          field: prop,
+          kind: LexChangeKind.propertyAdded,
+        ),
+      );
       continue;
     }
     if (newProp == null) {
-      changes.add(LexChange(nsid: nsid, defName: def, field: prop, kind: LexChangeKind.propertyRemoved));
+      changes.add(
+        LexChange(
+          nsid: nsid,
+          defName: def,
+          field: prop,
+          kind: LexChangeKind.propertyRemoved,
+        ),
+      );
       continue;
     }
 
     final oldType = _typeSig(oldProp);
     final newType = _typeSig(newProp);
     if (oldType != newType) {
-      changes.add(LexChange(nsid: nsid, defName: def, field: prop, kind: LexChangeKind.propertyTypeChanged, detail: '$oldType -> $newType'));
+      changes.add(
+        LexChange(
+          nsid: nsid,
+          defName: def,
+          field: prop,
+          kind: LexChangeKind.propertyTypeChanged,
+          detail: '$oldType -> $newType',
+        ),
+      );
       continue;
     }
 
     final wasRequired = oldRequired.contains(prop);
     final isRequired = newRequired.contains(prop);
     if (!wasRequired && isRequired) {
-      changes.add(LexChange(nsid: nsid, defName: def, field: prop, kind: LexChangeKind.propertyBecameRequired));
+      changes.add(
+        LexChange(
+          nsid: nsid,
+          defName: def,
+          field: prop,
+          kind: LexChangeKind.propertyBecameRequired,
+        ),
+      );
     } else if (wasRequired && !isRequired) {
-      changes.add(LexChange(nsid: nsid, defName: def, field: prop, kind: LexChangeKind.propertyBecameOptional));
+      changes.add(
+        LexChange(
+          nsid: nsid,
+          defName: def,
+          field: prop,
+          kind: LexChangeKind.propertyBecameOptional,
+        ),
+      );
     } else if (jsonEncode(oldProp) != jsonEncode(newProp)) {
-      changes.add(LexChange(nsid: nsid, defName: def, field: prop, kind: LexChangeKind.metadataChanged));
+      changes.add(
+        LexChange(
+          nsid: nsid,
+          defName: def,
+          field: prop,
+          kind: LexChangeKind.metadataChanged,
+        ),
+      );
     }
   }
   return changes;

--- a/scripts/gen_changelog/lexicon_diff_test.dart
+++ b/scripts/gen_changelog/lexicon_diff_test.dart
@@ -25,45 +25,95 @@ void main() {
     expect(
       changes,
       containsAll([
-        const LexChange(nsid: 'app.bsky.feed.post', defName: 'main', field: 'langs', kind: LexChangeKind.propertyAdded),
-        const LexChange(nsid: 'app.bsky.feed.post', defName: 'main', field: 'entities', kind: LexChangeKind.propertyRemoved),
+        const LexChange(
+          nsid: 'app.bsky.feed.post',
+          defName: 'main',
+          field: 'langs',
+          kind: LexChangeKind.propertyAdded,
+        ),
+        const LexChange(
+          nsid: 'app.bsky.feed.post',
+          defName: 'main',
+          field: 'entities',
+          kind: LexChangeKind.propertyRemoved,
+        ),
       ]),
     );
   });
 
   test('detects optional -> required', () {
     final old = _snap({
-      'x.y.z': '{"main":{"type":"object","required":[],"properties":{"a":{"type":"string"}}}}',
+      'x.y.z':
+          '{"main":{"type":"object","required":[],"properties":{"a":{"type":"string"}}}}',
     });
     final updated = _snap({
-      'x.y.z': '{"main":{"type":"object","required":["a"],"properties":{"a":{"type":"string"}}}}',
+      'x.y.z':
+          '{"main":{"type":"object","required":["a"],"properties":{"a":{"type":"string"}}}}',
     });
     expect(
       diffSnapshots(old, updated),
-      contains(const LexChange(nsid: 'x.y.z', defName: 'main', field: 'a', kind: LexChangeKind.propertyBecameRequired)),
+      contains(
+        const LexChange(
+          nsid: 'x.y.z',
+          defName: 'main',
+          field: 'a',
+          kind: LexChangeKind.propertyBecameRequired,
+        ),
+      ),
     );
   });
 
   test('detects new nsid as defAdded', () {
-    final changes = diffSnapshots({}, _snap({
-      'com.atproto.repo.applyWrites': '{"main":{"type":"procedure"}}',
-    }));
+    final changes = diffSnapshots(
+      {},
+      _snap({'com.atproto.repo.applyWrites': '{"main":{"type":"procedure"}}'}),
+    );
     expect(changes, [
-      const LexChange(nsid: 'com.atproto.repo.applyWrites', defName: 'main', kind: LexChangeKind.defAdded),
+      const LexChange(
+        nsid: 'com.atproto.repo.applyWrites',
+        defName: 'main',
+        kind: LexChangeKind.defAdded,
+      ),
     ]);
   });
 
   test('detects type change', () {
-    final old = _snap({'x.y.z': '{"main":{"type":"object","properties":{"a":{"type":"string"}}}}'});
-    final updated = _snap({'x.y.z': '{"main":{"type":"object","properties":{"a":{"type":"integer"}}}}'});
+    final old = _snap({
+      'x.y.z':
+          '{"main":{"type":"object","properties":{"a":{"type":"string"}}}}',
+    });
+    final updated = _snap({
+      'x.y.z':
+          '{"main":{"type":"object","properties":{"a":{"type":"integer"}}}}',
+    });
     expect(
       diffSnapshots(old, updated),
-      contains(const LexChange(nsid: 'x.y.z', defName: 'main', field: 'a', kind: LexChangeKind.propertyTypeChanged, detail: 'string -> integer')),
+      contains(
+        const LexChange(
+          nsid: 'x.y.z',
+          defName: 'main',
+          field: 'a',
+          kind: LexChangeKind.propertyTypeChanged,
+          detail: 'string -> integer',
+        ),
+      ),
     );
   });
 
   test('no change yields empty list', () {
-    final s = _snap({'x.y.z': '{"main":{"type":"object","properties":{"a":{"type":"string"}}}}'});
-    expect(diffSnapshots(s, _snap({'x.y.z': '{"main":{"type":"object","properties":{"a":{"type":"string"}}}}'})), isEmpty);
+    final s = _snap({
+      'x.y.z':
+          '{"main":{"type":"object","properties":{"a":{"type":"string"}}}}',
+    });
+    expect(
+      diffSnapshots(
+        s,
+        _snap({
+          'x.y.z':
+              '{"main":{"type":"object","properties":{"a":{"type":"string"}}}}',
+        }),
+      ),
+      isEmpty,
+    );
   });
 }

--- a/scripts/gen_changelog/lexicon_snapshot_test.dart
+++ b/scripts/gen_changelog/lexicon_snapshot_test.dart
@@ -17,7 +17,8 @@ void main() {
     final snap = parseSnapshot({
       'bad.json': 'not json',
       'nodefs.json': '{"id":"x.y.z"}',
-      'ok.json': '{"id":"com.atproto.repo.createRecord","defs":{"main":{"type":"query"}}}',
+      'ok.json':
+          '{"id":"com.atproto.repo.createRecord","defs":{"main":{"type":"query"}}}',
     });
     expect(snap.keys, ['com.atproto.repo.createRecord']);
   });

--- a/scripts/gen_changelog/version_planner.dart
+++ b/scripts/gen_changelog/version_planner.dart
@@ -65,21 +65,27 @@ Map<String, PackagePlan> planVersions({
         } else if (draft.depRangeUpdates[pkg] != producer.newVersion) {
           // Producer version rose during propagation; refresh the recorded range.
           draft.depRangeUpdates[pkg] = producer.newVersion;
-          final idx = draft.lines.indexWhere((l) => l.startsWith('chore: bump `$pkg` to '));
-          if (idx >= 0) draft.lines[idx] = 'chore: bump `$pkg` to `^${producer.newVersion}`';
+          final idx = draft.lines.indexWhere(
+            (l) => l.startsWith('chore: bump `$pkg` to '),
+          );
+          if (idx >= 0)
+            draft.lines[idx] =
+                'chore: bump `$pkg` to `^${producer.newVersion}`';
         }
       }
     }
   }
 
-  return drafts.map((pkg, d) => MapEntry(
-        pkg,
-        PackagePlan(
-          package: pkg,
-          oldVersion: d.oldVersion,
-          newVersion: d.newVersion,
-          changelogLines: d.lines,
-          depRangeUpdates: d.depRangeUpdates,
-        ),
-      ));
+  return drafts.map(
+    (pkg, d) => MapEntry(
+      pkg,
+      PackagePlan(
+        package: pkg,
+        oldVersion: d.oldVersion,
+        newVersion: d.newVersion,
+        changelogLines: d.lines,
+        depRangeUpdates: d.depRangeUpdates,
+      ),
+    ),
+  );
 }

--- a/scripts/gen_changelog/version_planner_test.dart
+++ b/scripts/gen_changelog/version_planner_test.dart
@@ -7,31 +7,55 @@ import 'semver.dart';
 import 'version_planner.dart';
 
 ClassifiedChange _c(BumpLevel level, String line) => ClassifiedChange(
-      change: const LexChange(nsid: 'x.y.z', defName: 'main', kind: LexChangeKind.defAdded),
-      level: level,
-      changelogLine: line,
-    );
+  change: const LexChange(
+    nsid: 'x.y.z',
+    defName: 'main',
+    kind: LexChangeKind.defAdded,
+  ),
+  level: level,
+  changelogLine: line,
+);
 
 void main() {
   test('patch bump for additions and trailing regenerated line', () {
     final plans = planVersions(
       changesByPackage: {
-        'atproto': [_c(BumpLevel.patch, 'feat: added `com.atproto.repo.applyWrites`')],
+        'atproto': [
+          _c(BumpLevel.patch, 'feat: added `com.atproto.repo.applyWrites`'),
+        ],
       },
-      currentVersions: {'atproto': Version.parse('1.7.0'), 'bluesky': Version.parse('1.7.1'), 'bluesky_cli': Version.parse('0.6.0')},
-      dependents: {'atproto': ['bluesky'], 'bluesky': ['bluesky_cli']},
+      currentVersions: {
+        'atproto': Version.parse('1.7.0'),
+        'bluesky': Version.parse('1.7.1'),
+        'bluesky_cli': Version.parse('0.6.0'),
+      },
+      dependents: {
+        'atproto': ['bluesky'],
+        'bluesky': ['bluesky_cli'],
+      },
     );
     expect(plans['atproto']!.newVersion.toString(), '1.7.1');
-    expect(plans['atproto']!.changelogLines.last, 'chore: regenerated from synced lexicons');
+    expect(
+      plans['atproto']!.changelogLines.last,
+      'chore: regenerated from synced lexicons',
+    );
   });
 
   test('minor bump when a breaking change is present', () {
     final plans = planVersions(
       changesByPackage: {
-        'bluesky': [_c(BumpLevel.patch, 'feat: added `app.bsky.a`'), _c(BumpLevel.minor, 'fix!: removed `app.bsky.b` (BREAKING)')],
+        'bluesky': [
+          _c(BumpLevel.patch, 'feat: added `app.bsky.a`'),
+          _c(BumpLevel.minor, 'fix!: removed `app.bsky.b` (BREAKING)'),
+        ],
       },
-      currentVersions: {'bluesky': Version.parse('1.7.1'), 'bluesky_cli': Version.parse('0.6.0')},
-      dependents: {'bluesky': ['bluesky_cli']},
+      currentVersions: {
+        'bluesky': Version.parse('1.7.1'),
+        'bluesky_cli': Version.parse('0.6.0'),
+      },
+      dependents: {
+        'bluesky': ['bluesky_cli'],
+      },
     );
     expect(plans['bluesky']!.newVersion.toString(), '1.8.0');
   });
@@ -41,24 +65,45 @@ void main() {
       changesByPackage: {
         'atproto': [_c(BumpLevel.patch, 'feat: added `com.atproto.x`')],
       },
-      currentVersions: {'atproto': Version.parse('1.7.0'), 'bluesky': Version.parse('1.7.1'), 'bluesky_cli': Version.parse('0.6.0')},
-      dependents: {'atproto': ['bluesky'], 'bluesky': ['bluesky_cli']},
+      currentVersions: {
+        'atproto': Version.parse('1.7.0'),
+        'bluesky': Version.parse('1.7.1'),
+        'bluesky_cli': Version.parse('0.6.0'),
+      },
+      dependents: {
+        'atproto': ['bluesky'],
+        'bluesky': ['bluesky_cli'],
+      },
     );
     expect(plans['bluesky']!.newVersion.toString(), '1.7.2');
     expect(plans['bluesky']!.depRangeUpdates['atproto']!.toString(), '1.7.1');
-    expect(plans['bluesky']!.changelogLines, contains('chore: bump `atproto` to `^1.7.1`'));
+    expect(
+      plans['bluesky']!.changelogLines,
+      contains('chore: bump `atproto` to `^1.7.1`'),
+    );
     expect(plans['bluesky_cli']!.newVersion.toString(), '0.6.1');
-    expect(plans['bluesky_cli']!.changelogLines, contains('chore: bump `bluesky` to `^1.7.2`'));
+    expect(
+      plans['bluesky_cli']!.changelogLines,
+      contains('chore: bump `bluesky` to `^1.7.2`'),
+    );
   });
 
   test('deduplicates identical changelog lines', () {
     final plans = planVersions(
       changesByPackage: {
-        'atproto': [_c(BumpLevel.patch, 'feat: added `com.atproto.x`'), _c(BumpLevel.patch, 'feat: added `com.atproto.x`')],
+        'atproto': [
+          _c(BumpLevel.patch, 'feat: added `com.atproto.x`'),
+          _c(BumpLevel.patch, 'feat: added `com.atproto.x`'),
+        ],
       },
       currentVersions: {'atproto': Version.parse('1.7.0')},
       dependents: {},
     );
-    expect(plans['atproto']!.changelogLines.where((l) => l == 'feat: added `com.atproto.x`').length, 1);
+    expect(
+      plans['atproto']!.changelogLines
+          .where((l) => l == 'feat: added `com.atproto.x`')
+          .length,
+      1,
+    );
   });
 }

--- a/scripts/gen_changelog/writer.dart
+++ b/scripts/gen_changelog/writer.dart
@@ -18,7 +18,9 @@ String bumpPubspec(String content, PackagePlan plan) {
       continue;
     }
     for (final dep in plan.depRangeUpdates.entries) {
-      final match = RegExp('^(\\s+)${RegExp.escape(dep.key)}:\\s*\\^').firstMatch(line);
+      final match = RegExp(
+        '^(\\s+)${RegExp.escape(dep.key)}:\\s*\\^',
+      ).firstMatch(line);
       if (match != null) {
         lines[i] = '${match.group(1)}${dep.key}: ^${dep.value}';
       }
@@ -48,7 +50,9 @@ String insertChangelog(String content, PackagePlan plan) {
     return '$body$content';
   }
   final insertAt = idx + marker.length;
-  return content.substring(0, insertAt) + body.toString() + content.substring(insertAt);
+  return content.substring(0, insertAt) +
+      body.toString() +
+      content.substring(insertAt);
 }
 
 /// Applies [plan] to the package's pubspec and changelog on disk.
@@ -57,5 +61,7 @@ void applyPlan(PackagePlan plan) {
   pubspec.writeAsStringSync(bumpPubspec(pubspec.readAsStringSync(), plan));
 
   final changelog = File('packages/${plan.package}/CHANGELOG.md');
-  changelog.writeAsStringSync(insertChangelog(changelog.readAsStringSync(), plan));
+  changelog.writeAsStringSync(
+    insertChangelog(changelog.readAsStringSync(), plan),
+  );
 }

--- a/scripts/gen_changelog/writer_test.dart
+++ b/scripts/gen_changelog/writer_test.dart
@@ -7,16 +7,21 @@ import 'semver.dart';
 import 'writer.dart';
 
 PackagePlan _plan() => PackagePlan(
-      package: 'bluesky',
-      oldVersion: Version.parse('1.7.1'),
-      newVersion: Version.parse('1.7.2'),
-      changelogLines: const ['feat: added `app.bsky.feed.post.langs`', 'chore: bump `atproto` to `^1.7.1`', 'chore: regenerated from synced lexicons'],
-      depRangeUpdates: {'atproto': Version.parse('1.7.1')},
-    );
+  package: 'bluesky',
+  oldVersion: Version.parse('1.7.1'),
+  newVersion: Version.parse('1.7.2'),
+  changelogLines: const [
+    'feat: added `app.bsky.feed.post.langs`',
+    'chore: bump `atproto` to `^1.7.1`',
+    'chore: regenerated from synced lexicons',
+  ],
+  depRangeUpdates: {'atproto': Version.parse('1.7.1')},
+);
 
 void main() {
   test('bumpPubspec rewrites version and dep range', () {
-    const pubspec = 'name: bluesky\nversion: 1.7.1\ndependencies:\n  atproto: ^1.7.0\n  http: ^1.4.0\n';
+    const pubspec =
+        'name: bluesky\nversion: 1.7.1\ndependencies:\n  atproto: ^1.7.0\n  http: ^1.4.0\n';
     final out = bumpPubspec(pubspec, _plan());
     expect(out, contains('version: 1.7.2'));
     expect(out, contains('  atproto: ^1.7.1'));

--- a/scripts/gen_changelog_test.dart
+++ b/scripts/gen_changelog_test.dart
@@ -32,8 +32,10 @@ void main() {
       },
     );
     expect(plans['bluesky']!.newVersion.toString(), '1.7.2');
-    expect(plans['bluesky']!.changelogLines,
-        contains('feat: added `app.bsky.feed.post.langs`'));
+    expect(
+      plans['bluesky']!.changelogLines,
+      contains('feat: added `app.bsky.feed.post.langs`'),
+    );
     expect(plans['bluesky_cli']!.newVersion.toString(), '0.6.1');
   });
 
@@ -47,8 +49,10 @@ void main() {
     expect(plans, isEmpty);
   });
 
-  test('directDependencyNames reads dependencies: only, not dev_dependencies:', () {
-    const pubspec = '''
+  test(
+    'directDependencyNames reads dependencies: only, not dev_dependencies:',
+    () {
+      const pubspec = '''
 name: bluesky_text
 version: 1.5.0
 
@@ -60,11 +64,12 @@ dev_dependencies:
   bluesky: ^1.7.0
   test: ^1.26.2
 ''';
-    final names = directDependencyNames(pubspec);
-    expect(names, containsAll(['xrpc', 'http']));
-    expect(names, isNot(contains('bluesky')));
-    expect(names, isNot(contains('test')));
-  });
+      final names = directDependencyNames(pubspec);
+      expect(names, containsAll(['xrpc', 'http']));
+      expect(names, isNot(contains('bluesky')));
+      expect(names, isNot(contains('test')));
+    },
+  );
 
   test('directDependencyNames skips path dependencies', () {
     const pubspec = '''


### PR DESCRIPTION
The per-package `dart format --set-exit-if-changed` CI check is failing on `atproto` / `atproto_core` / `atproto_oauth` / `bluesky` (and `scripts/gen_changelog`) because 28 files merged to `main` (from the OAuth and changelog-automation work) were left unformatted.

This PR runs `dart format .` over the workspace. **Format-only, no logic changes.** Unblocks CI for all open PRs built on current `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)