### PR TITLE
feat(feed_generator): runnable custom feed generator template (server + publisher)

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,6 +19,7 @@ workspace:
   - packages/lexicon
   - packages/multiformats
   - packages/xrpc
+  - templates/feed_generator
 
 dependencies:
   github: ^9.12.0

--- a/templates/feed_generator/LICENSE
+++ b/templates/feed_generator/LICENSE
@@ -1,0 +1,28 @@
+BSD 3-Clause License
+
+Copyright (c) 2023-2026, Shinya Kato
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/templates/feed_generator/README.md
+++ b/templates/feed_generator/README.md
@@ -39,6 +39,8 @@ control:
 
 The `serviceDid` is derived from the hostname as `did:web:<hostname>`, and that
 host must serve the document at `/.well-known/did.json` over HTTPS.
+`FEEDGEN_HOSTNAME` must be a **bare hostname with no port or scheme** (run behind
+TLS on 443) — a `did:web` built from a `host:port` is malformed.
 
 ```bash
 export FEEDGEN_HOSTNAME=feed.example.com

--- a/templates/feed_generator/README.md
+++ b/templates/feed_generator/README.md
@@ -1,34 +1,56 @@
 # Feed Generator Template
 
-A clone-and-edit template for building a Bluesky custom feed generator using the atproto.dart monorepo.
+A clone-and-edit template for building a Bluesky custom feed generator with the
+atproto.dart monorepo.
 
 ## Overview
 
-This template provides a minimal, working feed generator that indexes posts and serves them via a Bluesky feed. It includes:
+A feed generator is a small HTTP service that Bluesky's AppView calls to get an
+ordered list of post URIs (a "skeleton"). This template ships a complete,
+runnable one:
 
-- A `FeedGeneratorConfig` class for configuration (hostname, DID, credentials, etc.)
-- A server skeleton for hosting the feed generator service
-- Integration with the `bluesky` and `atproto_identity` packages
+- **`bin/server.dart`** — serves the three endpoints AppView needs
+  (`/.well-known/did.json`, `app.bsky.feed.describeFeedGenerator`,
+  `app.bsky.feed.getFeedSkeleton`) and verifies the inbound service-auth JWT via
+  `atproto_identity`.
+- **`bin/publish_feed.dart`** — registers the feed on the network by writing an
+  `app.bsky.feed.generator` record.
+- A firehose **indexer** (`lib/src/indexer/`) that ingests new posts.
+- A **`FeedAlgorithm`** interface with a reverse-chronological sample
+  (`whats_hot_algorithm.dart`) — replace its body with your ranking.
+- A **`FeedStore`** interface with an in-memory implementation — swap it for a
+  database in production.
 
 ## Configuration
 
-Edit `lib/src/config.dart` to set your deployment parameters:
+Configuration is read from environment variables (see
+`FeedGeneratorConfig.fromEnvironment`) so credentials never live in source
+control:
 
-```dart
-const config = FeedGeneratorConfig(
-  hostname: 'feed.example.com',
-  feedRecordKey: 'whats-hot',
-  feedDisplayName: 'What\'s Hot',
-  publisherHandle: 'handle.bsky.social',
-  publisherPassword: 'password',
-);
+| Variable                     | Required | Default      | Notes                                   |
+| ---------------------------- | -------- | ------------ | --------------------------------------- |
+| `FEEDGEN_HOSTNAME`           | yes      | —            | Public host, e.g. `feed.example.com`.   |
+| `FEEDGEN_PUBLISHER_HANDLE`   | yes      | —            | Account that publishes the feed record. |
+| `FEEDGEN_PUBLISHER_PASSWORD` | yes      | —            | An app password for that account.       |
+| `FEEDGEN_RECORD_KEY`         | no       | `whats-hot`  | Record key under `feed.generator`.      |
+| `FEEDGEN_DISPLAY_NAME`       | no       | `What's Hot` | Shown in the app.                       |
+| `FEEDGEN_DESCRIPTION`        | no       | —            | Optional feed description.              |
+| `FEEDGEN_PORT`               | no       | `3000`       | Port the server listens on.             |
+
+The `serviceDid` is derived from the hostname as `did:web:<hostname>`, and that
+host must serve the document at `/.well-known/did.json` over HTTPS.
+
+```bash
+export FEEDGEN_HOSTNAME=feed.example.com
+export FEEDGEN_PUBLISHER_HANDLE=handle.bsky.social
+export FEEDGEN_PUBLISHER_PASSWORD=xxxx-xxxx-xxxx-xxxx
 ```
 
-The `serviceDid` is derived from the hostname as `did:web:<hostname>`.
+You can also construct `FeedGeneratorConfig` directly if you prefer.
 
 ## Running the Feed Generator
 
-Start the indexer and server:
+Start the indexer and HTTP server:
 
 ```bash
 dart run bin/server.dart
@@ -36,7 +58,8 @@ dart run bin/server.dart
 
 ## Publishing the Feed
 
-Create and publish your feed record to the Bluesky network:
+Register (or update) the feed record so it becomes discoverable on the network.
+Safe to re-run:
 
 ```bash
 dart run bin/publish_feed.dart
@@ -44,14 +67,16 @@ dart run bin/publish_feed.dart
 
 ## Replacing the In-Memory Store
 
-By default, this template uses an in-memory store. For production use, implement the `FeedStore` interface and swap it in the server initialization code.
+By default this template keeps indexed posts in memory. For production,
+implement the `FeedStore` interface with a real database and construct it in
+`bin/server.dart`.
 
 ## Standalone Usage
 
 To use this template outside the monorepo:
-1. Remove the `resolution: workspace` line from `pubspec.yaml`
-2. Update dependency versions to published releases (e.g., `bluesky: ^2.0.0`)
-3. Run `dart pub get` to resolve packages from pub.dev
+
+1. Remove the `resolution: workspace` line from `pubspec.yaml`.
+2. Run `dart pub get` to resolve packages from pub.dev.
 
 ## License
 

