### PR TITLE
chore: fix non-incremental version bumps on unreleased packages

### DIFF
--- a/packages/atproto_test/CHANGELOG.md
+++ b/packages/atproto_test/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release Note
 
-## v1.1.0
+## v1.0.0
 
 - fix: mock response bodies are now encoded with `utf8.encode` instead of `.codeUnits`, so mock JSON containing non-ASCII characters (Japanese, emoji) is no longer corrupted (P-10).
 - fix: `testSubscription` uses a mock `WebSocketChannel` instead of connecting to the real `bsky.network`, so the shared subscription tests no longer spin on a live network connection (P-11).

--- a/packages/atproto_test/pubspec.yaml
+++ b/packages/atproto_test/pubspec.yaml
@@ -1,7 +1,7 @@
 name: atproto_test
 resolution: workspace
 description: This package provides core reusable and useful functionality for testing atproto based packages.
-version: 1.1.0
+version: 1.0.0
 publish_to: none
 homepage: https://atprotodart.com
 documentation: https://atprotodart.com/docs/intro

--- a/packages/bluesky/CHANGELOG.md
+++ b/packages/bluesky/CHANGELOG.md
@@ -1,16 +1,13 @@
 # Release Note
 
-## v2.0.1
+## v2.0.0
 
+- feat!: `Bluesky.fromOAuth(OAuthSessionManager)` (also on `BlueskyChat`/`OzoneTool`); `fromOAuthSession(session, {oauthClient})` wraps a shared manager; `oAuthSession` getter replaced by `oAuthSessionManager`.
 - chore: updated `tools.ozone.queue.defs#queueView.subjectTypes`
 - chore: regenerated from synced lexicons
 - fix: mute-word matching still scans quoted-post embeds when the top-level record fails validation.
 - fix: `LinkPreview` exposes cardyb's `error`/`likelyType` fields.
 - fix: the video service percent-encodes the port when building a `did:web` audience.
-
-## v2.0.0
-
-- feat!: `Bluesky.fromOAuth(OAuthSessionManager)` (also on `BlueskyChat`/`OzoneTool`); `fromOAuthSession(session, {oauthClient})` wraps a shared manager; `oAuthSession` getter replaced by `oAuthSessionManager`.
 
 ## v1.7.2
 

--- a/packages/bluesky/pubspec.yaml
+++ b/packages/bluesky/pubspec.yaml
@@ -1,7 +1,7 @@
 name: bluesky
 resolution: workspace
 description: The most famous and powerful Dart/Flutter library for Bluesky Social.
-version: 2.0.1
+version: 2.0.0
 homepage: https://atprotodart.com
 documentation: https://atprotodart.com/docs/packages/bluesky
 repository: https://github.com/myConsciousness/atproto.dart/tree/main/packages/bluesky

--- a/packages/lex_gen/CHANGELOG.md
+++ b/packages/lex_gen/CHANGELOG.md
@@ -1,23 +1,23 @@
 # Release Note
 
-## v0.4.3
+## v0.4.2
 
-Replace the string-template emission mechanism with a small typed Dart intermediate representation (IR) + emitter. The IR migration itself produces output **byte-for-byte identical** to v0.4.2.
+Two-pass internal refactor of the code generator, plus emitter fixes. The net effect changes generated output (see the fixes below), so **downstream regeneration is required**. (Consolidates the previously-unreleased v0.4.2 and v0.4.3 entries.)
 
