### PR TITLE
ci(website): deploy to S3/CloudFront via CodeBuild on pushes to main

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,4 +139,7 @@ coverage.lcov
 # Kiro IDE
 .kiro
 .lex_gen_baseline/
-docs
+# Anchored to the repository root on purpose. A bare `docs` also matches
+# website/docs, which silently dropped newly generated lexicon documents from
+# commits and left dangling links in the site.
+/docs/

--- a/scripts/gen_lexicon_matrix.dart
+++ b/scripts/gen_lexicon_matrix.dart
@@ -116,7 +116,14 @@ String _generateMatrixContent(String nsid, Map<String, LexUserType> defs) {
     _writeDefinition(matrix, def, id);
   }
 
-  return matrix.toString();
+  // This file is written to <root>/<segments except last>/<last>.md, which sits
+  // segments.length directories below the docs root, so that many '..' hops lead
+  // back to it. This used to be hardcoded to four, which happened to be right
+  // only for four-segment NSIDs and broke shorter ones such as
+  // com.germnetwork.declaration and site.standard.document.
+  final refRoot = List.filled(segments.length, '..').join('/');
+
+  return matrix.toString().replaceAll(_refRootToken, refRoot);
 }
 
 /// Writes a definition to the matrix buffer.
@@ -647,6 +654,14 @@ String _toSpecReference(final String type) => switch (type) {
   _ => type,
 };
 
+/// Placeholder for the relative hop back to the docs root.
+///
+/// Ref links are relative to the file being written, but [_toRefLink] receives
+/// only the target ref and so cannot know how deep the source file sits.
+/// [_generateMatrixContent] substitutes this token once the source NSID, and
+/// therefore the depth, is known.
+const _refRootToken = '{{REF_ROOT}}';
+
 /// Converts a reference to a markdown link.
 String _toRefLink(final String ref) {
   if (ref.startsWith('#')) return '[$ref](${ref.toLowerCase()})';
@@ -659,13 +674,13 @@ String _toRefLink(final String ref) {
     final fileName = segments.last;
     final objectId = pathAndObjectId.last.toLowerCase();
 
-    return '[$ref](../../../../lexicons/$path/$fileName.md#$objectId)';
+    return '[$ref]($_refRootToken/lexicons/$path/$fileName.md#$objectId)';
   }
 
   final segments = ref.split('.');
   final path = segments.sublist(0, segments.length - 1).join('/');
 
-  return '[$ref](../../../../lexicons/$path/${segments.last}.md#main)';
+  return '[$ref]($_refRootToken/lexicons/$path/${segments.last}.md#main)';
 }
 
 /// Escapes special characters in markdown.

--- a/website/buildspec.yaml
+++ b/website/buildspec.yaml
@@ -38,9 +38,18 @@ phases:
 
   post_build:
     commands:
+      # CodeBuild runs post_build even when build fails, so publishing must be
+      # gated on CODEBUILD_BUILD_SUCCEEDING. Without this a failed build still
+      # reaches the sync below, and because that sync runs with --delete, a
+      # failure that leaves build/ empty or partial would wipe the live site.
       - |
         [ "$(cat /tmp/deploy)" = "1" ] || exit 0
+        if [ "$CODEBUILD_BUILD_SUCCEEDING" != "1" ]; then
+          echo "build failed - refusing to publish"
+          exit 1
+        fi
         cd "$CODEBUILD_SRC_DIR/website"
+        test -f ./build/index.html || { echo "build/index.html missing - refusing to publish"; exit 1; }
         aws s3 sync ./build "s3://$S3_ORIGIN_BUCKET/" --delete
         aws cloudfront create-invalidation \
           --distribution-id "$CLOUDFRONT_DIST_ID" \

--- a/website/buildspec.yaml
+++ b/website/buildspec.yaml
@@ -1,27 +1,51 @@
 version: 0.2
 
+# Deploys website/ to the S3 origin behind CloudFront (atprotodart.com).
+#
+# The webhook that drives this project filters on PUSH + refs/heads/main only.
+# It deliberately does NOT use a FILE_PATH filter: AWS evaluates FILE_PATH against
+# only the first 100 changed files of a push, and this repo routinely lands codegen
+# pushes of 800-1600 files in which website/ sorts last. Those deploys would be
+# silently skipped. Diffing the real push range here cannot miss them.
+
 phases:
   install:
     runtime-versions:
       nodejs: 24
     commands:
-      - cd website
-      - npm install
+      # Decide whether this push actually touched website/. An unknown commit range
+      # (manual build, first build) deploys rather than skips, so ambiguity fails safe.
+      - |
+        DEPLOY=1
+        if [ -n "$CODEBUILD_WEBHOOK_PREV_COMMIT" ] && [ -n "$CODEBUILD_RESOLVED_SOURCE_VERSION" ]; then
+          if git diff --quiet "$CODEBUILD_WEBHOOK_PREV_COMMIT" "$CODEBUILD_RESOLVED_SOURCE_VERSION" -- website/; then
+            DEPLOY=0
+          fi
+        fi
+        echo "$DEPLOY" > /tmp/deploy
+        echo "website/ changed: $DEPLOY"
+      - |
+        [ "$(cat /tmp/deploy)" = "1" ] || exit 0
+        cd "$CODEBUILD_SRC_DIR/website"
+        npm ci
 
   build:
     commands:
-      - npm run build
+      - |
+        [ "$(cat /tmp/deploy)" = "1" ] || exit 0
+        cd "$CODEBUILD_SRC_DIR/website"
+        npm run build
 
   post_build:
     commands:
-      - aws s3 sync ./build s3://$S3_ORIGIN_BUCKET/ --delete
-      - aws cloudfront create-invalidation --distribution-id $CLOUDFRONT_DIST_ID --paths "/*"
-
-artifacts:
-  files:
-    - 'build/**/*'
-  name: BuildArtifact
+      - |
+        [ "$(cat /tmp/deploy)" = "1" ] || exit 0
+        cd "$CODEBUILD_SRC_DIR/website"
+        aws s3 sync ./build "s3://$S3_ORIGIN_BUCKET/" --delete
+        aws cloudfront create-invalidation \
+          --distribution-id "$CLOUDFRONT_DIST_ID" \
+          --paths "/*"
 
 cache:
   paths:
-    - 'node_modules/**/*'
+    - 'website/node_modules/**/*'