--- a/templates/feed_generator/README.md
+++ b/templates/feed_generator/README.md
@@ -1,0 +1,58 @@
+# Feed Generator Template
+
+A clone-and-edit template for building a Bluesky custom feed generator using the atproto.dart monorepo.
+
+## Overview
+
+This template provides a minimal, working feed generator that indexes posts and serves them via a Bluesky feed. It includes:
+
+- A `FeedGeneratorConfig` class for configuration (hostname, DID, credentials, etc.)
+- A server skeleton for hosting the feed generator service
+- Integration with the `bluesky` and `atproto_identity` packages
+
+## Configuration
+
+Edit `lib/src/config.dart` to set your deployment parameters:
+
+```dart
+const config = FeedGeneratorConfig(
+  hostname: 'feed.example.com',
+  feedRecordKey: 'whats-hot',
+  feedDisplayName: 'What\'s Hot',
+  publisherHandle: 'handle.bsky.social',
+  publisherPassword: 'password',
+);
+```
+
+The `serviceDid` is derived from the hostname as `did:web:<hostname>`.
+
+## Running the Feed Generator
+
+Start the indexer and server:
+
+```bash
+dart run bin/server.dart
+```
+
+## Publishing the Feed
+
+Create and publish your feed record to the Bluesky network:
+
+```bash
+dart run bin/publish_feed.dart
+```
+
+## Replacing the In-Memory Store
+
+By default, this template uses an in-memory store. For production use, implement the `FeedStore` interface and swap it in the server initialization code.
+
+## Standalone Usage
+
+To use this template outside the monorepo:
+1. Remove the `resolution: workspace` line from `pubspec.yaml`
+2. Update dependency versions to published releases (e.g., `bluesky: ^2.0.0`)
+3. Run `dart pub get` to resolve packages from pub.dev
+
+## License
+
+BSD-3-Clause (see LICENSE file)

--- a/templates/feed_generator/analysis_options.yaml
+++ b/templates/feed_generator/analysis_options.yaml
@@ -1,0 +1,58 @@
+# Analysis options for atproto.dart monorepo
+# Optimized for maintainability while keeping code quality high
+
+include: package:lints/recommended.yaml
+
+analyzer:
+  exclude:
+    - "**/*.freezed.dart"
+    - "**/*.g.dart"
+  errors:
+    # Allow invalid annotation targets (common in generated code)
+    invalid_annotation_target: ignore
+    # Relax some rules that are too strict for this codebase
+    lines_longer_than_80_chars: info
+    prefer_relative_imports: info
+    # Keep important errors as errors
+    missing_return: error
+    dead_code: error
+
+linter:
+  rules:
+    # Core quality rules - keep these strict
+    - avoid_null_checks_in_equality_operators
+    - avoid_unused_constructor_parameters
+    - await_only_futures
+    - cancel_subscriptions
+    - control_flow_in_finally
+    - empty_statements
+    - hash_and_equals
+    - implementation_imports
+    - collection_methods_unrelated_type
+    - test_types_in_equals
+    - throw_in_finally
+    - unrelated_type_equality_checks
+    
+    # Naming conventions - important for API consistency
+    - camel_case_types
+    - constant_identifier_names
+    - library_names
+    - library_prefixes
+    - non_constant_identifier_names
+    - package_names
+    - package_prefixed_library_names
+    
+    # Code style - helpful but not overly strict
+    - prefer_final_fields
+    - prefer_generic_function_type_aliases
+    - prefer_typing_uninitialized_variables
+    - unnecessary_brace_in_string_interps
+    
+    # Documentation - important for public APIs
+    # package_api_docs (removed in Dart 3.7.0+)
+
+    # Import organization - relaxed to info level
+    - prefer_relative_imports
+    
+    # Line length - relaxed for generated code and long URLs/descriptions
+    # Note: This is handled at error level above as 'info'

--- a/templates/feed_generator/bin/publish_feed.dart
+++ b/templates/feed_generator/bin/publish_feed.dart
@@ -1,0 +1,39 @@
+// Copyright (c) 2023-2026, Shinya Kato.
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:bluesky/atproto.dart';
+import 'package:bluesky/bluesky.dart';
+import 'package:feed_generator/src/config.dart';
+
+/// Publishes (or updates) this feed generator's `app.bsky.feed.generator`
+/// record in the publisher's repo, so the feed becomes discoverable on the
+/// network. Idempotent: safe to re-run after changing the display name or
+/// description. Configure it via the same `FEEDGEN_*` environment variables as
+/// the server.
+Future<void> main() async {
+  final config = FeedGeneratorConfig.fromEnvironment();
+
+  final session = await createSession(
+    service: 'bsky.social',
+    identifier: config.publisherHandle,
+    password: config.publisherPassword,
+  );
+  final bsky = Bluesky.fromSession(session.data);
+
+  await bsky.feed.generator.put(
+    rkey: config.feedRecordKey,
+    // The service DID tells the network which host serves this feed's
+    // skeleton (this must match the did:web document served at /.well-known).
+    did: config.serviceDid,
+    displayName: config.feedDisplayName,
+    description: config.feedDescription,
+  );
+
+  final feedUri =
+      'at://${session.data.did}/app.bsky.feed.generator/${config.feedRecordKey}';
+  stdout.writeln('published feed record: $feedUri');
+  stdout.writeln('served by: ${config.serviceDid}');
+}

--- a/templates/feed_generator/bin/server.dart
+++ b/templates/feed_generator/bin/server.dart
@@ -42,13 +42,23 @@ Future<void> main() async {
     );
   }
 
