### PR TITLE
fix(ci): run build_runner in Verify Generated; guard codegen tool bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,6 +28,21 @@ updates:
       pub-dependencies:
         patterns:
           - "*"
+    ignore:
+      # Codegen toolchain: a MAJOR bump changes the generated `.freezed.dart` /
+      # `.g.dart` output, which requires regenerating and committing all sources
+      # (Verify Generated will fail otherwise). Keep these updates in human
+      # hands; minor/patch updates still flow through.
+      - dependency-name: "freezed"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "freezed_annotation"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "build_runner"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "json_serializable"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "json_annotation"
+        update-types: ["version-update:semver-major"]
 
   # --- Dart/Flutter pub (bluesky_text_flutter) ----------------------------
   # bluesky_text_flutter is a Flutter package that lives OUTSIDE the Dart pub

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,8 +9,12 @@ on:
       - "pubspec.yaml"
       - "pubspec.lock"
       - "analysis_options.yaml"
-      - ".github/workflows/test.yml"
-      - ".github/actions/setup-dart-cached/**"
+      # Any CI/infra change runs the suite too, so the required `ci-ok` check is
+      # always produced (otherwise a `.github`-only PR is blocked forever waiting
+      # for a check that never fires). When no package is affected the `changes`
+      # job yields an empty matrix, so only the cheap `format-analyze` + `ci-ok`
+      # jobs run.
+      - ".github/**"
 
 # Cancel superseded runs for the same ref (e.g. rapid pushes to a PR branch).
 concurrency:

--- a/.github/workflows/verify_generated.yml
+++ b/.github/workflows/verify_generated.yml
@@ -3,11 +3,18 @@ name: Verify Generated
 on:
   workflow_dispatch:
   pull_request:
+    # Only the inputs to code generation can change the committed output, so we
+    # gate on those rather than every `lib/**` edit (running the full pipeline
+    # below is expensive). `pubspec.yaml` files are included because a bump to a
+    # codegen tool (freezed, build_runner, json_serializable, ...) changes the
+    # generated sources too.
     paths:
-      - "packages/*/lib/**"
       - "lexicons/**"
       - "packages/lex_gen/**"
       - "scripts/gen_*.dart"
+      - "packages/*/pubspec.yaml"
+      - "pubspec.yaml"
+      - ".github/workflows/verify_generated.yml"
 
 concurrency:
   group: verify-generated-${{ github.ref }}
@@ -27,21 +34,32 @@ jobs:
       # `dart pub get` at the repo root.
       - uses: ./.github/actions/setup-dart-cached
 
-      - name: Regenerate codegen sources
-        # Reproduce the committed generated output: run gen_codes then format
-        # the three codegen dirs. This mirrors Tier A of
-        # scripts/verify_gen_unchanged.sh, but instead of comparing against a
-        # separately captured baseline, we assert `git diff` against the
-        # committed tree (HEAD) is empty. That avoids the two-step
-        # baseline/check dance in CI and is equivalent for a PR gate: the
-        # checked-out tree already IS the reference, so any drift, hand-edit,
-        # or non-deterministic generation surfaces as a diff.
+      - name: Regenerate codegen sources (full pipeline)
+        # Reproduce the committed generated output exactly. This MUST mirror the
+        # real generation pipeline (see the `Generate`/`Build`/`Format` steps of
+        # sync_and_generate.yml and the melos `gen` script), because the three
+        # steps are interdependent:
+        #   1. gen_codes wipes the codegen dirs and emits the hand-authored
+        #      `.dart` part files (but not `.freezed.dart` / `.g.dart`).
+        #   2. build_runner (freezed + json_serializable) emits the
+        #      `.freezed.dart` / `.g.dart` parts.
+        #   3. `dart fix --apply` removes now-unused imports -- which it can only
+        #      do once the code COMPILES, i.e. after build_runner has produced
+        #      the parts. Skipping build_runner leaves the tree uncompilable and
+        #      dart fix cannot converge, so the output never matches HEAD.
+        # import_sorter + `dart format` then normalise imports and layout.
         run: |
           dart run ./scripts/gen_codes.dart
-          dart format \
-            packages/atproto/lib/src/services/codegen \
-            packages/bluesky/lib/src/services/codegen \
-            packages/bluesky_cli/lib/src/commands/codegen
+          (cd packages/atproto && dart run build_runner build --delete-conflicting-outputs)
+          (cd packages/bluesky && dart run build_runner build --delete-conflicting-outputs)
+          for package in lexicon atproto bluesky bluesky_cli; do
+            (
+              cd "packages/$package"
+              dart fix --apply
+              dart run import_sorter:main
+              dart format .
+            )
+          done
 
       - name: Assert generated sources are unchanged
         run: |
@@ -58,5 +76,7 @@ jobs:
             git diff --stat -- "${CODEGEN_DIRS[@]}"
             echo ""
             echo "Run 'melos gen' locally and commit the regenerated sources."
+            echo "(If a codegen tool such as freezed was bumped, the generated"
+            echo " output legitimately changed and must be regenerated + committed.)"
             exit 1
           fi


### PR DESCRIPTION
## Problem (surfaced by #2455)

The `Verify Generated` gate ran only `gen_codes.dart` + `dart format`. But `gen_codes` **wipes** the codegen dirs and emits only the hand-authored `.dart` part files — the `.freezed.dart` / `.g.dart` parts are produced by **build_runner**, which the job never ran. Consequences:

- With the `part` targets missing, the tree does not compile, so `dart fix --apply` cannot drop now-unused imports → the regenerated `.dart` never matches HEAD either.
- The job reported ~2000 files of spurious "drift" (mass deletions of `.freezed.dart` / `.g.dart`) on **any** codegen-touching PR. It had simply never triggered until Dependabot PR #2455 bumped `packages/lex_gen/pubspec.yaml` and hit the path filter for the first time.

Root cause confirmed locally: `gen_codes.dart` takes the two codegen dirs from **2028 → 0** `.freezed/.g` files.

## Fix

- `Verify Generated` now runs the **full pipeline** — `gen_codes → build_runner (atproto, bluesky) → dart fix → import_sorter → dart format` — mirroring `sync_and_generate.yml`, then asserts the three codegen dirs are byte-identical to HEAD. **Verified locally to converge to an empty diff.**
- Triggers narrowed to generation inputs + `pubspec.yaml` (codegen tool versions). The full pipeline is expensive, and hand-written `lib/**` edits cannot change generated output, so gating on every `lib/**` change was wasteful.
- `dependabot.yml`: **ignore MAJOR bumps** of the codegen toolchain (`freezed`, `freezed_annotation`, `build_runner`, `json_serializable`, `json_annotation`). A major bump changes generated output and must be regenerated + committed by hand — exactly what broke in #2455 (`freezed 3.2.0 → 4.0.0-dev.3`). Minor/patch updates still flow.

## Note on #2455

With this in place, `Verify Generated` failing on a freezed-major bump is **correct behavior**, not a false positive: the generated output genuinely changes. #2455 will be closed; the ignore rule keeps future codegen-tool majors in human hands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)