### PR TITLE
chore(bluesky_text_flutter): bump bluesky_text to ^1.5.1

### DIFF
--- a/packages/bluesky_text_flutter/CHANGELOG.md
+++ b/packages/bluesky_text_flutter/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Release Note
 
+## v0.1.1
+
+- **CHORE**: Bumped the minimum `bluesky_text` dependency to `^1.5.1`, which
+  fixes email addresses being partially linkified and non-ASCII URL paths being
+  truncated. This improves entity rendering in `BlueskyRichText` and
+  `BlueskyTextEditingController`.
+
 ## v0.1.0
 
 - **FEAT**: Initial release. Flutter companion for

--- a/packages/bluesky_text_flutter/pubspec.yaml
+++ b/packages/bluesky_text_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: bluesky_text_flutter
 description: Flutter widgets for bluesky_text — a rich-text editing controller that highlights entities and the over-limit tail as you type, and a viewer for fetched posts.
-version: 0.1.0
+version: 0.1.1
 homepage: https://atprotodart.com
 repository: https://github.com/myConsciousness/atproto.dart/tree/main/packages/bluesky_text_flutter
 issue_tracker: https://github.com/myConsciousness/atproto.dart/issues
@@ -20,7 +20,7 @@ topics:
 dependencies:
   flutter:
     sdk: flutter
-  bluesky_text: ^1.5.0
+  bluesky_text: ^1.5.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary

`bluesky_text_flutter` was resolving `bluesky_text` to **1.5.0** even though **1.5.1** is published. The dependency constraint was `^1.5.0` and the (git-ignored) lockfile had never been upgraded, so the package was building against the older release.

`bluesky_text` 1.5.1 ships two fixes that directly affect the widgets in this package:

- Email addresses are no longer partially linkified (e.g. the domain of `mail@alice.bsky.social` is no longer turned into a link).
- URL paths containing non-ASCII characters are no longer truncated (e.g. `https://ja.wikipedia.org/wiki/日本語` resolves to the full URL).

Both influence entity rendering in `BlueskyRichText` and `BlueskyTextEditingController`.

## Changes

- Bump the `bluesky_text` constraint from `^1.5.0` to `^1.5.1`.
- Release `bluesky_text_flutter` **0.1.1** with a matching CHANGELOG entry.

## Verification

- `flutter pub get` resolves `bluesky_text` to 1.5.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)