### PR TITLE
refactor: modernize hand-written control flow with Dart 3 switch and null-aware syntax

### DIFF
--- a/packages/atproto_oauth/lib/src/types/server_metadata.dart
+++ b/packages/atproto_oauth/lib/src/types/server_metadata.dart
@@ -63,13 +63,11 @@ final class OAuthServerMetadata {
   final List<String>? scopesSupported;
 
   Map<String, dynamic> toJson() => {
-    if (issuer != null) 'issuer': issuer,
-    if (pushedAuthorizationRequestEndpoint != null)
-      'pushed_authorization_request_endpoint':
-          pushedAuthorizationRequestEndpoint,
-    if (authorizationEndpoint != null)
-      'authorization_endpoint': authorizationEndpoint,
-    if (tokenEndpoint != null) 'token_endpoint': tokenEndpoint,
-    if (scopesSupported != null) 'scopes_supported': scopesSupported,
+    'issuer': ?issuer,
+    'pushed_authorization_request_endpoint':
+        ?pushedAuthorizationRequestEndpoint,
+    'authorization_endpoint': ?authorizationEndpoint,
+    'token_endpoint': ?tokenEndpoint,
+    'scopes_supported': ?scopesSupported,
   };
 }

--- a/packages/atproto_oauth/lib/src/types/session.dart
+++ b/packages/atproto_oauth/lib/src/types/session.dart
@@ -132,10 +132,10 @@ final class OAuthSession {
 
   Map<String, dynamic> toJson() => {
     'access_token': accessToken,
-    if (refreshToken != null) 'refresh_token': refreshToken,
+    'refresh_token': ?refreshToken,
     'token_type': tokenType,
     'scope': scope,
-    if (expiresAt != null) 'expires_at': expiresAt!.toUtc().toIso8601String(),
+    'expires_at': ?expiresAt?.toUtc().toIso8601String(),
     'sub': sub,
     'issuer': issuer,
     'pds': pds,

--- a/packages/bluesky/lib/src/moderation/decision.dart
+++ b/packages/bluesky/lib/src/moderation/decision.dart
@@ -285,99 +285,104 @@ final class ModerationDecision {
     final informs = <ModerationCause>[];
 
     for (final cause in causes) {
-      if (cause is UModerationCauseBlocking ||
-          cause is UModerationCauseBlockedBy ||
-          cause is UModerationCauseBlockOther) {
-        if (me) continue;
+      switch (cause) {
+        case UModerationCauseBlocking() ||
+            UModerationCauseBlockedBy() ||
+            UModerationCauseBlockOther():
+          if (me) continue;
 
-        if (context.isProfileList || context.isContentList) {
-          filters.add(cause);
-        }
-
-        if (!cause.downgraded) {
-          if (behaviors.block[context] == ModerationBehavior.blur) {
-            noOverride = true;
-            blurs.add(cause);
-          } else if (behaviors.block[context] == ModerationBehavior.alert) {
-            alerts.add(cause);
-          } else if (behaviors.block[context] == ModerationBehavior.inform) {
-            informs.add(cause);
-          }
-        }
-      } else if (cause is UModerationCauseMuted) {
-        if (me) continue;
-
-        if (context.isProfileList || context.isContentList) {
-          filters.add(cause);
-        }
-
-        if (!cause.downgraded) {
-          if (behaviors.mute[context] == ModerationBehavior.blur) {
-            blurs.add(cause);
-          } else if (behaviors.mute[context] == ModerationBehavior.alert) {
-            alerts.add(cause);
-          } else if (behaviors.mute[context] == ModerationBehavior.inform) {
-            informs.add(cause);
-          }
-        }
-      } else if (cause is UModerationCauseMuteWord) {
-        if (me) continue;
-
-        if (context.isContentList) {
-          filters.add(cause);
-        }
-
-        if (!cause.downgraded) {
-          if (behaviors.muteWord[context] == ModerationBehavior.blur) {
-            blurs.add(cause);
-          } else if (behaviors.muteWord[context] == ModerationBehavior.alert) {
-            alerts.add(cause);
-          } else if (behaviors.muteWord[context] == ModerationBehavior.inform) {
-            informs.add(cause);
-          }
-        }
-      } else if (cause is UModerationCauseHidden) {
-        if (context.isProfileList || context.isContentList) {
-          filters.add(cause);
-        }
-
-        if (!cause.downgraded) {
-          if (behaviors.hide[context] == ModerationBehavior.blur) {
-            blurs.add(cause);
-          } else if (behaviors.hide[context] == ModerationBehavior.alert) {
-            alerts.add(cause);
-          } else if (behaviors.hide[context] == ModerationBehavior.inform) {
-            informs.add(cause);
-          }
-        }
-      } else if (cause is UModerationCauseLabel) {
-        final labelCause = cause.data;
-
-        if (context.isProfileList && labelCause.target == LabelTarget.account) {
-          if (labelCause.setting == LabelPreference.hide && !me) {
+          if (context.isProfileList || context.isContentList) {
             filters.add(cause);
           }
-        } else if (context.isContentList &&
-            (labelCause.target == LabelTarget.account ||
-                labelCause.target == LabelTarget.content)) {
-          if (labelCause.setting == LabelPreference.hide && !me) {
-            filters.add(cause);
-          }
-        }
 
-        if (!labelCause.downgraded) {
-          if (labelCause.behavior[context] == ModerationBehavior.blur) {
-            blurs.add(cause);
-            if (labelCause.noOverride && !me) {
+          if (!cause.downgraded) {
+            if (behaviors.block[context] == ModerationBehavior.blur) {
               noOverride = true;
+              blurs.add(cause);
+            } else if (behaviors.block[context] == ModerationBehavior.alert) {
+              alerts.add(cause);
+            } else if (behaviors.block[context] == ModerationBehavior.inform) {
+              informs.add(cause);
             }
-          } else if (labelCause.behavior[context] == ModerationBehavior.alert) {
-            alerts.add(cause);
-          } else if (labelCause.behavior[context] ==
-              ModerationBehavior.inform) {
-            informs.add(cause);
           }
-        }
+        case UModerationCauseMuted():
+          if (me) continue;
+
+          if (context.isProfileList || context.isContentList) {
+            filters.add(cause);
+          }
+
+          if (!cause.downgraded) {
+            if (behaviors.mute[context] == ModerationBehavior.blur) {
+              blurs.add(cause);
+            } else if (behaviors.mute[context] == ModerationBehavior.alert) {
+              alerts.add(cause);
+            } else if (behaviors.mute[context] == ModerationBehavior.inform) {
+              informs.add(cause);
+            }
+          }
+        case UModerationCauseMuteWord():
+          if (me) continue;
+
+          if (context.isContentList) {
+            filters.add(cause);
+          }
+
+          if (!cause.downgraded) {
+            if (behaviors.muteWord[context] == ModerationBehavior.blur) {
+              blurs.add(cause);
+            } else if (behaviors.muteWord[context] ==
+                ModerationBehavior.alert) {
+              alerts.add(cause);
+            } else if (behaviors.muteWord[context] ==
+                ModerationBehavior.inform) {
+              informs.add(cause);
+            }
+          }
+        case UModerationCauseHidden():
+          if (context.isProfileList || context.isContentList) {
+            filters.add(cause);
+          }
+
+          if (!cause.downgraded) {
+            if (behaviors.hide[context] == ModerationBehavior.blur) {
+              blurs.add(cause);
+            } else if (behaviors.hide[context] == ModerationBehavior.alert) {
+              alerts.add(cause);
+            } else if (behaviors.hide[context] == ModerationBehavior.inform) {
+              informs.add(cause);
+            }
+          }
+        case UModerationCauseLabel(:final data):
+          final labelCause = data;
+
+          if (context.isProfileList &&
+              labelCause.target == LabelTarget.account) {
+            if (labelCause.setting == LabelPreference.hide && !me) {
+              filters.add(cause);
+            }
+          } else if (context.isContentList &&
+              (labelCause.target == LabelTarget.account ||
+                  labelCause.target == LabelTarget.content)) {
+            if (labelCause.setting == LabelPreference.hide && !me) {
+              filters.add(cause);
+            }
+          }
+
+          if (!labelCause.downgraded) {
+            if (labelCause.behavior[context] == ModerationBehavior.blur) {
+              blurs.add(cause);
+              if (labelCause.noOverride && !me) {
+                noOverride = true;
+              }
+            } else if (labelCause.behavior[context] ==
+                ModerationBehavior.alert) {
+              alerts.add(cause);
+            } else if (labelCause.behavior[context] ==
+                ModerationBehavior.inform) {
+              informs.add(cause);
+            }
+          }
       }
     }
 

--- a/packages/bluesky/lib/src/moderation/utils.dart
+++ b/packages/bluesky/lib/src/moderation/utils.dart
@@ -37,56 +37,61 @@ InterpretedLabelValueDefinition getInterpretedLabelValueDefinition({
       ? ModerationBehavior.inform
       : ModerationBehavior.none;
 
-  if (blurs == 'content') {
-    // target=account, blurs=content
-    accountBehavior[ModerationBehaviorContext.profileList] = alertOrInform;
-    accountBehavior[ModerationBehaviorContext.profileView] = alertOrInform;
-    accountBehavior[ModerationBehaviorContext.contentList] =
-        ModerationBehavior.blur;
-    accountBehavior[ModerationBehaviorContext.contentView] = adultOnly
-        ? ModerationBehavior.blur
-        : alertOrInform;
+  switch (blurs) {
+    case 'content':
+      // target=account, blurs=content
+      accountBehavior[ModerationBehaviorContext.profileList] = alertOrInform;
+      accountBehavior[ModerationBehaviorContext.profileView] = alertOrInform;
+      accountBehavior[ModerationBehaviorContext.contentList] =
+          ModerationBehavior.blur;
+      accountBehavior[ModerationBehaviorContext.contentView] = adultOnly
+          ? ModerationBehavior.blur
+          : alertOrInform;
 
-    // target=profile, blurs=content
-    profileBehavior[ModerationBehaviorContext.profileList] = alertOrInform;
-    profileBehavior[ModerationBehaviorContext.profileView] = alertOrInform;
+      // target=profile, blurs=content
+      profileBehavior[ModerationBehaviorContext.profileList] = alertOrInform;
+      profileBehavior[ModerationBehaviorContext.profileView] = alertOrInform;
 
-    // target=content, blurs=content
-    contentBehavior[ModerationBehaviorContext.contentList] =
-        ModerationBehavior.blur;
-    contentBehavior[ModerationBehaviorContext.contentView] = adultOnly
-        ? ModerationBehavior.blur
-        : alertOrInform;
-  } else if (blurs == 'media') {
-    // target=account, blurs=media
-    accountBehavior[ModerationBehaviorContext.profileList] = alertOrInform;
-    accountBehavior[ModerationBehaviorContext.profileView] = alertOrInform;
-    accountBehavior[ModerationBehaviorContext.avatar] = ModerationBehavior.blur;
-    accountBehavior[ModerationBehaviorContext.banner] = ModerationBehavior.blur;
+      // target=content, blurs=content
+      contentBehavior[ModerationBehaviorContext.contentList] =
+          ModerationBehavior.blur;
+      contentBehavior[ModerationBehaviorContext.contentView] = adultOnly
+          ? ModerationBehavior.blur
+          : alertOrInform;
+    case 'media':
+      // target=account, blurs=media
+      accountBehavior[ModerationBehaviorContext.profileList] = alertOrInform;
+      accountBehavior[ModerationBehaviorContext.profileView] = alertOrInform;
+      accountBehavior[ModerationBehaviorContext.avatar] =
+          ModerationBehavior.blur;
+      accountBehavior[ModerationBehaviorContext.banner] =
+          ModerationBehavior.blur;
 
-    // target=profile, blurs=media
-    profileBehavior[ModerationBehaviorContext.profileList] = alertOrInform;
-    profileBehavior[ModerationBehaviorContext.profileView] = alertOrInform;
-    profileBehavior[ModerationBehaviorContext.avatar] = ModerationBehavior.blur;
-    profileBehavior[ModerationBehaviorContext.banner] = ModerationBehavior.blur;
+      // target=profile, blurs=media
+      profileBehavior[ModerationBehaviorContext.profileList] = alertOrInform;
+      profileBehavior[ModerationBehaviorContext.profileView] = alertOrInform;
+      profileBehavior[ModerationBehaviorContext.avatar] =
+          ModerationBehavior.blur;
+      profileBehavior[ModerationBehaviorContext.banner] =
+          ModerationBehavior.blur;
 
-    // target=content, blurs=media
-    contentBehavior[ModerationBehaviorContext.contentMedia] =
-        ModerationBehavior.blur;
-  } else if (blurs == 'none') {
-    // target=account, blurs=none
-    accountBehavior[ModerationBehaviorContext.profileList] = alertOrInform;
-    accountBehavior[ModerationBehaviorContext.profileView] = alertOrInform;
-    accountBehavior[ModerationBehaviorContext.contentList] = alertOrInform;
-    accountBehavior[ModerationBehaviorContext.contentView] = alertOrInform;
+      // target=content, blurs=media
+      contentBehavior[ModerationBehaviorContext.contentMedia] =
+          ModerationBehavior.blur;
+    case 'none':
+      // target=account, blurs=none
+      accountBehavior[ModerationBehaviorContext.profileList] = alertOrInform;
+      accountBehavior[ModerationBehaviorContext.profileView] = alertOrInform;
+      accountBehavior[ModerationBehaviorContext.contentList] = alertOrInform;
+      accountBehavior[ModerationBehaviorContext.contentView] = alertOrInform;
 
-    // target=profile, blurs=none
-    profileBehavior[ModerationBehaviorContext.profileList] = alertOrInform;
-    profileBehavior[ModerationBehaviorContext.profileView] = alertOrInform;
+      // target=profile, blurs=none
+      profileBehavior[ModerationBehaviorContext.profileList] = alertOrInform;
+      profileBehavior[ModerationBehaviorContext.profileView] = alertOrInform;
 
-    // target=content, blurs=none
-    contentBehavior[ModerationBehaviorContext.contentList] = alertOrInform;
-    contentBehavior[ModerationBehaviorContext.contentView] = alertOrInform;
+      // target=content, blurs=none
+      contentBehavior[ModerationBehaviorContext.contentList] = alertOrInform;
+      contentBehavior[ModerationBehaviorContext.contentView] = alertOrInform;
   }
 
   return InterpretedLabelValueDefinition(
@@ -167,22 +172,23 @@ extension PreferencesExtension on ActorGetPreferencesOutput {
     final labelers = <Map<String, dynamic>>[];
     final labelPrefs = <ContentLabelPref>[];
     for (final preference in preferences) {
-      if (preference.isAdultContentPref) {
-        adultContentEnabled = preference.adultContentPref!.enabled;
-      } else if (preference.isLabelersPref) {
-        labelers.addAll(
-          preference.labelersPref!.labelers.map(
-            (e) => {'did': e.did, 'labels': <String, LabelPreference>{}},
-          ),
-        );
-      } else if (preference.isMutedWordsPref) {
-        mutedWords.addAll(preference.mutedWordsPref!.items);
-      } else if (preference.isHiddenPostsPref) {
-        hiddenPosts.addAll(
-          preference.hiddenPostsPref!.items.map((e) => e.toString()),
-        );
-      } else if (preference.isContentLabelPref) {
-        labelPrefs.add(preference.contentLabelPref!);
+      switch (preference) {
+        case UPreferencesAdultContentPref(:final data):
+          adultContentEnabled = data.enabled;
+        case UPreferencesLabelersPref(:final data):
+          labelers.addAll(
+            data.labelers.map(
+              (e) => {'did': e.did, 'labels': <String, LabelPreference>{}},
+            ),
+          );
+        case UPreferencesMutedWordsPref(:final data):
+          mutedWords.addAll(data.items);
+        case UPreferencesHiddenPostsPref(:final data):
+          hiddenPosts.addAll(data.items.map((e) => e.toString()));
+        case UPreferencesContentLabelPref(:final data):
+          labelPrefs.add(data);
+        default:
+          break;
       }
     }
 

--- a/packages/bluesky/lib/src/tools/utils/group_by.dart
+++ b/packages/bluesky/lib/src/tools/utils/group_by.dart
@@ -87,12 +87,4 @@ Map<T, List<S>> _groupBy<S, T>(Iterable<S> values, T Function(S) key) {
 
 List<List<Notification>> _buildChunks(
   final Map<DateTime, List<Notification>> grouped,
-) {
-  final chunks = <List<Notification>>[];
-
-  for (final notifications in grouped.values) {
-    chunks.add(notifications);
-  }
-
-  return chunks;
-}
+) => grouped.values.toList();

--- a/packages/did_plc/lib/src/client/http_client.dart
+++ b/packages/did_plc/lib/src/client/http_client.dart
@@ -249,16 +249,13 @@ final class _HttpClientImpl implements HttpClient {
         if (fromJson != null) {
           final jsonData = jsonDecode(response.body);
           // Handle both Map and List responses by wrapping Lists in a Map
-          final Map<String, dynamic> processedData;
-          if (jsonData is Map<String, dynamic>) {
-            processedData = jsonData;
-          } else if (jsonData is List) {
-            // For List responses (like operation logs), wrap in a map with 'log' key
-            processedData = {'log': jsonData};
-          } else {
+          final processedData = switch (jsonData) {
+            Map<String, dynamic> map => map,
+            // For List responses (like operation logs), wrap with a 'log' key
+            List() => {'log': jsonData},
             // For other types, wrap in a generic map
-            processedData = {'data': jsonData};
-          }
+            _ => {'data': jsonData},
+          };
           final data = fromJson(processedData);
           return HttpResponse.success(
             statusCode: statusCode,
@@ -356,18 +353,14 @@ final class _HttpClientImpl implements HttpClient {
         );
 
         // Calculate delay, considering rate limiting
-        Duration delay;
-        if (statusCode == 429) {
-          // Rate limiting - check for Retry-After header
-          final retryAfter = headers['retry-after'] ?? headers['Retry-After'];
-          delay = _retryPolicy.delayForRateLimit(retryAfter, attempt);
-        } else if (statusCode == 503) {
-          // Service unavailable - check for Retry-After header
-          final retryAfter = headers['retry-after'] ?? headers['Retry-After'];
-          delay = _retryPolicy.delayForRateLimit(retryAfter, attempt);
-        } else {
-          delay = _retryPolicy.delayForAttempt(attempt);
-        }
+        final delay = switch (statusCode) {
+          // 429 rate limiting / 503 service unavailable - honor Retry-After
+          429 || 503 => _retryPolicy.delayForRateLimit(
+            headers['retry-after'] ?? headers['Retry-After'],
+            attempt,
+          ),
+          _ => _retryPolicy.delayForAttempt(attempt),
+        };
 
         // Wait before retrying
         if (delay > Duration.zero) {

--- a/packages/did_plc/lib/src/types/converter/compatible_op_or_tombstone_converter.dart
+++ b/packages/did_plc/lib/src/types/converter/compatible_op_or_tombstone_converter.dart
@@ -20,21 +20,18 @@ final class _CompatibleOpOrTombstoneConverter
   @override
   CompatibleOpOrTombstone fromJson(Map<String, dynamic> json) {
     try {
-      final type = json['type'];
-
-      if (type == 'plc_operation') {
-        return CompatibleOpOrTombstone.op(data: Operation.fromJson(json));
-      } else if (type == 'plc_tombstone') {
-        return CompatibleOpOrTombstone.tombstone(
+      return switch (json['type']) {
+        'plc_operation' => CompatibleOpOrTombstone.op(
+          data: Operation.fromJson(json),
+        ),
+        'plc_tombstone' => CompatibleOpOrTombstone.tombstone(
           data: Tombstone.fromJson(json),
-        );
-      } else if (type == 'create') {
-        return CompatibleOpOrTombstone.createOpV1(
+        ),
+        'create' => CompatibleOpOrTombstone.createOpV1(
           data: CreateOperationV1.fromJson(json),
-        );
-      }
-
-      return CompatibleOpOrTombstone.unknown(data: json);
+        ),
+        _ => CompatibleOpOrTombstone.unknown(data: json),
+      };
     } catch (_) {
       return CompatibleOpOrTombstone.unknown(data: json);
     }


### PR DESCRIPTION
## Summary

Follow-up to #2463. That PR migrated freezed union *consumption* to `sealed` + `switch`; this PR applies the same Dart 3 modernization to the remaining **hand-written** control flow that it did not touch. **No behavior changes** — pure refactors, all covered by existing tests.

The changes came out of a full-package audit for "latest Dart syntax" opportunities. Most of the codebase is already modern (the generator emits sealed unions and enhanced enums), so this is the small, high-signal set of genuine hand-written wins; mechanical rewrites that did not improve readability were deliberately skipped.

## Changes

### Tier 1 — core packages (`4b80cb0b7`)
- **atproto_oauth**: null-aware map entries (`'k': ?value`, Dart 3.8) in `Session` / `AuthorizationServerMetadata` `toJson`, removing the `expiresAt!` force-unwrap.
- **did_plc**: `CompatibleOpOrTombstone.fromJson` → `switch` expression (now symmetric with `toJson`); PLC-client response-shape dispatch and retry-delay branches → `switch` (type patterns; `429 || 503` or-pattern).
- **bluesky**: dead `_buildChunks` loop → `grouped.values.toList()`.

### Tier 2 — bluesky moderation (`cbf0a1f85`)
- `getModerationPrefs`: `switch` over the sealed `UPreferences`, dropping **5 `xxxPref!` bang casts** via `case UPreferencesXxx(:final data)`.
- `getInterpretedLabelValueDefinition`: `switch` on the `blurs` discriminator.
- `ModerationDecision.getUI`: `switch` over the sealed `ModerationCause` (block causes grouped with an or-pattern) instead of the `is`-check chain, making exhaustiveness **compiler-checked** and consistent with the existing `downgrade()` / `_getCausePriority` switches in the same file.

## Verification
- `dart analyze` clean across all touched packages (the `getUI` switch compiles with no `default`, confirming all 7 `ModerationCause` variants are covered).
- Tests green: `atproto_oauth` (87), `did_plc` (108), bluesky moderation conformance suite (161, identical before/after), notifications grouper, actor service.

## Notes / deliberately skipped
- `severity` ternary in `getInterpretedLabelValueDefinition`: `ModerationBehavior.alert.name` is non-const, so a constant-pattern `switch` isn't possible and a `when`-guard version reads no better than the ternary.
- The `labelers` `Map<String, dynamic>` used as an ad-hoc struct in `getModerationPrefs` could become a record / typed model, but it threads through a mutation path in ported logic — left for a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)