--- a/website/docs/lexicons/app/bsky/graph/searchStarterPacksV2.md
+++ b/website/docs/lexicons/app/bsky/graph/searchStarterPacksV2.md
@@ -1,0 +1,28 @@
+---
+title: searchStarterPacksV2
+description: app.bsky.graph.searchStarterPacksV2
+---
+
+# [app.bsky.graph.searchStarterPacksV2](https://github.com/myConsciousness/atproto.dart/blob/main/lexicons/app/bsky/graph/searchStarterPacksV2.json)
+
+## #main
+
+Find starter packs matching search criteria. Does not require auth.
+
+### Parameters
+
+| Property | Type | Known Values | Required | Description |
+| --- | --- | --- | :---: | --- |
+| **q** | string | - | ✅ | Search query string. Syntax, phrase, boolean, and faceting is unspecified, but Lucene query syntax is recommended. |
+| **limit** | integer | - | ❌ | - |
+| **cursor** | string | - | ❌ | - |
+
+### Output
+
+- **Encoding**: application/json
+
+| Property | Type | Known Values | Required | Description |
+| --- | --- | --- | :---: | --- |
+| **cursor** | string | - | ❌ | - |
+| **hitsTotal** | integer | - | ❌ | Estimated total number of matching hits. May be rounded or truncated. |
+| **starterPacks** | array of [app.bsky.graph.defs#starterPackView](../../../../lexicons/app/bsky/graph/defs.md#starterpackview) | - | ✅ | - |

--- a/website/docs/lexicons/com/germnetwork/declaration.md
+++ b/website/docs/lexicons/com/germnetwork/declaration.md
@@ -11,7 +11,7 @@ description: com.germnetwork.declaration
 
 A declaration of a Germ Network account
 
-Use [com.atproto.repo.createRecord](../../../../lexicons/com/atproto/repo/createRecord.md#main) to create a record.
+Use [com.atproto.repo.createRecord](../../../lexicons/com/atproto/repo/createRecord.md#main) to create a record.
 
 | Property | Type | Known Values | Required | Description |
 | --- | --- | --- | :---: | --- |
@@ -25,7 +25,7 @@ Use [com.atproto.repo.createRecord](../../../../lexicons/com/atproto/repo/create
 
 | Property | Type | Known Values | Required | Description |
 | --- | --- | --- | :---: | --- |
-| ref | [com.atproto.repo.strongRef](../../../../lexicons/com/atproto/repo/strongRef.md#main) | - | ✅ | - |
+| ref | [com.atproto.repo.strongRef](../../../lexicons/com/atproto/repo/strongRef.md#main) | - | ✅ | - |
 
 ## #messageMe
 

--- a/website/docs/lexicons/site/standard/document.md
+++ b/website/docs/lexicons/site/standard/document.md
@@ -19,16 +19,16 @@ description: site.standard.document
 
 A document record representing a published article, blog post, or other content. Documents can belong to a publication or exist independently.
 
-Use [com.atproto.repo.createRecord](../../../../lexicons/com/atproto/repo/createRecord.md#main) to create a record.
+Use [com.atproto.repo.createRecord](../../../lexicons/com/atproto/repo/createRecord.md#main) to create a record.
 
 | Property | Type | Known Values | Required | Description |
 | --- | --- | --- | :---: | --- |
-| **bskyPostRef** | [com.atproto.repo.strongRef](../../../../lexicons/com/atproto/repo/strongRef.md#main) | - | ❌ | - |
+| **bskyPostRef** | [com.atproto.repo.strongRef](../../../lexicons/com/atproto/repo/strongRef.md#main) | - | ❌ | - |
 | **content** | union of <br/> | - | ❌ | - |
 | **contributors** | array of [#contributor](#contributor) | - | ❌ | - |
 | **coverImage** | [blob](https://atproto.com/specs/data-model#blob-type) | - | ❌ | Image to used for thumbnail or cover image. Less than 1MB is size. |
 | **description** | string | - | ❌ | A brief description or excerpt from the document. |
-| **labels** | union of <br/>[com.atproto.label.defs#selfLabels](../../../../lexicons/com/atproto/label/defs.md#selflabels) | - | ❌ | - |
+| **labels** | union of <br/>[com.atproto.label.defs#selfLabels](../../../lexicons/com/atproto/label/defs.md#selflabels) | - | ❌ | - |
 | **links** | union of <br/> | - | ❌ | - |
 | **path** | string | - | ❌ | Combine with site or publication url to construct a canonical URL to the document. Prepend with a leading slash. |
 | **publishedAt** | string ([datetime](https://atproto.com/specs/lexicon#datetime)) | - | ✅ | Timestamp of the documents publish time. |
@@ -42,4 +42,4 @@ Use [com.atproto.repo.createRecord](../../../../lexicons/com/atproto/repo/create
 
 | Property | Type | Known Values | Required | Description |
 | --- | --- | --- | :---: | --- |
-| ref | [com.atproto.repo.strongRef](../../../../lexicons/com/atproto/repo/strongRef.md#main) | - | ✅ | - |
+| ref | [com.atproto.repo.strongRef](../../../lexicons/com/atproto/repo/strongRef.md#main) | - | ✅ | - |

--- a/website/docs/lexicons/site/standard/publication.md
+++ b/website/docs/lexicons/site/standard/publication.md
@@ -11,14 +11,14 @@ description: site.standard.publication
 
 A publication record representing a blog, website, or content platform. Publications serve as containers for documents and define the overall branding and settings.
 
-Use [com.atproto.repo.createRecord](../../../../lexicons/com/atproto/repo/createRecord.md#main) to create a record.
+Use [com.atproto.repo.createRecord](../../../lexicons/com/atproto/repo/createRecord.md#main) to create a record.
 
 | Property | Type | Known Values | Required | Description |
 | --- | --- | --- | :---: | --- |
-| **basicTheme** | [site.standard.theme.basic](../../../../lexicons/site/standard/theme/basic.md#main) | - | ❌ | - |
+| **basicTheme** | [site.standard.theme.basic](../../../lexicons/site/standard/theme/basic.md#main) | - | ❌ | - |
 | **description** | string | - | ❌ | Brief description of the publication. |
 | **icon** | [blob](https://atproto.com/specs/data-model#blob-type) | - | ❌ | Square image to identify the publication. Should be at least 256x256. |
-| **labels** | union of <br/>[com.atproto.label.defs#selfLabels](../../../../lexicons/com/atproto/label/defs.md#selflabels) | - | ❌ | - |
+| **labels** | union of <br/>[com.atproto.label.defs#selfLabels](../../../lexicons/com/atproto/label/defs.md#selflabels) | - | ❌ | - |
 | **name** | string | - | ✅ | Name of the publication. |
 | **preferences** | [#preferences](#preferences) | - | ❌ | - |
 | **url** | string ([uri](https://atproto.com/specs/lexicon#uri)) | - | ✅ | Base publication url (ex: https://standard.site). The canonical document URL is formed by combining this value with the document path. |
@@ -27,7 +27,7 @@ Use [com.atproto.repo.createRecord](../../../../lexicons/com/atproto/repo/create
 
 | Property | Type | Known Values | Required | Description |
 | --- | --- | --- | :---: | --- |
-| ref | [com.atproto.repo.strongRef](../../../../lexicons/com/atproto/repo/strongRef.md#main) | - | ✅ | - |
+| ref | [com.atproto.repo.strongRef](../../../lexicons/com/atproto/repo/strongRef.md#main) | - | ✅ | - |
 
 ## #preferences
 


### PR DESCRIPTION
Sets up automated deployment of `website/` to the `atprotodart.com` S3 origin behind CloudFront, triggered by pushes to `main`.

## Why the path filter lives in the build, not the webhook

The obvious implementation is a CodeBuild `FILE_PATH` webhook filter on `^website/`. That is not safe in this repository. AWS evaluates `FILE_PATH` against [only the first 100 changed files](https://docs.aws.amazon.com/codebuild/latest/userguide/github-webhook.html) of a push, and this repo routinely lands codegen pushes of 800-1600 files in which `website/` sorts last.

Auditing the last 12 months of commits touching `website/`, 7 of ~25 would have been silently skipped:

| Commit | Files in push | First `website/` file at |
|---|---|---|
| `cfca9cf86` generate code based on lexicons | 1639 | #1633 |
| `b38b45315` Sync lexicons and regenerate (#2458) | 1171 | #1170 |
| `7aeda62fd` Update source files automatically | 883 | #883 |
| `836a408ba` Add chat/group convo codegen | 833 | #769 |
| `86743a1ea` Update source files automatically | 175 | #141 |
| `21b8e7eda` fix(lex_gen) generate List for props | 133 | #118 |
| `6ba544576` Update source files automatically | 116 | #108 |

The misses cluster on the recurring lexicon-sync commits, which are the most frequent path to `main`, and the failure is silent: nothing errors, the site just goes stale.

So the webhook filters only on `EVENT=PUSH` and `HEAD_REF=^refs/heads/main$`, and the buildspec diffs the real push range (`CODEBUILD_WEBHOOK_PREV_COMMIT..CODEBUILD_RESOLVED_SOURCE_VERSION`) to decide whether to deploy. Deploys still happen only for `website/` changes, but the decision cannot miss. An unknown commit range (manual or first build) deploys rather than skips, so ambiguity fails safe. This requires a full clone, hence `gitCloneDepth: 0`.

## Why the site had not updated since March

The published site was frozen at 2026-03-08. The cause was not a missing pipeline: `npm run build` has been failing on `main`. Three defects, fixed here.

1. **`gen_lexicon_matrix` hardcoded four `..` hops** in ref links. That is correct only for four-segment NSIDs. Shorter ones (`com.germnetwork.declaration`, `site.standard.document`) sit a directory higher, so the prefix overshot the docs root and every ref link on those pages dangled. The hop count is now derived from the NSID segment count.

2. **The bare `docs` pattern in `.gitignore`** was meant to exclude the repository-root `docs/` directory, but it also matched `website/docs`, so newly generated lexicon documents were silently dropped from commits. That is how `app.bsky.graph.searchStarterPacksV2` landed as a lexicon with no document, leaving `supported_api.md` pointing at a file that was never committed. The pattern is now anchored to the root.

3. **`post_build` published even when `build` failed.** CodeBuild runs `post_build` regardless of build outcome, and the sync uses `--delete`, so a build failing early enough to leave `build/` empty or partial would have deleted the live site rather than merely publishing stale content. Publishing is now gated on `CODEBUILD_BUILD_SUCCEEDING` plus an assertion that `build/index.html` exists.

Regenerating with fixes 1 and 2 changes only the three shallow-NSID files and adds the one missing document; the other 381 are untouched.

## Also corrected in the buildspec

- `artifacts` referenced `build/**/*` relative to the source root, but the output is `website/build`. Dropped entirely, since `post_build` already syncs to S3.
- `cache` referenced `node_modules/**/*` with the same root-relative mistake.
- `npm install` replaced by `npm ci` for reproducibility.

## AWS resources

Created outside this repo, in `ap-northeast-1`:

- CodeBuild project `atprotodart-origin-build` (PRIVATE, CloudWatch logs enabled), reusing the existing `atprotodart-origin` bucket and `EGA1X6C0HD2DD` distribution.
- A webhook restricted to `PUSH` on `refs/heads/main`.

Security notes, given this is a public repository:

- **No pull-request events.** Enabling them would let anyone execute arbitrary code from a fork PR under a role that can write to the production bucket. The event filter is a security boundary here, not just a convenience.
- The pre-existing service role granted `cloudfront:DeleteDistribution` and `cloudfront:UpdateDistribution`, neither of which the deploy uses. Since the build installs a large npm dependency tree, that was a supply-chain path to destroying the distribution. The role now holds only `CreateInvalidation` on the one distribution, `ListBucket` on the one bucket, and object read/write/delete on that bucket's contents.
- The trust policy previously had no `aws:SourceAccount` / `aws:SourceArn` conditions; both are now set.
- The base policy's blanket access to `codepipeline-ap-northeast-1-*` buckets was removed, as no pipeline is involved.

## Verification

- `npm run build` passes locally, and in CodeBuild end to end (build `a1ef41b7`, SUCCEEDED).
- Post-deploy, all previously broken paths return 200, including `/docs/lexicons/com/germnetwork/declaration`, `/docs/lexicons/site/standard/document`, and `/docs/lexicons/app/bsky/graph/searchStarterPacksV2` (which had no page at all before).
- The site is now current; four months of accumulated `website/` changes, including the Lysto OAuth client metadata, are live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)