### PR TITLE
chore(bluesky_text_flutter): bump bluesky_text to ^1.5.2

### DIFF
--- a/packages/bluesky_text_flutter/CHANGELOG.md
+++ b/packages/bluesky_text_flutter/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - docs: documented `BlueskyRichText`'s primary `onFeatureTap` callback (`FeatureTapCallback = void Function(FacetFeature feature)`) alongside the typed `onMentionTap`/`onLinkTap`/`onTagTap` conveniences, plus the `featureStyle`, `style`, `textAlign`, `maxLines`, and `overflow` styling parameters.
 - docs: bumped the README install snippet to `^0.1.2`.
+- chore: bump `bluesky_text` to `^1.5.2` (now published).
 
 ## v0.1.1
 

--- a/packages/bluesky_text_flutter/pubspec.yaml
+++ b/packages/bluesky_text_flutter/pubspec.yaml
@@ -20,7 +20,7 @@ topics:
 dependencies:
   flutter:
     sdk: flutter
-  bluesky_text: ^1.5.1
+  bluesky_text: ^1.5.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary

Follow-up to #2473. Now that **`bluesky_text 1.5.2` is published to pub.dev**, restore `bluesky_text_flutter`'s dependency constraint to `^1.5.2`.

`bluesky_text_flutter` lives outside the Dart pub workspace and resolves its dependencies from pub.dev, so in #2473 the constraint was temporarily held at `^1.5.1` to keep CI's `flutter pub get` green before the release (referencing the then-unpublished `1.5.2` failed version solving). With `1.5.2` now live, the constraint is bumped back.

No version bump: `bluesky_text_flutter 0.1.2` has not been published yet (pub.dev latest is `0.1.1`), so this ships as part of the pending `0.1.2` release.

## Verification

- `flutter pub get` resolves `bluesky_text 1.5.2` cleanly (local + example).

🤖 Generated with [Claude Code](https://claude.com/claude-code)