-Additional emitter fixes (these do change generated output, so downstream regeneration is required):
+Emitter fixes (these change generated output):
 
 - fix: lexicon descriptions and default values are escaped before interpolation, so text containing `"`, `$`, `\`, or newlines no longer produces uncompilable generated code.
 - fix: the generated repo-commit handler guards against a commit op whose block CID is absent from `blocks` (previously threw a `TypeError`, aborting the whole commit).
 - fix: a bare `ref` to a record lexicon now resolves to the correct `<Name>Record` type instead of an empty class name.
+
+IR migration (replaces the string-template emission mechanism with a small typed Dart intermediate representation (IR) + emitter; output byte-for-byte identical on its own):
 
 - refactor: add `lib/src/ir/{dart_ir,dart_emitter}.dart` — a purpose-built typed IR (`DartFile` / `DartImport` / `DartClass` / members) with explicit member-order and blank-line control, rendered by `emitDartFile`. Because the codegen pipeline runs `dart format`, the emitter only needs to control member order, blank-line presence, comments and tokens; `code_builder` was evaluated and rejected because it imposes its own member order and cannot express the intentional blank lines, so it cannot keep output byte-identical.
 - refactor: migrate every full-file emitter off its monolithic triple-quoted template onto the IR — the freezed data-class renderer (`object/{lex_object,lex_record,lex_input,lex_output}` via `renderFreezedDataClass`), `LexKnownValues`, `LexUnion`, `LexService`, `RepoCommitHandler`, `AtUriExtension`, and the command emitters (`LexCommand`'s query/procedure/blobProcedure/record kinds, `LexParentCommand`, `LexRootCommand`).
 - refactor: model `import` directives as structured `DartImport`s (uri + `show`/`hide`/`as`) instead of concatenated strings. This structurally eliminates the class of bug where an emitted `import '...';` inside a template string was mis-hoisted by `import_sorter` (the command emitters previously worked around this with a fragile concatenation and no longer need to).
 - test: add `srccheck` mode to `scripts/verify_gen_unchanged.sh` (asserts the lex_gen source itself stays import_sorter-stable), and make it non-destructive to any uncommitted working-tree changes.
 
-## v0.4.2
-
-Internal structural/readability refactor (second pass, continuing v0.4.1). Generated output is **byte-for-byte identical** to v0.4.1, verified end-to-end by running the full pipeline (`gen_codes` → `build_runner` → `dart fix` → `import_sorter` → `dart format`) and asserting an empty `git diff` across `atproto`/`bluesky`/`bluesky_cli`, so no downstream regeneration is required.
+Structural/readability refactor (output byte-for-byte identical to v0.4.1 on its own, verified end-to-end by running the full pipeline `gen_codes` → `build_runner` → `dart fix` → `import_sorter` → `dart format` and asserting an empty `git diff` across `atproto`/`bluesky`/`bluesky_cli`):
 
 - refactor: collapse `LexService`'s ~100-`writeln` record-accessor block into per-method emitters, unify the near-identical `create`/`put` bodies and the query/procedure/subscription function↔method pairs, and split the import collector out of `_getPackagePaths`.
 - refactor: lift `RepoCommitHandler`'s constant DTO block out of `format()` and unify the `RepoCommitCreate` / `RepoCommitUpdate` DTOs (which differ only by `createdAt`) into one parameterized emitter with a single-pass member builder.

--- a/packages/lex_gen/pubspec.yaml
+++ b/packages/lex_gen/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lex_gen
 resolution: workspace
 description: Provides a generator that automatically generates source code from the Lexicon in the AT Protocol.
-version: 0.4.3
+version: 0.4.2
 homepage: https://atprotodart.com
 repository: https://github.com/myConsciousness/atproto.dart/tree/main/packages/lex_gen
 issue_tracker: https://github.com/myConsciousness/atproto.dart/issues


### PR DESCRIPTION
## Problem

Three workspace packages had their `pubspec.yaml` / `CHANGELOG.md` version bumped **past** the last version actually published on pub.dev, skipping an intermediate version that was never released. `dart pub publish` rejects these as non-incremental (`It seems you are not publishing an incremental update…`).

| Package | Published (pub.dev) | Was | Skipped (unreleased) |
|---|---|---|---|
| `lex_gen` | `0.4.1` | `0.4.3` | `0.4.2` |
| `bluesky` | `1.7.2` | `2.0.1` | `2.0.0` |
| `atproto_test` | `0.1.2` | `1.1.0` | `0.1.3`…`1.0.x` |

## Fix

Renumber each down to the correct next version and fold the skipped, unreleased CHANGELOG entries together (no released version's notes are lost — none of the skipped versions ever shipped):

- **lex_gen** `0.4.3` → `0.4.2` — merged the two unreleased refactor passes into one `0.4.2` entry.
- **bluesky** `2.0.1` → `2.0.0` — merged the `feat!` OAuth change and the follow-up chores/fixes into one `2.0.0` entry.
- **atproto_test** `1.1.0` → `1.0.0` — single entry relabeled (first `1.0` release over `0.1.2`).

## Dependents verified

- `dart pub get` at the workspace root resolves cleanly (`Got dependencies!`).
- `dart run ./scripts/validate_dependencies.dart` → `✓ All dependency validations passed for 12 packages`.

The only version-form constraint on any renumbered package is `bluesky: ^2.0.0` (in `bluesky_text`), satisfied by `2.0.0`. `lex_gen` is a codegen tool that nothing depends on, and `atproto_test` is referenced only via `path:`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)