-  // Start indexing the firehose in the background.
-  unawaited(FirehoseIndexer(store).start());
+  // Start indexing the firehose in the background. If the initial connection
+  // fails, log it instead of leaving an unhandled async error; the server keeps
+  // serving (an empty feed until indexing recovers).
+  unawaited(
+    FirehoseIndexer(store).start().catchError(
+      (Object e) => stderr.writeln('firehose indexer failed to start: $e'),
+    ),
+  );
 
   final handler = createFeedGeneratorHandler(
     config: config,
     algorithm: algorithm,
     feedUri: feedUri,
+    // Enforcing `lxm` binds each service-auth JWT to this one method, so a token
+    // minted for another endpoint cannot be replayed here. Current AppView
+    // always sends it; pass `expectedLxm: null` only if you must accept tokens
+    // that omit the claim.
     verifyAuth: (authorizationHeader) => verifyServiceAuth(
       authorizationHeader,
       serviceDid: config.serviceDid,

--- a/templates/feed_generator/bin/server.dart
+++ b/templates/feed_generator/bin/server.dart
@@ -1,0 +1,69 @@
+// Copyright (c) 2023-2026, Shinya Kato.
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:atproto_identity/atproto_identity.dart';
+import 'package:feed_generator/src/algorithm/whats_hot_algorithm.dart';
+import 'package:feed_generator/src/config.dart';
+import 'package:feed_generator/src/indexer/firehose_indexer.dart';
+import 'package:feed_generator/src/server/feed_generator_service.dart';
+import 'package:feed_generator/src/store/in_memory_feed_store.dart';
+import 'package:shelf/shelf_io.dart' as shelf_io;
+
+/// Runs the feed generator: starts the firehose indexer and serves the three
+/// AppView-facing endpoints. Configure it via the `FEEDGEN_*` environment
+/// variables consumed by [FeedGeneratorConfig.fromEnvironment].
+Future<void> main() async {
+  final config = FeedGeneratorConfig.fromEnvironment();
+
+  // The store the indexer writes to and the algorithm reads from. Swap
+  // InMemoryFeedStore for a database-backed FeedStore in production.
+  final store = InMemoryFeedStore();
+  final algorithm = WhatsHotAlgorithm(store);
+
+  // Verifies the AppView's inbound service-auth JWT against the issuer's
+  // #atproto signing key resolved from its DID document.
+  final resolver = HttpIdentityResolver();
+
+  // Best-effort: advertise the published feed's AT-URI in
+  // describeFeedGenerator. Not fatal if the handle cannot be resolved yet.
+  String? feedUri;
+  try {
+    final publisher = await resolver.resolve(config.publisherHandle);
+    feedUri =
+        'at://${publisher.did}/app.bsky.feed.generator/${config.feedRecordKey}';
+  } catch (e) {
+    stderr.writeln(
+      'warning: could not resolve "${config.publisherHandle}" for '
+      'describeFeedGenerator ($e); advertising no feeds',
+    );
+  }
+
+  // Start indexing the firehose in the background.
+  unawaited(FirehoseIndexer(store).start());
+
+  final handler = createFeedGeneratorHandler(
+    config: config,
+    algorithm: algorithm,
+    feedUri: feedUri,
+    verifyAuth: (authorizationHeader) => verifyServiceAuth(
+      authorizationHeader,
+      serviceDid: config.serviceDid,
+      resolver: resolver,
+      expectedLxm: feedSkeletonLxm,
+    ),
+  );
+
+  final server = await shelf_io.serve(
+    handler,
+    InternetAddress.anyIPv4,
+    config.port,
+  );
+  stdout.writeln(
+    'feed generator (${config.serviceDid}) listening on '
+    'http://${server.address.host}:${server.port}',
+  );
+}

--- a/templates/feed_generator/lib/src/algorithm/feed_algorithm.dart
+++ b/templates/feed_generator/lib/src/algorithm/feed_algorithm.dart
@@ -1,0 +1,19 @@
+// Copyright (c) 2023-2026, Shinya Kato.
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:bluesky/app_bsky_feed_getfeedskeleton.dart';
+
+/// A parsed getFeedSkeleton request. [viewerDid] is set by the server after
+/// verifying the AppView's service-auth JWT (null when unauthenticated).
+final class FeedRequest {
+  const FeedRequest({required this.limit, this.cursor, this.viewerDid});
+  final int limit;
+  final String? cursor;
+  final String? viewerDid;
+}
+
+/// The one method a feed developer implements. Return the ordered post URIs.
+abstract interface class FeedAlgorithm {
+  Future<FeedGetFeedSkeletonOutput> getFeedSkeleton(final FeedRequest request);
+}

--- a/templates/feed_generator/lib/src/algorithm/whats_hot_algorithm.dart
+++ b/templates/feed_generator/lib/src/algorithm/whats_hot_algorithm.dart
@@ -1,0 +1,34 @@
+// Copyright (c) 2023-2026, Shinya Kato.
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:atproto_core/atproto_core.dart' show AtUri;
+import 'package:bluesky/app_bsky_feed_defs.dart';
+import 'package:bluesky/app_bsky_feed_getfeedskeleton.dart';
+
+import '../store/feed_store.dart';
+import 'feed_algorithm.dart';
+
+/// A minimal reverse-chronological sample feed. Replace the body of
+/// [getFeedSkeleton] with your own ranking to build a real feed.
+final class WhatsHotAlgorithm implements FeedAlgorithm {
+  const WhatsHotAlgorithm(this._store);
+  final FeedStore _store;
+
+  @override
+  Future<FeedGetFeedSkeletonOutput> getFeedSkeleton(
+    final FeedRequest request,
+  ) async {
+    final before = request.cursor == null
+        ? null
+        : DateTime.tryParse(request.cursor!)?.toUtc();
+    final posts = await _store.recent(limit: request.limit, before: before);
+
+    return FeedGetFeedSkeletonOutput(
+      feed: posts.map((p) => SkeletonFeedPost(post: AtUri(p.uri))).toList(),
+      cursor: posts.isEmpty
+          ? null
+          : posts.last.indexedAt.toUtc().toIso8601String(),
+    );
+  }
+}

--- a/templates/feed_generator/lib/src/config.dart
+++ b/templates/feed_generator/lib/src/config.dart
@@ -2,8 +2,11 @@
 // All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// Configuration for the feed generator. Edit these values (or wire them to
-/// environment variables) for your deployment.
+import 'dart:io';
+
+/// Configuration for the feed generator. Construct it directly for a quick
+/// start, or use [FeedGeneratorConfig.fromEnvironment] to keep credentials out
+/// of source control for a real deployment.
 final class FeedGeneratorConfig {
   const FeedGeneratorConfig({
     required this.hostname,
@@ -14,6 +17,49 @@ final class FeedGeneratorConfig {
     required this.publisherHandle,
     required this.publisherPassword,
   });
+
+  /// Builds the config from environment variables so secrets never live in the
+  /// repository:
+  ///
+  /// - `FEEDGEN_HOSTNAME`         (required) e.g. `feed.example.com`
+  /// - `FEEDGEN_PUBLISHER_HANDLE` (required) e.g. `handle.bsky.social`
+  /// - `FEEDGEN_PUBLISHER_PASSWORD` (required) an app password
+  /// - `FEEDGEN_RECORD_KEY`       (default `whats-hot`)
+  /// - `FEEDGEN_DISPLAY_NAME`     (default `What's Hot`)
+  /// - `FEEDGEN_DESCRIPTION`      (optional)
+  /// - `FEEDGEN_PORT`             (default `3000`)
+  ///
+  /// Throws [StateError] when a required variable is missing or `FEEDGEN_PORT`
+  /// is not a valid port number.
+  factory FeedGeneratorConfig.fromEnvironment([
+    final Map<String, String>? environment,
+  ]) {
+    final env = environment ?? Platform.environment;
+
+    String require(final String key) {
+      final value = env[key];
+      if (value == null || value.isEmpty) {
+        throw StateError('Missing required environment variable: $key');
+      }
+      return value;
+    }
+
+    final portRaw = env['FEEDGEN_PORT'];
+    final port = portRaw == null ? 3000 : int.tryParse(portRaw);
+    if (port == null || port < 0 || port > 65535) {
+      throw StateError('FEEDGEN_PORT is not a valid port number: "$portRaw"');
+    }
+
+    return FeedGeneratorConfig(
+      hostname: require('FEEDGEN_HOSTNAME'),
+      feedRecordKey: env['FEEDGEN_RECORD_KEY'] ?? 'whats-hot',
+      feedDisplayName: env['FEEDGEN_DISPLAY_NAME'] ?? "What's Hot",
+      feedDescription: env['FEEDGEN_DESCRIPTION'],
+      port: port,
+      publisherHandle: require('FEEDGEN_PUBLISHER_HANDLE'),
+      publisherPassword: require('FEEDGEN_PUBLISHER_PASSWORD'),
+    );
+  }
 
   /// The public hostname of this service (e.g. `feed.example.com`).
   final String hostname;

--- a/templates/feed_generator/lib/src/config.dart
+++ b/templates/feed_generator/lib/src/config.dart
@@ -61,7 +61,10 @@ final class FeedGeneratorConfig {
     );
   }
 
-  /// The public hostname of this service (e.g. `feed.example.com`).
+  /// The public hostname of this service (e.g. `feed.example.com`). Must be a
+  /// bare hostname with no port or scheme: a `did:web` derived from a
+  /// host:port would treat the port as a path segment (the colon has to be
+  /// percent-encoded), which breaks resolution. Run behind TLS on 443.
   final String hostname;
 
   /// This service's DID (`did:web:<hostname>`).

--- a/templates/feed_generator/lib/src/config.dart
+++ b/templates/feed_generator/lib/src/config.dart
@@ -1,0 +1,34 @@
+// Copyright (c) 2023-2026, Shinya Kato.
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// Configuration for the feed generator. Edit these values (or wire them to
+/// environment variables) for your deployment.
+final class FeedGeneratorConfig {
+  const FeedGeneratorConfig({
+    required this.hostname,
+    required this.feedRecordKey,
+    required this.feedDisplayName,
+    this.feedDescription,
+    this.port = 3000,
+    required this.publisherHandle,
+    required this.publisherPassword,
+  });
+
+  /// The public hostname of this service (e.g. `feed.example.com`).
+  final String hostname;
+
+  /// This service's DID (`did:web:<hostname>`).
+  String get serviceDid => 'did:web:$hostname';
+
+  /// The record key of the feed under `app.bsky.feed.generator` (e.g. `whats-hot`).
+  final String feedRecordKey;
+
+  final String feedDisplayName;
+  final String? feedDescription;
+  final int port;
+
+  /// Credentials of the account that publishes the feed generator record.
+  final String publisherHandle;
+  final String publisherPassword;
+}

--- a/templates/feed_generator/lib/src/indexer/firehose_indexer.dart
+++ b/templates/feed_generator/lib/src/indexer/firehose_indexer.dart
@@ -11,10 +11,17 @@ import '../store/feed_store.dart';
 /// Pure mapping from a created post URI to an [IndexedPost]. Extracted so it
 /// can be unit-tested without a live firehose socket.
 IndexedPost indexedPostFrom(final AtUri uri, {final DateTime? now}) =>
-    IndexedPost(uri: uri.toString(), indexedAt: (now ?? DateTime.now()).toUtc());
+    IndexedPost(
+      uri: uri.toString(),
+      indexedAt: (now ?? DateTime.now()).toUtc(),
+    );
 
 /// Subscribes to the public firehose and indexes every newly created post.
 /// Replace the filter/mapping to index only what your feed needs.
+///
+/// NOTE: This is a template-grade indexer. A production indexer should also
+/// persist the cursor (so it can resume where it left off) and reconnect on
+/// disconnect - both are out of scope here for simplicity.
 final class FirehoseIndexer {
   FirehoseIndexer(this._store);
   final FeedStore _store;
@@ -22,14 +29,30 @@ final class FirehoseIndexer {
   Future<void> start() async {
     final bsky = Bluesky.anonymous();
     final subscription = await bsky.atproto.sync.subscribeRepos();
-    subscription.data.stream.listen((event) {
-      final repos = const firehose.SyncSubscribeReposAdaptor().execute(event);
-      if (!repos.isCommit) return;
-      firehose.RepoCommitHandler(
-        onCreateFeedPost: (data) async {
-          await _store.index(indexedPostFrom(data.uri));
-        },
-      ).execute(repos.commit!);
-    });
+    subscription.data.stream.listen(
+      (event) async {
+        try {
+          final repos = const firehose.SyncSubscribeReposAdaptor().execute(
+            event,
+          );
+          if (!repos.isCommit) return;
+          await firehose.RepoCommitHandler(
+            onCreateFeedPost: (data) async {
+              await _store.index(indexedPostFrom(data.uri));
+            },
+          ).execute(repos.commit!);
+        } catch (e) {
+          // A single malformed frame or a failed store write should not
+          // bring down the whole indexer - log it and keep consuming the
+          // stream.
+          print('skipped a firehose frame: $e');
+        }
+      },
+      onError: (Object error) {
+        // Stream-level errors (e.g. a socket hiccup from the public relay)
+        // are logged and swallowed so the subscription keeps running.
+        print('firehose stream error: $error');
+      },
+    );
   }
 }

--- a/templates/feed_generator/lib/src/indexer/firehose_indexer.dart
+++ b/templates/feed_generator/lib/src/indexer/firehose_indexer.dart
@@ -1,0 +1,35 @@
+// Copyright (c) 2023-2026, Shinya Kato.
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:atproto_core/atproto_core.dart' show AtUri;
+import 'package:bluesky/bluesky.dart';
+import 'package:bluesky/firehose.dart' as firehose;
+
+import '../store/feed_store.dart';
+
+/// Pure mapping from a created post URI to an [IndexedPost]. Extracted so it
+/// can be unit-tested without a live firehose socket.
+IndexedPost indexedPostFrom(final AtUri uri, {final DateTime? now}) =>
+    IndexedPost(uri: uri.toString(), indexedAt: (now ?? DateTime.now()).toUtc());
+
+/// Subscribes to the public firehose and indexes every newly created post.
+/// Replace the filter/mapping to index only what your feed needs.
+final class FirehoseIndexer {
+  FirehoseIndexer(this._store);
+  final FeedStore _store;
+
+  Future<void> start() async {
+    final bsky = Bluesky.anonymous();
+    final subscription = await bsky.atproto.sync.subscribeRepos();
+    subscription.data.stream.listen((event) {
+      final repos = const firehose.SyncSubscribeReposAdaptor().execute(event);
+      if (!repos.isCommit) return;
+      firehose.RepoCommitHandler(
+        onCreateFeedPost: (data) async {
+          await _store.index(indexedPostFrom(data.uri));
+        },
+      ).execute(repos.commit!);
+    });
+  }
+}

--- a/templates/feed_generator/lib/src/server/feed_generator_service.dart
+++ b/templates/feed_generator/lib/src/server/feed_generator_service.dart
@@ -18,7 +18,10 @@ import '../config.dart';
 typedef ServiceAuthVerifier =
     Future<String> Function(String authorizationHeader);
 
-const _skeletonLxm = 'app.bsky.feed.getFeedSkeleton';
+/// The lexicon-mandated `lxm` value a getFeedSkeleton service-auth JWT must
+/// carry; `bin/server.dart` passes this to `verifyServiceAuth`.
+const feedSkeletonLxm = 'app.bsky.feed.getFeedSkeleton';
+
 const _defaultLimit = 50;
 const _minLimit = 1;
 const _maxLimit = 100;
@@ -71,6 +74,10 @@ Handler createFeedGeneratorHandler({
       final params = request.url.queryParameters;
       final limit = _parseLimit(params['limit']);
       final cursor = params['cursor'];
+      // This template serves a single feed, so the `feed` AT-URI parameter is
+      // not inspected. A multi-feed service should read `params['feed']`,
+      // dispatch to the matching algorithm, and return an `UnknownFeed` error
+      // (HTTP 400) for an unrecognised feed.
 
       String? viewerDid;
       if (verifyAuth != null) {
@@ -96,10 +103,6 @@ Handler createFeedGeneratorHandler({
 
   return router.call;
 }
-
-/// The lexicon-mandated `lxm` value a getFeedSkeleton service-auth JWT must
-/// carry; `bin/server.dart` passes this to `verifyServiceAuth`.
-const feedSkeletonLxm = _skeletonLxm;
 
 int _parseLimit(final String? raw) {
   final parsed = raw == null ? null : int.tryParse(raw);

--- a/templates/feed_generator/lib/src/server/feed_generator_service.dart
+++ b/templates/feed_generator/lib/src/server/feed_generator_service.dart
@@ -1,0 +1,114 @@
+// Copyright (c) 2023-2026, Shinya Kato.
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:convert';
+
+import 'package:atproto_identity/atproto_identity.dart' show IdentityException;
+import 'package:shelf/shelf.dart';
+import 'package:shelf_router/shelf_router.dart';
+
+import '../algorithm/feed_algorithm.dart';
+import '../config.dart';
+
+/// Verifies the AppView's inbound service-auth `Authorization` header and
+/// returns the requester (viewer) DID, or throws [IdentityException] when the
+/// token is invalid. `bin/server.dart` wires this to
+/// `atproto_identity.verifyServiceAuth`; tests inject a stub.
+typedef ServiceAuthVerifier =
+    Future<String> Function(String authorizationHeader);
+
+const _skeletonLxm = 'app.bsky.feed.getFeedSkeleton';
+const _defaultLimit = 50;
+const _minLimit = 1;
+const _maxLimit = 100;
+
+/// Builds the HTTP handler that implements the three endpoints a Bluesky custom
+/// feed generator must expose:
+///
+/// - `GET /.well-known/did.json` — the `did:web` document AppView fetches to
+///   discover this service.
+/// - `GET /xrpc/app.bsky.feed.describeFeedGenerator` — advertises the feeds
+///   this service can serve.
+/// - `GET /xrpc/app.bsky.feed.getFeedSkeleton` — returns the ordered post URIs;
+///   [algorithm] produces the ranking.
+///
+/// When [verifyAuth] is non-null and a request carries an `Authorization`
+/// header, the header is verified and the resulting viewer DID is passed to
+/// [algorithm]; verification failure yields `401`. A request with no header is
+/// served anonymously (service-auth is optional per the lexicon). Pass
+/// [feedUri] (the published `app.bsky.feed.generator` record's AT-URI) to have
+/// `describeFeedGenerator` advertise it.
+Handler createFeedGeneratorHandler({
+  required final FeedGeneratorConfig config,
+  required final FeedAlgorithm algorithm,
+  final ServiceAuthVerifier? verifyAuth,
+  final String? feedUri,
+}) {
+  final router = Router()
+    ..get('/.well-known/did.json', (final Request request) {
+      return _json({
+        '@context': const ['https://www.w3.org/ns/did/v1'],
+        'id': config.serviceDid,
+        'service': [
+          {
+            'id': '#bsky_fg',
+            'type': 'BskyFeedGenerator',
+            'serviceEndpoint': 'https://${config.hostname}',
+          },
+        ],
+      });
+    })
+    ..get('/xrpc/app.bsky.feed.describeFeedGenerator', (final Request request) {
+      return _json({
+        'did': config.serviceDid,
+        'feeds': [
+          if (feedUri != null) {'uri': feedUri},
+        ],
+      });
+    })
+    ..get('/xrpc/app.bsky.feed.getFeedSkeleton', (final Request request) async {
+      final params = request.url.queryParameters;
+      final limit = _parseLimit(params['limit']);
+      final cursor = params['cursor'];
+
+      String? viewerDid;
+      if (verifyAuth != null) {
+        final authHeader = request.headers['authorization'];
+        if (authHeader != null) {
+          try {
+            viewerDid = await verifyAuth(authHeader);
+          } on IdentityException catch (e) {
+            return _json({
+              'error': 'AuthRequired',
+              'message': e.message,
+            }, status: 401);
+          }
+        }
+      }
+
+      final output = await algorithm.getFeedSkeleton(
+        FeedRequest(limit: limit, cursor: cursor, viewerDid: viewerDid),
+      );
+
+      return _json(output.toJson());
+    });
+
+  return router.call;
+}
+
+/// The lexicon-mandated `lxm` value a getFeedSkeleton service-auth JWT must
+/// carry; `bin/server.dart` passes this to `verifyServiceAuth`.
+const feedSkeletonLxm = _skeletonLxm;
+
+int _parseLimit(final String? raw) {
+  final parsed = raw == null ? null : int.tryParse(raw);
+  if (parsed == null) return _defaultLimit;
+  return parsed.clamp(_minLimit, _maxLimit);
+}
+
+Response _json(final Object body, {final int status = 200}) => Response(
+  status,
+  body: jsonEncode(body),
+  headers: const {'content-type': 'application/json; charset=utf-8'},
+);

--- a/templates/feed_generator/lib/src/store/feed_store.dart
+++ b/templates/feed_generator/lib/src/store/feed_store.dart
@@ -1,0 +1,19 @@
+// Copyright (c) 2023-2026, Shinya Kato.
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// A single indexed post: its AT-URI and when this service indexed it.
+final class IndexedPost {
+  const IndexedPost({required this.uri, required this.indexedAt});
+  final String uri;
+  final DateTime indexedAt;
+}
+
+/// The storage the feed algorithm reads from and the indexer writes to.
+/// Swap [InMemoryFeedStore] for a database-backed implementation in production.
+abstract interface class FeedStore {
+  Future<void> index(final IndexedPost post);
+
+  /// Returns posts newest-first, at most [limit], older than [before] if given.
+  Future<List<IndexedPost>> recent({required final int limit, final DateTime? before});
+}

--- a/templates/feed_generator/lib/src/store/feed_store.dart
+++ b/templates/feed_generator/lib/src/store/feed_store.dart
@@ -15,5 +15,8 @@ abstract interface class FeedStore {
   Future<void> index(final IndexedPost post);
 
   /// Returns posts newest-first, at most [limit], older than [before] if given.
-  Future<List<IndexedPost>> recent({required final int limit, final DateTime? before});
+  Future<List<IndexedPost>> recent({
+    required final int limit,
+    final DateTime? before,
+  });
 }

--- a/templates/feed_generator/lib/src/store/in_memory_feed_store.dart
+++ b/templates/feed_generator/lib/src/store/in_memory_feed_store.dart
@@ -1,0 +1,29 @@
+// Copyright (c) 2023-2026, Shinya Kato.
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'feed_store.dart';
+
+/// A non-persistent [FeedStore] for local development and tests. NOT for
+/// production — replace with a database-backed store.
+final class InMemoryFeedStore implements FeedStore {
+  final List<IndexedPost> _posts = [];
+
+  @override
+  Future<void> index(final IndexedPost post) async {
+    _posts.add(post);
+  }
+
+  @override
+  Future<List<IndexedPost>> recent({
+    required final int limit,
+    final DateTime? before,
+  }) async {
+    final sorted = [..._posts]
+      ..sort((a, b) => b.indexedAt.compareTo(a.indexedAt));
+    final filtered = before == null
+        ? sorted
+        : sorted.where((p) => p.indexedAt.isBefore(before)).toList();
+    return filtered.take(limit).toList();
+  }
+}

--- a/templates/feed_generator/pubspec.yaml
+++ b/templates/feed_generator/pubspec.yaml
@@ -10,7 +10,6 @@ dependencies:
   bluesky: ^2.0.0
   atproto_core: ^2.0.0
   atproto_identity: ^0.1.0
-  did_plc: ^1.1.0
   shelf: ^1.4.0
   shelf_router: ^1.1.0
 

--- a/templates/feed_generator/pubspec.yaml
+++ b/templates/feed_generator/pubspec.yaml
@@ -1,0 +1,18 @@
+name: feed_generator
+publish_to: none
+resolution: workspace
+description: A clone-and-edit template for building a Bluesky custom feed generator with atproto.dart.
+
+environment:
+  sdk: ">=3.8.0 <4.0.0"
+
+dependencies:
+  bluesky: ^2.0.0
+  atproto_identity: ^0.1.0
+  did_plc: ^1.1.0
+  shelf: ^1.4.0
+  shelf_router: ^1.1.0
+
+dev_dependencies:
+  lints: ^6.0.0
+  test: ^1.26.2

--- a/templates/feed_generator/pubspec.yaml
+++ b/templates/feed_generator/pubspec.yaml
@@ -8,6 +8,7 @@ environment:
 
 dependencies:
   bluesky: ^2.0.0
+  atproto_core: ^2.0.0
   atproto_identity: ^0.1.0
   did_plc: ^1.1.0
   shelf: ^1.4.0

--- a/templates/feed_generator/test/algorithm/whats_hot_algorithm_test.dart
+++ b/templates/feed_generator/test/algorithm/whats_hot_algorithm_test.dart
@@ -1,0 +1,34 @@
+import 'package:feed_generator/src/algorithm/feed_algorithm.dart';
+import 'package:feed_generator/src/algorithm/whats_hot_algorithm.dart';
+import 'package:feed_generator/src/store/feed_store.dart';
+import 'package:feed_generator/src/store/in_memory_feed_store.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('returns newest-first skeleton with a pagination cursor', () async {
+    final store = InMemoryFeedStore();
+    for (var i = 0; i < 3; i++) {
+      await store.index(
+        IndexedPost(
+          uri: 'at://did:plc:x/app.bsky.feed.post/$i',
+          indexedAt: DateTime.utc(2026, 1, 1, 0, 0, i),
+        ),
+      );
+    }
+    final algo = WhatsHotAlgorithm(store);
+
+    final page1 = await algo.getFeedSkeleton(const FeedRequest(limit: 2));
+    expect(page1.feed.map((p) => p.post.toString()), [
+      'at://did:plc:x/app.bsky.feed.post/2',
+      'at://did:plc:x/app.bsky.feed.post/1',
+    ]);
+    expect(page1.cursor, isNotNull);
+
+    final page2 = await algo.getFeedSkeleton(
+      FeedRequest(limit: 2, cursor: page1.cursor),
+    );
+    expect(page2.feed.map((p) => p.post.toString()), [
+      'at://did:plc:x/app.bsky.feed.post/0',
+    ]);
+  });
+}

--- a/templates/feed_generator/test/indexer/firehose_indexer_test.dart
+++ b/templates/feed_generator/test/indexer/firehose_indexer_test.dart
@@ -1,0 +1,16 @@
+// Copyright (c) 2023-2026, Shinya Kato.
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:atproto_core/atproto_core.dart' show AtUri;
+import 'package:feed_generator/src/indexer/firehose_indexer.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('maps a created feed post URI to an IndexedPost', () {
+    final at = AtUri('at://did:plc:x/app.bsky.feed.post/abc');
+    final indexed = indexedPostFrom(at, now: DateTime.utc(2026, 1, 1));
+    expect(indexed.uri, 'at://did:plc:x/app.bsky.feed.post/abc');
+    expect(indexed.indexedAt, DateTime.utc(2026, 1, 1));
+  });
+}

--- a/templates/feed_generator/test/indexer/firehose_indexer_test.dart
+++ b/templates/feed_generator/test/indexer/firehose_indexer_test.dart
@@ -13,4 +13,21 @@ void main() {
     expect(indexed.uri, 'at://did:plc:x/app.bsky.feed.post/abc');
     expect(indexed.indexedAt, DateTime.utc(2026, 1, 1));
   });
+
+  test('defaults indexedAt to the current UTC time when now is omitted', () {
+    final at = AtUri('at://did:plc:x/app.bsky.feed.post/abc');
+    final before = DateTime.now().toUtc();
+    final indexed = indexedPostFrom(at);
+    final after = DateTime.now().toUtc();
+
+    expect(indexed.indexedAt.isUtc, isTrue);
+    expect(
+      indexed.indexedAt.isAfter(before.subtract(const Duration(seconds: 5))),
+      isTrue,
+    );
+    expect(
+      indexed.indexedAt.isBefore(after.add(const Duration(seconds: 5))),
+      isTrue,
+    );
+  });
 }

--- a/templates/feed_generator/test/server/feed_generator_service_test.dart
+++ b/templates/feed_generator/test/server/feed_generator_service_test.dart
@@ -43,9 +43,11 @@ Future<Response> _get(
   final Handler handler,
   final String path, {
   final Map<String, String>? headers,
-}) => Future.value(
-  handler(Request('GET', Uri.parse('http://localhost$path'), headers: headers)),
-).then((r) => r);
+}) => Future.sync(
+  () => handler(
+    Request('GET', Uri.parse('http://localhost$path'), headers: headers),
+  ),
+);
 
 void main() {
   group('did.json', () {

--- a/templates/feed_generator/test/server/feed_generator_service_test.dart
+++ b/templates/feed_generator/test/server/feed_generator_service_test.dart
@@ -1,0 +1,223 @@
+// Copyright (c) 2023-2026, Shinya Kato.
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:convert';
+
+import 'package:atproto_core/atproto_core.dart' show AtUri;
+import 'package:atproto_identity/atproto_identity.dart' show IdentityException;
+import 'package:bluesky/app_bsky_feed_defs.dart';
+import 'package:bluesky/app_bsky_feed_getfeedskeleton.dart';
+import 'package:feed_generator/src/algorithm/feed_algorithm.dart';
+import 'package:feed_generator/src/config.dart';
+import 'package:feed_generator/src/server/feed_generator_service.dart';
+import 'package:shelf/shelf.dart';
+import 'package:test/test.dart';
+
+const _config = FeedGeneratorConfig(
+  hostname: 'feed.example.com',
+  feedRecordKey: 'whats-hot',
+  feedDisplayName: "What's Hot",
+  publisherHandle: 'alice.test',
+  publisherPassword: 'app-password',
+);
+
+/// Records the [FeedRequest] it last received and returns a fixed skeleton.
+final class _FakeAlgorithm implements FeedAlgorithm {
+  FeedRequest? lastRequest;
+
+  @override
+  Future<FeedGetFeedSkeletonOutput> getFeedSkeleton(
+    final FeedRequest request,
+  ) async {
+    lastRequest = request;
+    return FeedGetFeedSkeletonOutput(
+      feed: [
+        SkeletonFeedPost(post: AtUri('at://did:plc:x/app.bsky.feed.post/1')),
+      ],
+    );
+  }
+}
+
+Future<Response> _get(
+  final Handler handler,
+  final String path, {
+  final Map<String, String>? headers,
+}) => Future.value(
+  handler(Request('GET', Uri.parse('http://localhost$path'), headers: headers)),
+).then((r) => r);
+
+void main() {
+  group('did.json', () {
+    test('returns the did:web document for the service host', () async {
+      final handler = createFeedGeneratorHandler(
+        config: _config,
+        algorithm: _FakeAlgorithm(),
+      );
+
+      final res = await _get(handler, '/.well-known/did.json');
+      expect(res.statusCode, 200);
+
+      final body = jsonDecode(await res.readAsString()) as Map<String, dynamic>;
+      expect(body['id'], 'did:web:feed.example.com');
+      final service = (body['service'] as List).first as Map<String, dynamic>;
+      expect(service['type'], 'BskyFeedGenerator');
+      expect(service['serviceEndpoint'], 'https://feed.example.com');
+    });
+  });
+
+  group('describeFeedGenerator', () {
+    test('lists the configured feed uri', () async {
+      final handler = createFeedGeneratorHandler(
+        config: _config,
+        algorithm: _FakeAlgorithm(),
+        feedUri: 'at://did:plc:pub/app.bsky.feed.generator/whats-hot',
+      );
+
+      final res = await _get(
+        handler,
+        '/xrpc/app.bsky.feed.describeFeedGenerator',
+      );
+      expect(res.statusCode, 200);
+
+      final body = jsonDecode(await res.readAsString()) as Map<String, dynamic>;
+      expect(body['did'], 'did:web:feed.example.com');
+      expect((body['feeds'] as List).single, {
+        'uri': 'at://did:plc:pub/app.bsky.feed.generator/whats-hot',
+      });
+    });
+
+    test('returns an empty feed list when no feed uri is known', () async {
+      final handler = createFeedGeneratorHandler(
+        config: _config,
+        algorithm: _FakeAlgorithm(),
+      );
+
+      final res = await _get(
+        handler,
+        '/xrpc/app.bsky.feed.describeFeedGenerator',
+      );
+      final body = jsonDecode(await res.readAsString()) as Map<String, dynamic>;
+      expect(body['feeds'], isEmpty);
+    });
+  });
+
+  group('getFeedSkeleton', () {
+    test('serves the algorithm output as JSON, unauthenticated', () async {
+      final algo = _FakeAlgorithm();
+      final handler = createFeedGeneratorHandler(
+        config: _config,
+        algorithm: algo,
+      );
+
+      final res = await _get(
+        handler,
+        '/xrpc/app.bsky.feed.getFeedSkeleton?feed=at://x/app.bsky.feed.generator/whats-hot',
+      );
+      expect(res.statusCode, 200);
+      expect(res.headers['content-type'], contains('application/json'));
+
+      final body = jsonDecode(await res.readAsString()) as Map<String, dynamic>;
+      final feed = (body['feed'] as List).single as Map<String, dynamic>;
+      expect(feed['post'], 'at://did:plc:x/app.bsky.feed.post/1');
+      expect(algo.lastRequest!.viewerDid, isNull);
+      expect(algo.lastRequest!.limit, 50);
+    });
+
+    test('parses limit and cursor query parameters', () async {
+      final algo = _FakeAlgorithm();
+      final handler = createFeedGeneratorHandler(
+        config: _config,
+        algorithm: algo,
+      );
+
+      await _get(
+        handler,
+        '/xrpc/app.bsky.feed.getFeedSkeleton?limit=5&cursor=abc',
+      );
+      expect(algo.lastRequest!.limit, 5);
+      expect(algo.lastRequest!.cursor, 'abc');
+    });
+
+    test('clamps out-of-range or invalid limits', () async {
+      final algo = _FakeAlgorithm();
+      final handler = createFeedGeneratorHandler(
+        config: _config,
+        algorithm: algo,
+      );
+
+      await _get(handler, '/xrpc/app.bsky.feed.getFeedSkeleton?limit=999');
+      expect(algo.lastRequest!.limit, 100);
+
+      await _get(handler, '/xrpc/app.bsky.feed.getFeedSkeleton?limit=0');
+      expect(algo.lastRequest!.limit, 1);
+
+      await _get(handler, '/xrpc/app.bsky.feed.getFeedSkeleton?limit=abc');
+      expect(algo.lastRequest!.limit, 50);
+    });
+
+    test(
+      'propagates the verified viewer DID from a valid service-auth JWT',
+      () async {
+        final algo = _FakeAlgorithm();
+        final handler = createFeedGeneratorHandler(
+          config: _config,
+          algorithm: algo,
+          verifyAuth: (header) async => 'did:plc:viewer',
+        );
+
+        final res = await _get(
+          handler,
+          '/xrpc/app.bsky.feed.getFeedSkeleton',
+          headers: {'authorization': 'Bearer token'},
+        );
+        expect(res.statusCode, 200);
+        expect(algo.lastRequest!.viewerDid, 'did:plc:viewer');
+      },
+    );
+
+    test('returns 401 when service-auth verification fails', () async {
+      final handler = createFeedGeneratorHandler(
+        config: _config,
+        algorithm: _FakeAlgorithm(),
+        verifyAuth: (header) async =>
+            throw const IdentityException('bad token'),
+      );
+
+      final res = await _get(
+        handler,
+        '/xrpc/app.bsky.feed.getFeedSkeleton',
+        headers: {'authorization': 'Bearer bad'},
+      );
+      expect(res.statusCode, 401);
+      final body = jsonDecode(await res.readAsString()) as Map<String, dynamic>;
+      expect(body['error'], 'AuthRequired');
+    });
+
+    test(
+      'treats a missing Authorization header as an anonymous viewer',
+      () async {
+        final algo = _FakeAlgorithm();
+        final handler = createFeedGeneratorHandler(
+          config: _config,
+          algorithm: algo,
+          verifyAuth: (header) async => 'did:plc:viewer',
+        );
+
+        final res = await _get(handler, '/xrpc/app.bsky.feed.getFeedSkeleton');
+        expect(res.statusCode, 200);
+        expect(algo.lastRequest!.viewerDid, isNull);
+      },
+    );
+  });
+
+  test('unknown routes return 404', () async {
+    final handler = createFeedGeneratorHandler(
+      config: _config,
+      algorithm: _FakeAlgorithm(),
+    );
+
+    final res = await _get(handler, '/nope');
+    expect(res.statusCode, 404);
+  });
+}

--- a/templates/feed_generator/test/store/in_memory_feed_store_test.dart
+++ b/templates/feed_generator/test/store/in_memory_feed_store_test.dart
@@ -6,10 +6,12 @@ void main() {
   test('recent returns newest-first, honoring limit', () async {
     final store = InMemoryFeedStore();
     for (var i = 0; i < 5; i++) {
-      await store.index(IndexedPost(
-        uri: 'at://did:plc:x/app.bsky.feed.post/$i',
-        indexedAt: DateTime.utc(2026, 1, 1, 0, 0, i),
-      ));
+      await store.index(
+        IndexedPost(
+          uri: 'at://did:plc:x/app.bsky.feed.post/$i',
+          indexedAt: DateTime.utc(2026, 1, 1, 0, 0, i),
+        ),
+      );
     }
     final recent = await store.recent(limit: 3);
     expect(recent.map((p) => p.uri), [
@@ -22,12 +24,17 @@ void main() {
   test('before paginates strictly older than the cursor time', () async {
     final store = InMemoryFeedStore();
     for (var i = 0; i < 5; i++) {
-      await store.index(IndexedPost(
-        uri: 'at://did:plc:x/app.bsky.feed.post/$i',
-        indexedAt: DateTime.utc(2026, 1, 1, 0, 0, i),
-      ));
+      await store.index(
+        IndexedPost(
+          uri: 'at://did:plc:x/app.bsky.feed.post/$i',
+          indexedAt: DateTime.utc(2026, 1, 1, 0, 0, i),
+        ),
+      );
     }
-    final page = await store.recent(limit: 10, before: DateTime.utc(2026, 1, 1, 0, 0, 3));
+    final page = await store.recent(
+      limit: 10,
+      before: DateTime.utc(2026, 1, 1, 0, 0, 3),
+    );
     expect(page.map((p) => p.uri), [
       'at://did:plc:x/app.bsky.feed.post/2',
       'at://did:plc:x/app.bsky.feed.post/1',

--- a/templates/feed_generator/test/store/in_memory_feed_store_test.dart
+++ b/templates/feed_generator/test/store/in_memory_feed_store_test.dart
@@ -1,0 +1,37 @@
+import 'package:feed_generator/src/store/feed_store.dart';
+import 'package:feed_generator/src/store/in_memory_feed_store.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('recent returns newest-first, honoring limit', () async {
+    final store = InMemoryFeedStore();
+    for (var i = 0; i < 5; i++) {
+      await store.index(IndexedPost(
+        uri: 'at://did:plc:x/app.bsky.feed.post/$i',
+        indexedAt: DateTime.utc(2026, 1, 1, 0, 0, i),
+      ));
+    }
+    final recent = await store.recent(limit: 3);
+    expect(recent.map((p) => p.uri), [
+      'at://did:plc:x/app.bsky.feed.post/4',
+      'at://did:plc:x/app.bsky.feed.post/3',
+      'at://did:plc:x/app.bsky.feed.post/2',
+    ]);
+  });
+
+  test('before paginates strictly older than the cursor time', () async {
+    final store = InMemoryFeedStore();
+    for (var i = 0; i < 5; i++) {
+      await store.index(IndexedPost(
+        uri: 'at://did:plc:x/app.bsky.feed.post/$i',
+        indexedAt: DateTime.utc(2026, 1, 1, 0, 0, i),
+      ));
+    }
+    final page = await store.recent(limit: 10, before: DateTime.utc(2026, 1, 1, 0, 0, 3));
+    expect(page.map((p) => p.uri), [
+      'at://did:plc:x/app.bsky.feed.post/2',
+      'at://did:plc:x/app.bsky.feed.post/1',
+      'at://did:plc:x/app.bsky.feed.post/0',
+    ]);
+  });
+}


### PR DESCRIPTION
## Summary

Adds a **complete, runnable Bluesky custom feed generator template** under `templates/feed_generator/`.

This is **stacked on top of #2460** (`atproto_identity` + `verifyServiceAuth`). #2460 delivers the missing *protocol primitive*; this PR delivers the *project scaffold a developer clones* to actually run a feed. Merge #2460 first (this PR targets its branch, so the diff here is only the template).

Before this PR the template had the building blocks (store, algorithm interface + `whats-hot` sample, firehose indexer) but **no server** — the README pointed at `bin/server.dart` / `bin/publish_feed.dart` that did not exist, and `shelf`/`shelf_router` were declared but unused. It was not a runnable feed generator.

## What this adds

- **`bin/server.dart`** — serves the three AppView-facing endpoints with `shelf_router`:
  - `GET /.well-known/did.json` — the `did:web:<hostname>` document
  - `GET /xrpc/app.bsky.feed.describeFeedGenerator`
  - `GET /xrpc/app.bsky.feed.getFeedSkeleton`
  
  It verifies the inbound service-auth JWT via `atproto_identity.verifyServiceAuth` (with `lxm = app.bsky.feed.getFeedSkeleton`) and starts the firehose indexer.
- **`bin/publish_feed.dart`** — idempotently writes the `app.bsky.feed.generator` record (`feed.generator.put`) so the feed is discoverable.
- **`lib/src/server/feed_generator_service.dart`** — a testable handler builder:
  - injectable `ServiceAuthVerifier` (real crypto wired in `bin/`, a stub in tests)
  - service-auth is optional per the lexicon: **no header → anonymous viewer**, **invalid header → 401**, valid header → viewer DID passed to the algorithm
  - `limit` parsing with clamping to `1..100` (default `50`)
- **`config`** — `FeedGeneratorConfig.fromEnvironment` reads `FEEDGEN_*` env vars so credentials stay out of source control; the direct constructor still works. Dropped the unused `did_plc` dependency. README rewritten to match (env-based config, accurate `bin/` usage).

## Testing

- 11 new server tests (`did.json`, `describeFeedGenerator` with/without feed URI, getFeedSkeleton JSON shape, limit parsing/clamping, viewer-DID propagation, 401 on bad auth, anonymous fallback, 404).
- `dart analyze` clean, `dart format` clean, full template suite green (15 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T7uT3S8kHKPb6QQZ4HUjWV