### PR TITLE
docs(website): align bluesky, atproto and bluesky_text with the real API

### DIFF
--- a/website/docs/packages/atproto.md
+++ b/website/docs/packages/atproto.md
@@ -32,16 +32,17 @@ This package focuses on core AT Protocol functionality, making it ideal for buil
 
 ## Features ⭐
 
-- ✅ **Zero External Dependencies** - Pure Dart implementation with minimal footprint
-- ✅ **Advanced Built-In Retry** using **[Exponential BackOff And Jitter](https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/)** algorithm
+- ✅ **Small Dependency Footprint** - Only `atproto_core`, `xrpc`, and the two codegen annotation packages
+- ✅ **Pluggable Retry** - An opt-in **[Exponential BackOff And Jitter](https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/)** policy that is idempotency-safe, plus a `RetryStrategy` interface to replace it wholesale
 - ✅ **Comprehensive API Coverage** - Supports **[All Major Endpoints](../supported_api.md#atproto)** for [`com.atproto.*`](https://github.com/bluesky-social/atproto/tree/main/lexicons/com/atproto)
-- ✅ **Multiple Authentication Methods** - Session-based auth, OAuth 2.0 with DPoP, and anonymous access
-- ✅ **Real-time Firehose API** - Stream live events from AT Protocol services
+- ✅ **Multiple Authentication Methods** - Session-based auth with transparent refresh, OAuth 2.0 with DPoP, and anonymous access
+- ✅ **Real-time Firehose API** - Stream live events from AT Protocol services, already decoded and typed
 - ✅ **Production Ready** - Well documented, thoroughly tested, and actively maintained
 - ✅ **Type Safe** - 100% null safety with comprehensive error handling
 - ✅ **Service Agnostic** - Works with any AT Protocol service, not just Bluesky
 - ✅ **Rate Limit Handling** - Built-in rate limit detection and management
 - ✅ **Union Type Support** - Handles complex AT Protocol data structures safely
+- ✅ **Injectable Transport** - Supply your own HTTP client for tests, proxies, or tracing
 
 :::tip
 See **[API Supported Matrix](../supported_api.md#atproto)** for a list of endpoints supported by **[atproto](https://pub.dev/packages/atproto)**.
@@ -114,20 +115,22 @@ See **[API Supported Matrix](../supported_api.md#atproto)** for whether authenti
 
 For most applications, use session-based authentication with your handle/email and password:
 
+<!-- snippet: atproto/session.dart -->
 ```dart title="Session Authentication"
 import 'package:atproto/atproto.dart' as atp;
 
 Future<void> main() async {
-  // Create session with your credentials
+  // Create session with your credentials.
   final session = await atp.createSession(
     identifier: 'your.handle.com', // Your handle or email
-    password: 'your-app-password',  // App password recommended
+    password: 'your-app-password', // App password recommended
   );
 
-  // Create ATProto instance from session
+  // Create ATProto instance from session. An expired access token is
+  // refreshed transparently using the session's refresh token.
   final atproto = atp.ATProto.fromSession(session.data);
-  
-  // Now you can use authenticated endpoints
+
+  // Now you can use authenticated endpoints.
   final profile = await atproto.repo.getRecord(
     repo: session.data.did,
     collection: 'app.bsky.actor.profile',
@@ -135,17 +138,23 @@ Future<void> main() async {
   );
 }
 ```
+<!-- /snippet -->
+
+An instance built this way keeps its own session alive: when a request comes back `401` because the access token has expired, the refresh token is spent, the session is replaced, and the request is retried once. See **[Session Refresh](#session-refresh)**.
 
 #### 2. OAuth Authentication
 
 For applications requiring OAuth 2.0 with DPoP, use **[atproto_oauth](./atproto_oauth.md)**. Every stage of the flow is pluggable, and `authorize` persists the per-authorization state in an `OAuthStateStore` (in-memory by default), so `callback` takes only the redirect URL — you no longer thread a context object through by hand.
 
+The primary constructor is **[`ATProto.fromOAuth`](https://pub.dev/documentation/atproto/latest/atproto/ATProto/ATProto.fromOAuth.html)**, which takes an `OAuthSessionManager`. The manager owns DPoP header building and transparent token refresh, so it is what you want whenever you hold on to a client for more than one request. **[`ATProto.fromOAuthSession`](https://pub.dev/documentation/atproto/latest/atproto/ATProto/ATProto.fromOAuthSession.html)** is a convenience wrapper that builds the manager for you from a session.
+
+<!-- snippet: atproto/oauth.dart -->
 ```dart title="OAuth Authentication"
 import 'package:atproto/atproto.dart' as atp;
 import 'package:atproto/atproto_oauth.dart';
 
 Future<void> main() async {
-  // Use your client metadata
+  // Use your client metadata.
   final metadata = await getClientMetadata(
     'https://atprotodart.com/oauth/bluesky/atprotodart/client-metadata.json',
   );
@@ -178,11 +187,21 @@ Future<void> main() async {
   // final refreshed = await client.refresh(session);
   // await client.revoke(session);
 
-  // Create ATProto instance from OAuth session. Pass `oauthClient` so tokens
-  // refresh transparently.
-  final atproto = atp.ATProto.fromOAuthSession(restored!, oauthClient: client);
+  // The primary constructor takes an OAuthSessionManager, which owns DPoP
+  // header building and transparent token refresh.
+  final atproto = atp.ATProto.fromOAuth(
+    OAuthSessionManager.fromSession(restored!, client: client),
+  );
+
+  // `fromOAuthSession` is a thin wrapper over the above.
+  final same = atp.ATProto.fromOAuthSession(restored, oauthClient: client);
 }
 ```
+<!-- /snippet -->
+
+:::caution
+`fromOAuthSession` without an `oauthClient` uses the session as-is and **cannot refresh it**. Once the access token expires, every request fails with `401`.
+:::
 
 :::tip
 See the **[atproto_oauth](./atproto_oauth.md)** guide for the full pluggable flow, `OAuthSessionManager`, and session persistence.
@@ -192,19 +211,20 @@ See the **[atproto_oauth](./atproto_oauth.md)** guide for the full pluggable flo
 
 For public endpoints that don't require authentication:
 
+<!-- snippet: atproto/anonymous.dart -->
 ```dart title="Anonymous Access"
 import 'package:atproto/atproto.dart';
 
 Future<void> main() async {
-  // Create anonymous instance
+  // Create anonymous instance.
   final atproto = ATProto.anonymous();
-  
-  // Use public endpoints
-  final did = await atproto.identity.resolveHandle(
-    handle: 'bsky.app',
-  );
+
+  // Use public endpoints.
+  final did = await atproto.identity.resolveHandle(handle: 'bsky.app');
+  print(did.data.did);
 }
 ```
+<!-- /snippet -->
 
 :::info
 See **[Session Management](#session-management)** for more details about authentication.
@@ -216,45 +236,52 @@ See **[Session Management](#session-management)** for more details about authent
 
 | Property | Class | Lexicon | Description |
 | -------- | ----- | ------- | ----------- |
+| **[admin](https://pub.dev/documentation/atproto/latest/atproto/ATProto/admin.html)** | [AdminService](https://pub.dev/documentation/atproto/latest/atproto/AdminService-class.html) | [`com.atproto.admin.*`](https://github.com/bluesky-social/atproto/tree/main/lexicons/com/atproto/admin) | Server administration, account and subject status |
 | **[server](https://pub.dev/documentation/atproto/latest/atproto/ATProto/server.html)** | [ServerService](https://pub.dev/documentation/atproto/latest/atproto/ServerService-class.html) | [`com.atproto.server.*`](https://github.com/bluesky-social/atproto/tree/main/lexicons/com/atproto/server) | Account management, sessions, app passwords |
 | **[identity](https://pub.dev/documentation/atproto/latest/atproto/ATProto/identity.html)** | [IdentityService](https://pub.dev/documentation/atproto/latest/atproto/IdentityService-class.html) | [`com.atproto.identity.*`](https://github.com/bluesky-social/atproto/tree/main/lexicons/com/atproto/identity) | Handle resolution, DID operations |
 | **[repo](https://pub.dev/documentation/atproto/latest/atproto/ATProto/repo.html)** | [RepoService](https://pub.dev/documentation/atproto/latest/atproto/RepoService-class.html) | [`com.atproto.repo.*`](https://github.com/bluesky-social/atproto/tree/main/lexicons/com/atproto/repo) | Record CRUD operations, blob uploads |
 | **[moderation](https://pub.dev/documentation/atproto/latest/atproto/ATProto/moderation.html)** | [ModerationService](https://pub.dev/documentation/atproto/latest/atproto/ModerationService-class.html) | [`com.atproto.moderation.*`](https://github.com/bluesky-social/atproto/tree/main/lexicons/com/atproto/moderation) | Content reporting and moderation |
-| **[sync](https://pub.dev/documentation/atproto/latest/atproto/ATProto/sync.html)** | [SyncService](https://pub.dev/documentation/atproto/latest/atproto/SyncService-class.html) | [`com.atproto.sync.*`](https://github.com/bluesky-social/atproto/tree/main/lexicons/com/atproto/sync) | Repository synchronization, Firehose API |
+| **[sync](https://pub.dev/documentation/atproto/latest/atproto/ATProto/sync.html)** | [SyncServiceImpl](https://pub.dev/documentation/atproto/latest/atproto/SyncServiceImpl-class.html) | [`com.atproto.sync.*`](https://github.com/bluesky-social/atproto/tree/main/lexicons/com/atproto/sync) | Repository synchronization, Firehose API |
 | **[label](https://pub.dev/documentation/atproto/latest/atproto/ATProto/label.html)** | [LabelService](https://pub.dev/documentation/atproto/latest/atproto/LabelService-class.html) | [`com.atproto.label.*`](https://github.com/bluesky-social/atproto/tree/main/lexicons/com/atproto/label) | Content labeling and queries |
+| **[lexicon](https://pub.dev/documentation/atproto/latest/atproto/ATProto/lexicon.html)** | [LexiconService](https://pub.dev/documentation/atproto/latest/atproto/LexiconService-class.html) | [`com.atproto.lexicon.*`](https://github.com/bluesky-social/atproto/tree/main/lexicons/com/atproto/lexicon) | Lexicon schema resolution |
 | **[temp](https://pub.dev/documentation/atproto/latest/atproto/ATProto/temp.html)** | [TempService](https://pub.dev/documentation/atproto/latest/atproto/TempService-class.html) | [`com.atproto.temp.*`](https://github.com/bluesky-social/atproto/tree/main/lexicons/com/atproto/temp) | Temporary/experimental endpoints |
+
+:::note
+`sync` is typed as `SyncServiceImpl` rather than the generated `SyncService`. It adds **[`subscribeReposAsMessages`](#firehose-api)**, which yields decoded, typed Firehose messages, on top of every generated `com.atproto.sync.*` method.
+:::
 
 #### Service Usage Examples
 
 Once you have an ATProto instance, access endpoints through their corresponding service properties:
 
-```dart
+<!-- snippet: atproto/services_public.dart -->
+```dart title="services_public.dart"
 import 'package:atproto/atproto.dart' as atp;
 
 Future<void> main() async {
   final atproto = atp.ATProto.anonymous();
 
-  // Identity Service - Resolve handles to DIDs
-  final didResult = await atproto.identity.resolveHandle(
-    handle: 'bsky.app',
-  );
+  // Identity Service - Resolve handles to DIDs.
+  final didResult = await atproto.identity.resolveHandle(handle: 'bsky.app');
   print('DID: ${didResult.data.did}');
 
-  // Server Service - Get server information
+  // Server Service - Get server information.
   final serverInfo = await atproto.server.describeServer();
   print('Server: ${serverInfo.data.availableUserDomains}');
 
-  // Label Service - Query content labels
+  // Label Service - Query content labels.
   final labels = await atproto.label.queryLabels(
     uriPatterns: ['at://did:plc:example'],
   );
   print('Labels found: ${labels.data.labels.length}');
 }
 ```
+<!-- /snippet -->
 
 For authenticated operations:
 
-```dart
+<!-- snippet: atproto/services_authenticated.dart -->
+```dart title="services_authenticated.dart"
 import 'package:atproto/atproto.dart' as atp;
 
 Future<void> main() async {
@@ -262,10 +289,10 @@ Future<void> main() async {
     identifier: 'your.handle.com',
     password: 'your-app-password',
   );
-  
+
   final atproto = atp.ATProto.fromSession(session.data);
 
-  // Repo Service - Create a record
+  // Repo Service - Create a record.
   final record = await atproto.repo.createRecord(
     repo: session.data.did,
     collection: 'app.bsky.feed.post',
@@ -274,17 +301,18 @@ Future<void> main() async {
       'createdAt': DateTime.now().toUtc().toIso8601String(),
     },
   );
-  
-  // Repo Service - List your records
+
+  // Repo Service - List your records.
   final records = await atproto.repo.listRecords(
     repo: session.data.did,
     collection: 'app.bsky.feed.post',
   );
-  
+
   print('Created record: ${record.data.uri}');
   print('Total posts: ${records.data.records.length}');
 }
 ```
+<!-- /snippet -->
 
 :::tip
 See **[API Supported Matrix](../supported_api.md#atproto)** for a list of endpoints supported by **[atproto](https://pub.dev/packages/atproto)**.
@@ -296,7 +324,8 @@ Okay then, let's try some endpoints!
 
 The following example first authenticates the user against `bsky.social`, sends the post to Bluesky, and then deletes it using a reference to the created record.
 
-```dart
+<!-- snippet: atproto/create_and_delete_record.dart -->
+```dart title="create_and_delete_record.dart"
 import 'package:atproto/atproto.dart' as atp;
 
 Future<void> main() async {
@@ -313,12 +342,13 @@ Future<void> main() async {
     collection: 'app.bsky.feed.post',
     record: {
       'text': 'Hello, Bluesky!',
-      "createdAt": DateTime.now().toUtc().toIso8601String(),
+      'createdAt': DateTime.now().toUtc().toIso8601String(),
     },
   );
 
-  // And delete it.
-  final uri = AtUri(strongRef.data.uri);
+  // And delete it. `uri` is already an `AtUri`, so it can be destructured
+  // directly.
+  final uri = strongRef.data.uri;
   await atproto.repo.deleteRecord(
     repo: uri.hostname,
     collection: uri.collection.toString(),
@@ -326,6 +356,7 @@ Future<void> main() async {
   );
 }
 ```
+<!-- /snippet -->
 
 :::tip
 See **[API Support Matrix](../supported_api.md#atproto)** for all supported endpoints.
@@ -341,31 +372,62 @@ AT Protocol uses session-based authentication for secure API access. A **[`Sessi
 
 Use the `createSession` function to authenticate with your credentials:
 
-```dart
+<!-- snippet: atproto/create_session.dart -->
+```dart title="create_session.dart"
 import 'package:atproto/atproto.dart' as atp;
 
 Future<void> main() async {
   try {
     final session = await atp.createSession(
       identifier: 'your.handle.com', // Handle or email
-      password: 'your-app-password',  // App password recommended
-      service: 'bsky.social',         // Optional: specify service
+      password: 'your-app-password', // App password recommended
+      service: 'bsky.social', // Optional: specify service
     );
 
     print('Authenticated as: ${session.data.handle}');
     print('DID: ${session.data.did}');
-    
   } catch (e) {
     print('Authentication failed: $e');
   }
 }
 ```
+<!-- /snippet -->
 
 #### Using Sessions
 
 Once you have a session, create an ATProto instance to make authenticated requests:
 
-```dart
+<!-- snippet: atproto/session.dart -->
+```dart title="session.dart"
+import 'package:atproto/atproto.dart' as atp;
+
+Future<void> main() async {
+  // Create session with your credentials.
+  final session = await atp.createSession(
+    identifier: 'your.handle.com', // Your handle or email
+    password: 'your-app-password', // App password recommended
+  );
+
+  // Create ATProto instance from session. An expired access token is
+  // refreshed transparently using the session's refresh token.
+  final atproto = atp.ATProto.fromSession(session.data);
+
+  // Now you can use authenticated endpoints.
+  final profile = await atproto.repo.getRecord(
+    repo: session.data.did,
+    collection: 'app.bsky.actor.profile',
+    rkey: 'self',
+  );
+}
+```
+<!-- /snippet -->
+
+#### Session Refresh
+
+Access tokens expire, but **you do not have to refresh them yourself**. `ATProto.fromSession` installs a refresh hook: when a request is rejected with `401`, the instance spends the refresh token, merges the new credentials over the current session, and replays the request once. The rotated fields (`accessJwt`, `refreshJwt`, `didDoc`, `handle`, `active`, `status`) are updated while the email fields — which `refreshSession` does not return — are carried forward.
+
+<!-- snippet: atproto/auto_session_refresh.dart -->
+```dart title="auto_session_refresh.dart"
 import 'package:atproto/atproto.dart' as atp;
 
 Future<void> main() async {
@@ -374,39 +436,59 @@ Future<void> main() async {
     password: 'your-app-password',
   );
 
-  // Create authenticated ATProto instance
   final atproto = atp.ATProto.fromSession(session.data);
 
-  // Now you can use authenticated endpoints
-  final profile = await atproto.repo.getRecord(
+  // If the access token has expired, this call transparently refreshes the
+  // session and retries once. Nothing extra to write.
+  await atproto.repo.listRecords(
     repo: session.data.did,
-    collection: 'app.bsky.actor.profile',
-    rkey: 'self',
+    collection: 'app.bsky.feed.post',
+  );
+
+  // `atproto.session` always reflects the *current* credentials, so persist
+  // from here rather than from the session you passed in.
+  print(atproto.session?.accessJwt);
+  print(atproto.session?.refreshJwt);
+}
+```
+<!-- /snippet -->
+
+:::tip
+Read the current credentials from `atproto.session`, not from the `Session` you constructed the instance with. After a transparent refresh the latter is stale, so persisting it will log your user out at the next launch.
+:::
+
+The standalone **[`refreshSession`](https://pub.dev/documentation/atproto/latest/atproto/refreshSession.html)** function is still there for the cases the hook cannot cover — refreshing tokens you hold outside any `ATProto` instance, or refreshing ahead of expiry on a schedule.
+
+<!-- snippet: atproto/session_refresh.dart -->
+```dart title="session_refresh.dart"
+import 'package:atproto/atproto.dart' as atp;
+
+Future<void> main() async {
+  final session = await atp.createSession(
+    identifier: 'your.handle.com',
+    password: 'your-app-password',
+  );
+
+  // Refresh explicitly. `ATProto.fromSession` already does this for you when a
+  // request fails with 401, so reach for it only when you manage the tokens
+  // yourself, e.g. to persist them before the instance is created.
+  final refreshed = await atp.refreshSession(
+    refreshJwt: session.data.refreshJwt,
+  );
+
+  final atproto = atp.ATProto.fromSession(refreshed.data);
+
+  final result = await atproto.repo.listRecords(
+    repo: refreshed.data.did,
+    collection: 'app.bsky.feed.post',
   );
 }
 ```
+<!-- /snippet -->
 
-#### Session Refresh
-
-Sessions have expiration times. You can refresh sessions manually:
-
-```dart
-final session = await atp.createSession(
-  identifier: 'your.handle.com',
-  password: 'your-app-password',
-);
-
-final refreshedSession = await refreshSession(
-  refreshJwt: session.data.refreshJwt,
-);
-
-final atproto = atp.ATProto.fromSession(refreshedSession.data);
-
-final result = await atproto.repo.listRecords(
-  repo: session.data.did,
-  collection: 'app.bsky.feed.post',
-);
-```
+:::note
+OAuth sessions refresh through a different path: the `OAuthSessionManager` behind `ATProto.fromOAuth` handles it, provided the manager was given an `OAuthClient`.
+:::
 
 ### App Passwords
 
@@ -433,28 +515,31 @@ App passwords:
 
 You can validate if a password follows the app password format:
 
-```dart
+<!-- snippet: atproto/app_password.dart -->
+```dart title="app_password.dart"
 import 'package:atproto/core.dart' as core;
 
-Future<void> main() async {
-  // Valid app password format
+void main() {
+  // Valid app password format.
   print(core.isValidAppPassword('abcd-efgh-ijkl-mnop')); // => true
-  
-  // Invalid formats
-  print(core.isValidAppPassword('regular-password'));     // => false
-  print(core.isValidAppPassword('abcd-efgh-ijkl'));      // => false (too short)
-  print(core.isValidAppPassword('abcdefghijklmnop'));     // => false (no dashes)
+
+  // Invalid formats.
+  print(core.isValidAppPassword('regular-password')); // => false
+  print(core.isValidAppPassword('abcd-efgh-ijkl')); // => false (too short)
+  print(core.isValidAppPassword('abcdefghijklmnop')); // => false (no dashes)
 }
 ```
+<!-- /snippet -->
 
 #### Best Practices
 
-```dart
+<!-- snippet: atproto/app_password_best_practice.dart -->
+```dart title="app_password_best_practice.dart"
 import 'package:atproto/atproto.dart' as atp;
 import 'package:atproto/core.dart' as core;
 
 Future<void> authenticateUser(String identifier, String password) async {
-  // Check if user provided an app password
+  // Check if user provided an app password.
   if (!core.isValidAppPassword(password)) {
     print('Warning: Consider using an app password for better security');
   }
@@ -464,22 +549,30 @@ Future<void> authenticateUser(String identifier, String password) async {
       identifier: identifier,
       password: password,
     );
-    
-    print('Successfully authenticated with ${core.isValidAppPassword(password) ? 'app password' : 'main password'}');
-    
+
+    print('Successfully authenticated as ${session.data.handle}');
   } catch (e) {
     print('Authentication failed: $e');
   }
 }
 ```
+<!-- /snippet -->
 
 ### Other Than `bsky.social`
 
 The endpoints provided by **[atproto](https://pub.dev/packages/atproto)** always access `bsky.social` by default. But as you know, certain services such as Bluesky, built on the AT Protocol, are **distributed services**. In other words, there must be a way to access services other than `bsky.social` as needed.
 
-You can specify any `service` as follows.
+Every factory takes **two** host parameters, because AT Protocol splits the roles:
 
-```dart
+| Parameter | Default | Used by |
+| --------- | ------- | ------- |
+| `service` | `bsky.social` | Ordinary XRPC queries and procedures — your PDS |
+| `relayService` | `bsky.network` | Subscriptions, notably the **[Firehose](#firehose-api)** — the relay |
+
+Overriding `service` alone leaves the Firehose pointed at `bsky.network`. If you run your own relay, set `relayService` too.
+
+<!-- snippet: atproto/custom_service.dart -->
+```dart title="custom_service.dart"
 import 'package:atproto/atproto.dart' as atp;
 
 Future<void> main() async {
@@ -496,42 +589,48 @@ Future<void> main() async {
 
     // Add this, or resolve dynamically based on session.
     service: 'boobee.blue',
+
+    // Firehose and other relay-backed endpoints use this instead of `service`.
+    // Defaults to `bsky.network`.
+    relayService: 'relay.example.com',
   );
+
+  print(atproto.service); // => boobee.blue
+  print(atproto.relayService); // => relay.example.com
 }
 ```
+<!-- /snippet -->
 
 ### De/Serialize
 
 All objects representing JSON objects returned from the API provided by **[atproto](https://pub.dev/packages/atproto)** are generated using [freezed](https://pub.dev/packages/freezed) and [json_serializable](https://pub.dev/packages/json_serializable). So, it allows for easy JSON-based de/serialize of these model objects based on the common contract between the `fromJson` and `toJson` methods.
 
-For example, if you have the following code:
+Every endpoint returns an **[`XRPCResponse`](https://pub.dev/documentation/xrpc/latest/xrpc/XRPCResponse-class.html)**, which carries transport metadata such as `status` and `rateLimit`. The model is the `data` property, and that is what round-trips through `fromJson`/`toJson`.
 
-```dart
+Models are named after the lexicon method that produced them: `com.atproto.identity.resolveHandle` yields an **`IdentityResolveHandleOutput`**. Each one is exported from its own library, e.g. `package:atproto/com_atproto_identity_resolvehandle.dart`.
+
+<!-- snippet: atproto/serialize.dart -->
+```dart title="serialize.dart"
 import 'package:atproto/atproto.dart';
+import 'package:atproto/com_atproto_identity_resolvehandle.dart';
 
 Future<void> main() async {
   final atproto = ATProto.anonymous();
 
-  // Just find the DID of `shinyakato.dev`
-  final did = await atproto.identity.resolveHandle(
-    handle: 'shinyakato.dev',
-  );
+  // Just find the DID of `shinyakato.dev`.
+  final did = await atproto.identity.resolveHandle(handle: 'shinyakato.dev');
+
+  // Serialize the model to JSON. `did` is an `XRPCResponse`, and the model
+  // itself lives in `.data`.
+  final json = did.data.toJson();
+  print(json); // => {did: did:plc:iijrtk7ocored6zuziwmqq3c}
+
+  // And back again.
+  final decoded = IdentityResolveHandleOutput.fromJson(json);
+  print(decoded.did);
 }
 ```
-
-Then you can deserialize `DID` object as JSON with `toJson` as follows:
-
-```dart
-print(did.toJson()); // => {did: did:plc:iijrtk7ocored6zuziwmqq3c}
-```
-
-And you can serialize JSON as `DID` object with `fromJson` as follows:
-
-```dart
-final json = did.toJson();
-
-final serializedDID = DID.fromJson(json);
-```
+<!-- /snippet -->
 
 ### Thrown Exceptions
 
@@ -543,7 +642,7 @@ The following exceptions may be thrown as AT Protocol-related errors when using 
 | -------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- | :-------: |
 | **[XRPCException](https://pub.dev/documentation/xrpc/latest/xrpc/XRPCException-class.html)**                               | Parent class of all the following exception classes.                                                                   |     ❌     |
 | **[UnauthorizedException](https://pub.dev/documentation/xrpc/latest/xrpc/UnauthorizedException-class.html)**               | Thrown when a status code of **`401`** is returned from the ATP server. Indicating **authentication failure**.         |     ❌     |
-| **[RateLimitExceededException](https://pub.dev/documentation/xrpc/latest/xrpc/RateLimitExceededException-class.html)**     | Thrown when a status code of **`429`** is returned from the ATP server. Indicating **rate limits exceeded**.           |     ❌     |
+| **[RateLimitExceededException](https://pub.dev/documentation/xrpc/latest/xrpc/RateLimitExceededException-class.html)**     | Thrown when a status code of **`429`** is returned from the ATP server. Indicating **rate limits exceeded**.           |     ✅     |
 | **[XRPCNotSupportedException](https://pub.dev/documentation/xrpc/latest/xrpc/XRPCNotSupportedException-class.html)**       | Thrown when a status code of **`1xx`** or **`3xx`** is returned from the ATP server. Indicating **unsupported error**. |     ❌     |
 | **[InvalidRequestException](https://pub.dev/documentation/xrpc/latest/xrpc/InvalidRequestException-class.html)**           | Thrown when a status code of **`4xx`** is returned from the ATP server. Indicating **client error**.                   |     ❌     |
 | **[InternalServerErrorException](https://pub.dev/documentation/xrpc/latest/xrpc/InternalServerErrorException-class.html)** | Thrown when a status code of **`5xx`** is returned from the ATP server. Indicating **server error**.                   |     ✅     |
@@ -552,11 +651,16 @@ Also, the following exceptions may be thrown due to temporary network failures.
 
 | Exception                                                                                        | Description                                                                | Retriable |
 | ------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------- | :-------: |
-| **[SocketException](https://api.dart.dev/stable/3.0.2/dart-io/SocketException-class.html)**      | Thrown when a socket operation fails.                                      |      ❌     |
+| **[SocketException](https://api.dart.dev/stable/3.0.2/dart-io/SocketException-class.html)**      | Thrown when a socket operation fails. On the Dart VM these usually surface through `package:http` as a `ClientException`; both are classified alike. |     ✅     |
 | **[TimeoutException](https://api.dart.dev/stable/3.0.2/dart-async/TimeoutException-class.html)** | Thrown when a scheduled timeout happens while waiting for an async result. |     ✅     |
 
 :::info
-Exceptions with `Retriable` set to ✅ are subject to **[automatic retry](#advanced-built-in-retry)**. Exceptions with ❌ cannot be retried.
+Exceptions with `Retriable` set to ✅ are *candidates* for **[retry](#pluggable-retry)**; the rest always propagate.
+
+"Candidate" is doing real work in that sentence. A retriable failure is only retried when both of the following hold:
+
+1. You passed a `retryConfig`. Retries are **opt-in** — the parameter defaults to `null`, and then every failure propagates on the first attempt.
+2. The policy agrees to retry *this* request. With the default `RetryConfig`, a **procedure (`POST`)** that fails *ambiguously* — a `5xx`, or a timeout after the request was sent — is **not** retried, because the server may already have applied it. See **[Retries and Idempotency](#retries-and-idempotency)**.
 :::
 
 ### Rate Limits
@@ -566,7 +670,8 @@ The main purpose of setting a rate limit for the API is to prevent excessive req
 
 Rate limits in the AT Protocol are defined in a common specification for the protocol and are set and you can easily access this information as follows.
 
-```dart
+<!-- snippet: atproto/rate_limit.dart -->
+```dart title="rate_limit.dart"
 import 'package:atproto/atproto.dart' as atp;
 
 Future<void> main() async {
@@ -604,6 +709,7 @@ Future<void> main() async {
   await rateLimit.waitUntilReset();
 }
 ```
+<!-- /snippet -->
 
 As in the example above, the rate limits when using **[atproto](https://pub.dev/packages/atproto)** are **_always_** accessible from **[XRPCResponse](https://pub.dev/documentation/xrpc/latest/xrpc/XRPCResponse-class.html)**.
 In more detail, rate limit information is read from the HTTP response headers returned by the ATP server and can be accessed via the `rateLimit` property of the **[XRPCResponse](https://pub.dev/documentation/xrpc/latest/xrpc/XRPCResponse-class.html)** as a **[RateLimit](https://pub.dev/documentation/xrpc/latest/xrpc/RateLimit-class.html)** object.
@@ -635,7 +741,11 @@ if (rateLimit.isExceeded) {
 ```
 
 :::caution
-Rate limits per endpoint must be properly handled. If the request is sent again while the rate limit is exceeded, the HTTP status will always be `429 Too Many Requests` and a [RateLimitExceededException](https://pub.dev/documentation/xrpc/latest/xrpc/RateLimitExceededException-class.html) will be thrown.
+Rate limits per endpoint must be properly handled. If the request is sent again while the rate limit is exceeded, the HTTP status will always be `429 Too Many Requests`.
+
+If you configured a **[retry strategy](#pluggable-retry)**, a `429` **is** retried — the request was rejected before the server processed it, so retrying is safe even for a procedure, and the retry waits at least as long as the server's `Retry-After` or `ratelimit-reset` header asks (capped at 60 seconds). A [RateLimitExceededException](https://pub.dev/documentation/xrpc/latest/xrpc/RateLimitExceededException-class.html) then surfaces only once the attempts are exhausted; without a retry strategy it is thrown immediately.
+
+Either way, checking `rateLimit` proactively is worth doing — it avoids burning attempts on a request that cannot succeed yet.
 :::
 
 :::tip
@@ -653,82 +763,74 @@ That is, **[RateLimit](https://pub.dev/documentation/xrpc/latest/xrpc/RateLimit-
 
 AT Protocol's Lexicon supports Union types, allowing endpoints to return different JSON structures based on context. Since Dart doesn't natively support Union types, **[atproto](https://pub.dev/packages/atproto)** uses **[freezed](https://pub.dev/packages/freezed)** to provide type-safe Union type handling.
 
-#### Using .when() Method
+Union classes are prefixed with `U`, and each variant is a subclass named after it — `USyncSubscribeReposMessage` has `USyncSubscribeReposMessageCommit`, `…Identity`, and so on. Every variant holds its payload in a `data` field.
 
-All Union types provide a `.when()` method for exhaustive pattern matching:
+#### Using Pattern Matching
 
-```dart
+Union types are declared `sealed`, so a `switch` that covers every variant is checked for exhaustiveness by the compiler. Add a variant to a lexicon and your switch fails to compile instead of silently falling through.
+
+<!-- snippet: atproto/union_pattern.dart -->
+```dart title="union_pattern.dart"
 import 'package:atproto/atproto.dart' as atp;
-import 'package:atproto/com_atproto_sync_subscriberepos.dart';
 import 'package:atproto/firehose.dart';
 
 Future<void> main() async {
   final atproto = atp.ATProto.anonymous();
-  final subscription = await atproto.sync.subscribeRepos();
+  final subscription = await atproto.sync.subscribeReposAsMessages();
 
-  await for (final event in subscription.data.stream) {
-    final repos = const SyncSubscribeReposAdaptor().execute(event);
-
-    repos.when(
-      commit: (data) => print('Commit: ${data.ops.length} operations'),
-      identity: (data) => print('Identity: ${data.did}'),
-      account: (data) => print('Account: ${data.did}'),
-      sync: (data) => print('Sync: ${data.did}'),
-      info: (data) => print('Info: ${data.name}'),
-      unknown: (data) => print('Unknown event: $data'),
-    );
-  }
-}
-```
-
-#### Using Pattern Matching (Dart 3.0+)
-
-For modern Dart applications, use pattern matching with Union classes prefixed with `U`:
-
-```dart
-import 'package:atproto/atproto.dart' as atp;
-import 'package:atproto/com_atproto_sync_subscriberepos.dart';
-import 'package:atproto/firehose.dart';
-
-Future<void> main() async {
-  final atproto = atp.ATProto.anonymous();
-  final subscription = await atproto.sync.subscribeRepos();
-
-  await for (final event in subscription.data.stream) {
-    final repos = const SyncSubscribeReposAdaptor().execute(event);
-
-    switch (repos) {
-      case USyncSubscribeReposMessageCommit():
-        print('Commit with ${repos.data.ops.length} operations');
-
-        // Handle specific operations
-        for (final op in repos.data.ops) {
-          switch (op.action.knownValue) {
-            case KnownRepoOpAction.create:
-              print('Created: ${op.cid}');
-            case KnownRepoOpAction.update:
-              print('Updated: ${op.cid}');
-            case KnownRepoOpAction.delete:
-              print('Deleted: ${op.cid}');
-            default:
-              print('unknown op');
-          }
-        }
-
-      case USyncSubscribeReposMessageIdentity():
-        print('Identity changed: ${repos.data.handle} -> ${repos.data.did}');
-
-      default:
-        print('Other event type');
+  await for (final message in subscription.data.stream) {
+    // The union is a `sealed` class, so the compiler checks the switch for you
+    // once every variant is listed.
+    switch (message) {
+      case USyncSubscribeReposMessageCommit(:final data):
+        print('Commit: ${data.ops.length} operations');
+      case USyncSubscribeReposMessageIdentity(:final data):
+        print('Identity: ${data.did}');
+      case USyncSubscribeReposMessageAccount(:final data):
+        print('Account: ${data.did}');
+      case USyncSubscribeReposMessageSync(:final data):
+        print('Sync: ${data.did}');
+      case USyncSubscribeReposMessageInfo(:final data):
+        print('Info: ${data.name}');
+      case USyncSubscribeReposMessageUnknown(:final data):
+        print('Unknown event: $data');
     }
   }
 }
 ```
+<!-- /snippet -->
+
+#### Using the Generated Helpers
+
+When you care about one variant, the generated `isX` / `isNotX` predicates and the nullable `x` accessor are shorter than a switch.
+
+<!-- snippet: atproto/union_helpers.dart -->
+```dart title="union_helpers.dart"
+import 'package:atproto/atproto.dart' as atp;
+import 'package:atproto/firehose.dart';
+
+Future<void> main() async {
+  final atproto = atp.ATProto.anonymous();
+  final subscription = await atproto.sync.subscribeReposAsMessages();
+
+  await for (final message in subscription.data.stream) {
+    // Every union exposes `isX` / `isNotX` predicates and a nullable `x`
+    // accessor, which read well when you care about a single variant.
+    if (message.isNotCommit) continue;
+
+    final commit = message.commit!;
+    print('Commit from ${commit.repo} at seq ${commit.seq}');
+  }
+}
+```
+<!-- /snippet -->
 
 :::info
 **Unknown Event Handling**
 
 All Union types include an `unknown` case for forward compatibility. When AT Protocol introduces new event types, they'll be captured as `unknown` events with raw JSON data, ensuring your application continues to work without updates.
+
+A payload whose `$type` *does* match a known variant but fails to convert is deliberately left to throw, so malformed data surfaces rather than degrading quietly to `unknown`.
 :::
 
 ## Related Packages
@@ -755,184 +857,207 @@ See the **[Package Overview](./overview.md)** for a complete list of all availab
 
 The **Firehose API** provides real-time access to all repository events across AT Protocol services. This powerful streaming API enables applications to monitor content creation, updates, deletions, and account changes as they happen.
 
+It streams from the **relay** (`relayService`, `bsky.network` by default), not from your PDS, and needs no authentication.
+
 #### Basic Firehose Usage
 
-Access the Firehose through the `sync.subscribeRepos()` method. No authentication is required:
+Reach for **[`sync.subscribeReposAsMessages()`](https://pub.dev/documentation/atproto/latest/atproto/SyncServiceImpl/subscribeReposAsMessages.html)**. It wires the CBOR/CAR decoding into the subscription for you, so the stream yields typed `USyncSubscribeReposMessage`s: `blocks` are expanded into a `CID -> record` map, and the `ops`, `commit`, and `prevData` CID links are normalized per the atproto data model.
 
-```dart
+<!-- snippet: atproto/firehose_basic.dart -->
+```dart title="firehose_basic.dart"
 import 'package:atproto/atproto.dart' as atp;
-import 'package:atproto/com_atproto_sync_subscriberepos.dart';
 import 'package:atproto/firehose.dart';
 
 Future<void> main() async {
   final atproto = atp.ATProto.anonymous();
 
-  // Subscribe to the firehose
-  final subscription = await atproto.sync.subscribeRepos();
+  // Frames arrive already CBOR/CAR-decoded and typed.
+  final subscription = await atproto.sync.subscribeReposAsMessages();
 
   print('Firehose connected! Listening for events...');
 
-  await for (final event in subscription.data.stream) {
-    final repos = const SyncSubscribeReposAdaptor().execute(event);
-
-    repos.whenOrNull(
-      commit: (data) {
-        print('Commit from ${data.repo}');
-        print('Operations: ${data.ops.length}');
+  await for (final message in subscription.data.stream) {
+    switch (message) {
+      case USyncSubscribeReposMessageCommit(:final data):
+        print('Commit from ${data.repo} with ${data.ops.length} operations');
 
         for (final op in data.ops) {
-          if (op.action.isUnknown) continue;
-
-          switch (op.action.knownValue!) {
+          switch (op.action.knownValue) {
             case KnownRepoOpAction.create:
-              print(' Created: $op');
+              print('  Created: ${op.path}');
             case KnownRepoOpAction.update:
-              print(' Updated: $op');
+              print('  Updated: ${op.path}');
             case KnownRepoOpAction.delete:
-              print(' Deleted: $op');
+              print('  Deleted: ${op.path}');
+            case null:
+              print('  Unknown action: ${op.action}');
           }
         }
-      },
 
-      info: (data) {
-        print(' Info message: ${data.name}');
-      },
+      case USyncSubscribeReposMessageIdentity(:final data):
+        print('Identity: ${data.handle} -> ${data.did}');
 
-      unknown: (data) {
-        print(' Unknown event: $data');
-      },
-    );
+      case USyncSubscribeReposMessageInfo(:final data):
+        print('Info: ${data.name}');
+
+      default:
+        print('Other event: $message');
+    }
   }
 }
 ```
+<!-- /snippet -->
+
+A frame that fails to decode is delivered as a stream *error* and does not terminate the subscription, so one malformed commit never tears down your consumer.
+
+#### Decoding Frames Yourself
+
+`subscribeRepos()` is the lower-level path: it yields the raw `Uint8List` frames and leaves decoding to you. Use it when you need to inspect, buffer, or forward the bytes before they are parsed; otherwise prefer `subscribeReposAsMessages`.
+
+<!-- snippet: atproto/firehose_manual.dart -->
+```dart title="firehose_manual.dart"
+import 'package:atproto/atproto.dart' as atp;
+import 'package:atproto/firehose.dart';
+
+Future<void> main() async {
+  final atproto = atp.ATProto.anonymous();
+
+  // Yields the raw binary frames; decoding is yours to drive.
+  final subscription = await atproto.sync.subscribeRepos();
+
+  await for (final event in subscription.data.stream) {
+    final message = const SyncSubscribeReposAdaptor().execute(event);
+
+    if (message case USyncSubscribeReposMessageCommit(:final data)) {
+      print('Commit from ${data.repo}');
+    }
+  }
+}
+```
+<!-- /snippet -->
 
 #### Filtering Firehose Events
 
 You can filter events by collection type or specific repositories:
 
-```dart
+<!-- snippet: atproto/firehose_filter.dart -->
+```dart title="firehose_filter.dart"
 import 'package:atproto/atproto.dart' as atp;
-import 'package:atproto/com_atproto_sync_subscriberepos.dart';
 import 'package:atproto/core.dart';
 import 'package:atproto/firehose.dart';
 
 Future<void> main() async {
   final atproto = atp.ATProto.anonymous();
 
-  // Subscribe to the firehose
-  final subscription = await atproto.sync.subscribeRepos();
+  final subscription = await atproto.sync.subscribeReposAsMessages();
 
-  print('Firehose connected! Listening for events...');
+  await for (final message in subscription.data.stream) {
+    if (message case USyncSubscribeReposMessageCommit(:final data)) {
+      for (final op in data.ops) {
+        if (op.action.knownValue != KnownRepoOpAction.create) continue;
 
-  await for (final event in subscription.data.stream) {
-    final repos = const SyncSubscribeReposAdaptor().execute(event);
-
-    repos.whenOrNull(
-      commit: (data) {
-        print('Commit from ${data.repo}');
-        print('Operations: ${data.ops.length}');
-
-        for (final op in data.ops) {
-          if (op.action.isUnknown) continue;
-
-          switch (op.action.knownValue!) {
-            case KnownRepoOpAction.create:
-              final uri = _getUri(data, op);
-
-              switch (uri.collection.toString()) {
-                case 'app.bsky.feed.post':
-                  print('📄 New post: $op');
-                case 'app.bsky.actor.profile':
-                  print('📄 New profile: $op');
-              }
-            case KnownRepoOpAction.update:
-              print(' Updated: $op');
-            case KnownRepoOpAction.delete:
-              print(' Deleted: $op');
-          }
+        // Filtering early keeps the per-event work small, which matters at
+        // firehose volume.
+        switch (_getUri(data, op).collection.toString()) {
+          case 'app.bsky.feed.post':
+            print('New post: ${op.path}');
+          case 'app.bsky.actor.profile':
+            print('New profile: ${op.path}');
         }
-      },
-
-      info: (data) {
-        print(' Info message: ${data.name}');
-      },
-
-      unknown: (data) {
-        print(' Unknown event: $data');
-      },
-    );
-  }
-}
-
-AtUri _getUri(final Commit commit, final RepoOp op) {
-  return AtUri('at://${commit.repo}/${op.path}');
-}
-```
-
-#### Advanced Firehose Features
-
-For production applications, consider implementing error handling and reconnection logic:
-
-```dart
-import 'package:atproto/atproto.dart' as atp;
-import 'package:atproto/com_atproto_sync_subscriberepos.dart';
-import 'package:atproto/firehose.dart';
-
-Future<void> robustFirehose() async {
-  while (true) {
-    try {
-      final atproto = atp.ATProto.anonymous();
-      final subscription = await atproto.sync.subscribeRepos();
-
-      print('🔥 Firehose connected');
-
-      await for (final event in subscription.data.stream) {
-        final repos = const SyncSubscribeReposAdaptor().execute(event);
-
-        // Process events...
-        await processEvent(repos);
       }
-    } catch (e) {
-      print('❌ Firehose error: $e');
-      print('🔄 Reconnecting in 5 seconds...');
-      await Future.delayed(Duration(seconds: 5));
     }
   }
 }
 
-Future<void> processEvent(USyncSubscribeReposMessage event) async {
-  // Your event processing logic here
-  event.whenOrNull(
-    commit: (data) async {
-      // Process commits
-      for (final op in data.ops) {
-        // Handle operations
+AtUri _getUri(final Commit commit, final RepoOp op) =>
+    AtUri('at://${commit.repo}/${op.path}');
+```
+<!-- /snippet -->
+
+#### Firehose Errors
+
+Two exception types are specific to the Firehose, both exported from `package:atproto/firehose.dart`:
+
+| Exception | Meaning | What to do |
+| --------- | ------- | ---------- |
+| **[FirehoseErrorException](https://pub.dev/documentation/atproto/latest/firehose/FirehoseErrorException-class.html)** | The relay sent an error frame (`op == -1`), such as `FutureCursor` or `ConsumerTooSlow`. Carries `error` and an optional `message`. | Inspect `error`. A `FutureCursor` never becomes valid — drop the cursor before reconnecting. A `ConsumerTooSlow` means you are not draining the stream fast enough. |
+| **[FirehoseFrameException](https://pub.dev/documentation/atproto/latest/firehose/FirehoseFrameException-class.html)** | A single frame was malformed or arrived in an unexpected shape, e.g. a text frame where a binary one was required. | Log and skip. The subscription survives. |
+
+#### Advanced Firehose Features
+
+For production applications, track the cursor and reconnect deliberately:
+
+<!-- snippet: atproto/firehose_robust.dart -->
+```dart title="firehose_robust.dart"
+import 'package:atproto/atproto.dart' as atp;
+import 'package:atproto/firehose.dart';
+
+Future<void> robustFirehose() async {
+  // Resume from where the last run stopped instead of replaying everything.
+  int? cursor;
+
+  while (true) {
+    try {
+      final atproto = atp.ATProto.anonymous();
+      final subscription = await atproto.sync.subscribeReposAsMessages(
+        cursor: cursor,
+      );
+
+      print('Firehose connected');
+
+      await for (final message in subscription.data.stream) {
+        if (message case USyncSubscribeReposMessageCommit(:final data)) {
+          cursor = data.seq;
+        }
+
+        await processEvent(message);
       }
-    },
-    identity: (data) async {
-      // Process identity changes
-    },
-    account: (data) async {
-      // Process account changes
-    },
-    sync: (data) async {
-      // Process sync events
-    },
-    info: (data) async {
-      // Process info messages
-    },
-    unknown: (data) async {
-      // Handle unknown events
-    },
-  );
+    } on FirehoseErrorException catch (e) {
+      // The relay rejected the stream itself, e.g. `FutureCursor` or
+      // `ConsumerTooSlow`. A cursor from the future never becomes valid, so
+      // drop it and reconnect from the live tip.
+      print('Relay error: ${e.error}');
+      if (e.error == 'FutureCursor') cursor = null;
+    } on FirehoseFrameException catch (e) {
+      // A single malformed frame. Decoding errors are delivered as stream
+      // errors and do not tear down the subscription.
+      print('Malformed frame: ${e.message}');
+    } catch (e) {
+      print('Firehose error: $e');
+    }
+
+    print('Reconnecting in 5 seconds...');
+    await Future<void>.delayed(const Duration(seconds: 5));
+  }
+}
+
+Future<void> processEvent(final USyncSubscribeReposMessage message) async {
+  switch (message) {
+    case USyncSubscribeReposMessageCommit(:final data):
+      for (final op in data.ops) {
+        // Handle operations.
+      }
+    case USyncSubscribeReposMessageIdentity(:final data):
+    // Process identity changes.
+    case USyncSubscribeReposMessageAccount(:final data):
+    // Process account changes.
+    case USyncSubscribeReposMessageSync(:final data):
+    // Process sync events.
+    case USyncSubscribeReposMessageInfo(:final data):
+    // Process info messages.
+    case USyncSubscribeReposMessageUnknown(:final data):
+    // Handle forward-compatible unknown events.
+  }
 }
 ```
+<!-- /snippet -->
 
 :::info
 **Performance Considerations**
 
 The Firehose can generate high volumes of events. For production applications:
 - Implement proper error handling and reconnection logic
+- Persist the cursor so a restart resumes instead of replaying from the tip
 - Consider using a message queue for event processing
 - Filter events early to reduce processing overhead
 - Monitor memory usage and implement backpressure handling
@@ -946,7 +1071,8 @@ However, depending on system requirements, it may be necessary to set a time sho
 
 In that case, when creating an instance of the **[ATProto](https://pub.dev/documentation/atproto/latest/atproto/ATProto-class.html)** object, the timeout period can be specified as follows.
 
-```dart
+<!-- snippet: atproto/timeout.dart -->
+```dart title="timeout.dart"
 import 'package:atproto/atproto.dart';
 
 Future<void> main() async {
@@ -956,10 +1082,15 @@ Future<void> main() async {
   );
 }
 ```
+<!-- /snippet -->
 
-### Advanced Built-In Retry
+### Pluggable Retry
 
-**[atproto](https://pub.dev/packages/atproto)** includes sophisticated retry logic using **[Exponential Backoff with Jitter](https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/)** to handle temporary network failures gracefully.
+**[atproto](https://pub.dev/packages/atproto)** can retry transient failures for you. Pass a `retryConfig` and you get **[Exponential Backoff with Jitter](https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/)** with an idempotency-safe retry decision; implement `RetryStrategy` and you replace that policy entirely.
+
+:::caution
+Retries are **opt-in**. `retryConfig` defaults to `null` on every factory, and a client built without one fails on the first attempt.
+:::
 
 #### Why Retry Logic Matters
 
@@ -967,15 +1098,24 @@ Network communication is inherently unreliable. Temporary failures like network 
 
 #### Exponential Backoff with Jitter
 
-Simple retry mechanisms that wait fixed intervals can create "thundering herd" problems where multiple clients retry simultaneously, overwhelming recovering servers. **[atproto](https://pub.dev/packages/atproto)** uses exponential backoff with jitter (randomization) to:
+Simple retry mechanisms that wait fixed intervals can create "thundering herd" problems where multiple clients retry simultaneously, overwhelming recovering servers. The default policy uses exponential backoff with jitter (randomization) to:
 
 - Gradually increase wait times between retries
 - Add randomness to prevent synchronized retry storms
 - Distribute load more evenly across time
 
+The interval for each attempt is:
+
+> **(2 ^ (attempt - 1)) + jitter**
+
+A wait the server asked for via `Retry-After` or `ratelimit-reset` is honored as a *lower bound*, capped at 60 seconds so a hostile value cannot stall a retry indefinitely.
+
 #### Configuring Retry Behavior
 
-```dart
+**[`RetryConfig`](https://pub.dev/documentation/atproto_core/latest/atproto_core/RetryConfig-class.html)** is the built-in policy. Pass it as `retryConfig` to any factory or to a top-level function such as `createSession`. Its jitter defaults to `Jitter(maxInSeconds: 4)`; `maxAttempts` is required and must not be negative.
+
+<!-- snippet: atproto/retry.dart -->
+```dart title="retry.dart"
 import 'package:atproto/atproto.dart' as atp;
 import 'package:atproto/core.dart' as core;
 
@@ -984,19 +1124,19 @@ Future<void> main() async {
 
   final atproto = atp.ATProto.anonymous(
     retryConfig: core.RetryConfig(
-      // Maximum number of retry attempts
+      // Maximum number of retry attempts.
       maxAttempts: maxAttempts,
 
-      // Jitter configuration for randomized delays
+      // Jitter configuration for randomized delays.
       jitter: core.Jitter(
         minInSeconds: 1, // Minimum delay
         maxInSeconds: 5, // Maximum delay
       ),
 
-      // Optional: Monitor retry events
+      // Optional: Monitor retry events.
       onExecute: (event) {
         print(
-          '🔄 Retry ${event.retryCount}/$maxAttempts '
+          'Retry ${event.retryCount}/$maxAttempts '
           'after ${event.intervalInSeconds}s delay',
         );
       },
@@ -1004,62 +1144,235 @@ Future<void> main() async {
   );
 
   try {
-    // This request will automatically retry on temporary failures
+    // This request will automatically retry on temporary failures.
     final result = await atproto.identity.resolveHandle(handle: 'bsky.app');
-    print('✅ Success: ${result.data.did}');
+    print('Success: ${result.data.did}');
   } catch (e) {
-    print('❌ Failed after all retries: $e');
+    print('Failed after all retries: $e');
   }
 }
 ```
+<!-- /snippet -->
 
 #### Automatic Retry Conditions
 
-The library automatically retries requests when encountering:
+A failure is a retry *candidate* when it is transient:
 
-| Condition | Description | Retriable |
-|-----------|-------------|-----------|
-| **5xx Server Errors** | Internal server errors, service unavailable | ✅ |
-| **SocketException** | Network connectivity issues |❌ |
-| **TimeoutException** | Request timeout exceeded | ✅ |
-| **4xx Client Errors** | Bad request, unauthorized, not found | ❌ |
-| **Rate Limit Exceeded** | 429 Too Many Requests | ❌* |
+| Condition | Description | Candidate | `RetryReason` |
+|-----------|-------------|:---------:|---------------|
+| **5xx Server Errors** | Internal server errors, service unavailable | ✅ | `serverError` |
+| **TimeoutException** | Request timeout exceeded | ✅ | `timeout` |
+| **SocketException / ClientException** | Connection refused, reset, DNS failure | ✅ | `network` |
+| **Rate Limit Exceeded** | 429 Too Many Requests; the server's `Retry-After` is honored | ✅ | `rateLimited` |
+| **4xx Client Errors** | Bad request, not found | ❌ | — |
+| **401 Unauthorized** | Handled by session refresh and the DPoP nonce handshake, not by retry | ❌ | — |
 
-*Rate limit errors are not retried automatically, but you can handle them using the [rate limit management](#rate-limits) features.
+#### Retries and Idempotency
+
+Being a candidate is not enough. **This is the behavior most likely to surprise you, and it changed in 2.0.0.**
+
+A retry is only safe if repeating the request cannot repeat its effect. So the default policy also asks two questions about the failed request:
+
+- **Is it a procedure?** An XRPC procedure is a `POST` with side effects, like `createRecord`. Queries (`GET`) and subscriptions are not procedures.
+- **Was the failure ambiguous?** A `5xx` and a timeout *after the request was sent* leave it unknown whether the server applied the request. A `429`, and a connection that provably never reached the server (connection refused, DNS failure), do not.
+
+**By default, an ambiguous failure of a procedure is not retried.** Retrying could duplicate the write.
+
+| Request | 5xx / post-send timeout | 429 | Connection refused |
+|---------|:-----------------------:|:---:|:------------------:|
+| Query (`GET`), subscription | ✅ retried | ✅ retried | ✅ retried |
+| Procedure (`POST`) | ❌ **not** retried | ✅ retried | ✅ retried |
+
+:::caution
+`createRecord` that fails with a `500` will **not** be retried under the default configuration, even with `maxAttempts: 5`. The exception propagates to you on the first failure. This is deliberate: the alternative is silently posting twice.
+:::
+
+If duplicate writes are acceptable — or your records carry an idempotency key of their own — set `retryProcedureOnAmbiguousFailure: true` to restore unconditional retries.
+
+<!-- snippet: atproto/retry_idempotency.dart -->
+```dart title="retry_idempotency.dart"
+import 'package:atproto/atproto.dart' as atp;
+import 'package:atproto/core.dart' as core;
+
+Future<void> main() async {
+  final session = await atp.createSession(
+    identifier: 'YOUR_HANDLE_OR_EMAIL',
+    password: 'YOUR_PASSWORD',
+  );
+
+  // Default: a `createRecord` that fails with a 500 or a post-send timeout is
+  // NOT retried, because the server may already have created the record.
+  final safe = atp.ATProto.fromSession(
+    session.data,
+    retryConfig: core.RetryConfig(maxAttempts: 3),
+  );
+
+  // Opt out when duplicate writes are acceptable or your records carry an
+  // idempotency key of their own. This restores pre-2.0.0 behavior.
+  final atMostOnceIsFine = atp.ATProto.fromSession(
+    session.data,
+    retryConfig: core.RetryConfig(
+      maxAttempts: 3,
+      retryProcedureOnAmbiguousFailure: true,
+    ),
+  );
+}
+```
+<!-- /snippet -->
+
+#### Custom Retry Strategies
+
+`retryConfig` is typed **[`RetryStrategy`](https://pub.dev/documentation/atproto_core/latest/atproto_core/RetryStrategy-class.html)**, not `RetryConfig`. `RetryConfig` is simply the implementation shipped in the box; implement the interface yourself and you own the entire decision — backoff shape, which failures are retryable, and idempotency handling.
+
+The interface is one method:
+
+```dart
+abstract interface class RetryStrategy {
+  /// Returns the delay to wait before the next attempt, or `null` to stop
+  /// retrying and let the original error propagate.
+  FutureOr<Duration?> nextDelay(final RetryContext context);
+}
+```
+
+Every failed attempt hands it a fresh **[`RetryContext`](https://pub.dev/documentation/atproto_core/latest/atproto_core/RetryContext-class.html)**:
+
+| Property | Description |
+| -------- | ----------- |
+| `attempt` | Attempts that have already failed, starting at `1`. |
+| `reason` | The **[`RetryReason`](https://pub.dev/documentation/atproto_core/latest/atproto_core/RetryReason.html)**: `timeout`, `serverError`, `rateLimited`, or `network`. |
+| `isProcedure` | Whether the request was a `POST` with side effects. `isQuery` is its inverse. |
+| `isAmbiguous` | Whether the server may already have applied the request. |
+| `nsid` | The lexicon method id, when known — useful for per-endpoint policies. |
+| `statusCode` | The HTTP status, when the failure carried one. |
+| `error` | The thrown error. |
+| `retryAfter` | The wait the server asked for, already resolved to a `Duration`. |
+
+<!-- snippet: atproto/retry_strategy.dart -->
+```dart title="retry_strategy.dart"
+import 'dart:async';
+
+import 'package:atproto/atproto.dart' as atp;
+import 'package:atproto/core.dart' as core;
+
+/// Waits a constant second between attempts, never retries a write that may
+/// already have been applied, and gives up on anything but a network blip.
+final class ConstantBackoff implements core.RetryStrategy {
+  const ConstantBackoff({this.maxAttempts = 3});
+
+  final int maxAttempts;
+
+  @override
+  FutureOr<Duration?> nextDelay(final core.RetryContext context) {
+    // Returning null stops retrying and lets the original error propagate.
+    if (context.attempt > maxAttempts) return null;
+    if (context.isProcedure && context.isAmbiguous) return null;
+
+    // Everything the decision needs is on the context.
+    print('${context.nsid} failed: ${context.reason} (${context.statusCode})');
+
+    return switch (context.reason) {
+      // Honor the server's own wait when it sent one.
+      core.RetryReason.rateLimited =>
+        context.retryAfter ?? const Duration(seconds: 5),
+      core.RetryReason.network ||
+      core.RetryReason.timeout => const Duration(seconds: 1),
+      core.RetryReason.serverError => const Duration(seconds: 2),
+    };
+  }
+}
+
+Future<void> main() async {
+  final atproto = atp.ATProto.anonymous(
+    // Any RetryStrategy is accepted here, not just RetryConfig.
+    retryConfig: const ConstantBackoff(maxAttempts: 5),
+  );
+}
+```
+<!-- /snippet -->
 
 #### Production Retry Configuration
 
 For production applications, consider these retry configurations:
 
-```dart
+<!-- snippet: atproto/retry_production.dart -->
+```dart title="retry_production.dart"
 import 'package:atproto/atproto.dart' as atp;
 import 'package:atproto/core.dart' as core;
 
-// Conservative retry for user-facing operations
-final userFacingClient = atp.ATProto.fromSession(
-  session,
-  retryConfig: core.RetryConfig(
-    maxAttempts: 2,
-    jitter: core.Jitter(minInSeconds: 1, maxInSeconds: 3),
-  ),
-);
+void configure(final core.Session session) {
+  // Conservative retry for user-facing operations.
+  final userFacingClient = atp.ATProto.fromSession(
+    session,
+    retryConfig: core.RetryConfig(
+      maxAttempts: 2,
+      jitter: core.Jitter(minInSeconds: 1, maxInSeconds: 3),
+    ),
+  );
 
-// Aggressive retry for background operations
-final backgroundClient = atp.ATProto.fromSession(
-  session,
-  retryConfig: core.RetryConfig(
-    maxAttempts: 5,
-    jitter: core.Jitter(minInSeconds: 2, maxInSeconds: 10),
-    onExecute: (event) => logger.info('Retrying background operation'),
-  ),
-);
+  // Aggressive retry for background operations.
+  final backgroundClient = atp.ATProto.fromSession(
+    session,
+    retryConfig: core.RetryConfig(
+      maxAttempts: 5,
+      jitter: core.Jitter(minInSeconds: 2, maxInSeconds: 10),
+      onExecute: (event) => print('Retrying background operation'),
+    ),
+  );
 
-// No retry for time-sensitive operations
-final realTimeClient = atp.ATProto.fromSession(
-  session,
-  retryConfig: core.RetryConfig(maxAttempts: 1),
-);
+  // No retry at all for time-sensitive operations.
+  final realTimeClient = atp.ATProto.fromSession(session, retryConfig: null);
+}
 ```
+<!-- /snippet -->
+
+:::tip
+To disable retries entirely, pass `retryConfig: null` — which is also the default. `RetryConfig(maxAttempts: 0)` has the same effect but allocates a policy that always declines.
+:::
+
+### Injecting an HTTP Client
+
+Every factory accepts `getClient` and `postClient`, typed **[`GetClient`](https://pub.dev/documentation/xrpc/latest/xrpc/GetClient.html)** and **[`PostClient`](https://pub.dev/documentation/xrpc/latest/xrpc/PostClient.html)**. They stand in for `http.get` and `http.post`, which makes them the seam for tests, proxies, tracing, and custom connection pooling.
+
+<!-- snippet: atproto/http_client_injection.dart -->
+```dart title="http_client_injection.dart"
+import 'package:atproto/atproto.dart' as atp;
+import 'package:http/http.dart' as http;
+
+Future<void> main() async {
+  final atproto = atp.ATProto.anonymous(
+    // Swap in your own transport: a mock in tests, a proxy, a client that
+    // adds tracing headers, or one backed by a connection pool.
+    getClient: (url, {headers}) async {
+      print('GET $url');
+      return await http.get(url, headers: headers);
+    },
+    postClient: (url, {headers, body, encoding}) async {
+      print('POST $url');
+      return await http.post(
+        url,
+        headers: headers,
+        body: body,
+        encoding: encoding,
+      );
+    },
+  );
+
+  // The same hooks are typed as `core.GetClient` / `core.PostClient`, so a
+  // shared fake can be declared once and reused across tests.
+  final offline = atp.ATProto.anonymous(getClient: _alwaysEmpty);
+}
+
+/// A stand-in transport for tests: every GET resolves to an empty JSON body.
+Future<http.Response> _alwaysEmpty(
+  final Uri url, {
+  final Map<String, String>? headers,
+}) async => http.Response('{}', 200);
+```
+<!-- /snippet -->
+
+:::note
+Subscriptions do not go through these hooks — they are WebSockets, not HTTP requests. The matching seam is **[`WebSocketChannelFactory`](https://pub.dev/documentation/xrpc/latest/xrpc/WebSocketChannelFactory.html)**, re-exported from `package:atproto/core.dart`.
+:::
 
 ### Lexicon/Object IDs
 
@@ -1067,16 +1380,20 @@ Some objects returned from AT Protocol's API are identified by IDs defined in Le
 
 **[atproto](https://pub.dev/packages/atproto)** provides all the IDs defined in Lexicon for `com.atproto.*` as constants, and it can be easily used from `package:atproto/ids.dart` as follows.
 
-```dart
+Constants are named by lower-camel-casing the ID, so `com.atproto.repo.strongRef` becomes `comAtprotoRepoStrongRef` and a definition reference like `com.atproto.sync.subscribeRepos#commit` becomes `comAtprotoSyncSubscribeReposCommit`.
+
+<!-- snippet: atproto/ids.dart -->
+```dart title="ids.dart"
 import 'package:atproto/ids.dart' as ids;
 
 void main() {
-  // `blob`
-  ids.blob;
+  // `com.atproto.repo.strongRef`
+  print(ids.comAtprotoRepoStrongRef);
   // `com.atproto.sync.subscribeRepos#commit`
-  ids.comAtprotoSyncSubscribeReposCommit;
+  print(ids.comAtprotoSyncSubscribeReposCommit);
 }
 ```
+<!-- /snippet -->
 
 :::note
 These ID constants are automatically maintained when a new Lexicon is officially added. [See script](https://github.com/myConsciousness/atproto.dart/blob/main/scripts/gen_lexicon_ids.dart).
@@ -1092,11 +1409,12 @@ For more details about design of pagination and `cursor` in the AT Protocol, [se
 
 **[atproto](https://pub.dev/packages/atproto)** also follows the common design of AT Protocol and allows paging by using `cursor`. It can be easily implemented as in the following example.
 
-```dart
+<!-- snippet: atproto/pagination.dart -->
+```dart title="pagination.dart"
 import 'package:atproto/atproto.dart' as atp;
 
 Future<void> main() async {
-  final atproto = atp.ATProto.fromSession(await _session);
+  final atproto = atp.ATProto.anonymous();
 
   // Pagination is performed on a per-cursor basis.
   String? nextCursor;
@@ -1117,6 +1435,7 @@ Future<void> main() async {
   } while (nextCursor != null); // If there is no next page, it ends.
 }
 ```
+<!-- /snippet -->
 
 :::tip
 Endpoints that can be paged can be seen in **[this matrix](../supported_api.md#atproto)**.

--- a/website/docs/packages/bluesky.md
+++ b/website/docs/packages/bluesky.md
@@ -6,7 +6,7 @@ description: API wrapper for Bluesky things.
 
 # bluesky [![pub package](https://img.shields.io/pub/v/bluesky.svg?logo=dart&logoColor=00b9fc)](https://pub.dev/packages/bluesky) [![Dart SDK Version](https://badgen.net/pub/sdk-version/bluesky)](https://pub.dev/packages/bluesky/)
 
-**bluesky** is a comprehensive wrapper library supporting all endpoints defined in [`app.bsky.*`](https://github.com/bluesky-social/atproto/tree/main/lexicons/app/bsky) and [`chat.bsky.*`](https://github.com/bluesky-social/atproto/tree/main/lexicons/chat/bsky) Lexicons.
+**bluesky** is a comprehensive wrapper library for the [`app.bsky.*`](https://github.com/bluesky-social/atproto/tree/main/lexicons/app/bsky), [`chat.bsky.*`](https://github.com/bluesky-social/atproto/tree/main/lexicons/chat/bsky), and [`tools.ozone.*`](https://github.com/bluesky-social/atproto/tree/main/lexicons/tools/ozone) Lexicons.
 
 This package includes complete Bluesky API support, including the latest chat features, plus all core AT Protocol functionality from the **[atproto](./atproto.md)** package. It's your one-stop solution for Bluesky application development.
 
@@ -35,13 +35,12 @@ If you are having trouble implementing **RichText** in the Bluesky API, check ou
 
 ## Features ⭐
 
-- ✅ **Zero Dependency**
-- ✅ Supports **Powerful Built-In Retry** using **[Exponential BackOff And Jitter](https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/)**
-- ✅ Supports **[All Endpoints](https://atprotodart.com/docs/supported_api#bluesky)** for [`app.bsky.*`](https://github.com/bluesky-social/atproto/tree/main/lexicons/app/bsky) and [`chat.bsky.*`](https://github.com/bluesky-social/atproto/tree/main/lexicons/chat/bsky)
-- ✅ **Complete Chat API Support** with conversation management and messaging
+- ✅ Supports **Powerful Built-In Retry** using **[Exponential BackOff And Jitter](https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/)**, with a pluggable **`RetryStrategy`**
+- ✅ Supports the **[endpoints listed in the matrix](https://atprotodart.com/docs/supported_api#bluesky)** for [`app.bsky.*`](https://github.com/bluesky-social/atproto/tree/main/lexicons/app/bsky), [`chat.bsky.*`](https://github.com/bluesky-social/atproto/tree/main/lexicons/chat/bsky), and [`tools.ozone.*`](https://github.com/bluesky-social/atproto/tree/main/lexicons/tools/ozone)
+- ✅ **Chat API Support** with conversation management and messaging
 - ✅ **Advanced Feed Operations** including posts, likes, reposts, and timeline management
 - ✅ **Comprehensive Social Graph** with follows, blocks, mutes, and lists
-- ✅ **Rich Notification System** with real-time updates and preferences
+- ✅ **Rich Notification System**, including **client-side notification grouping** that matches the official app
 - ✅ **Video Upload Support** with status tracking and limits management
 - ✅ **Well Documented** and **Well Tested**
 - ✅ Supports **Powerful Firehose API** for real-time data streaming
@@ -121,6 +120,17 @@ import 'package:bluesky/bluesky_chat.dart' as chat;
 import 'package:bluesky/ozone.dart' as ozone;
 ```
 
+Several focused libraries round out the package:
+
+| Library | Contents |
+| --- | --- |
+| `package:bluesky/moderation.dart` | Client-side moderation engine. **Import unprefixed** — much of it is extensions. |
+| `package:bluesky/firehose.dart` | `SyncSubscribeReposAdaptor`, `RepoCommitHandler` |
+| `package:bluesky/cardyb.dart` | `getLinkPreview(url)` and `LinkPreview` for link cards |
+| `package:bluesky/atproto_oauth.dart` | `OAuthClient`, `OAuthSessionManager`, `OAuthSession` |
+| `package:bluesky/ids.dart` | Every Lexicon ID as a constant |
+| `package:bluesky/core.dart` | `AtUri`, `Session`, `RetryConfig`, the XRPC exceptions |
+
 ### Instantiate **Bluesky**
 
 You need to use **[Bluesky](https://pub.dev/documentation/bluesky/latest/bluesky/Bluesky-class.html)** object to access most of the features supported by **[bluesky](https://pub.dev/packages/bluesky)**. And there are two ways to instantiate an **[Bluesky](https://pub.dev/documentation/bluesky/latest/bluesky/Bluesky-class.html)** object.
@@ -139,6 +149,7 @@ Your credentials will be sent safely and securely to the ATP server when you exe
 
 You then do not need to be particularly aware of the contents of the retrieved Session object, just pass it to the `.fromSession` constructor of **[Bluesky](https://pub.dev/documentation/bluesky/latest/bluesky/Bluesky-class.html)** to safely and securely create an instance of the **[Bluesky](https://pub.dev/documentation/bluesky/latest/bluesky/Bluesky-class.html)** object.
 
+<!-- snippet: bluesky/auth_session.dart -->
 ```dart title="Require Auth"
 import 'package:bluesky/atproto.dart';
 import 'package:bluesky/bluesky.dart';
@@ -156,9 +167,11 @@ Future<void> main() async {
   final bsky = Bluesky.fromSession(session.data);
 }
 ```
+<!-- /snippet -->
 
-Or, it's very easy if authentication is not required , simply use the `.anonymous()` constructor.
+Or, it's very easy if authentication is not required, simply use the `.anonymous()` constructor.
 
+<!-- snippet: bluesky/auth_anonymous.dart -->
 ```dart title="Not Require Auth"
 import 'package:bluesky/bluesky.dart';
 
@@ -167,10 +180,67 @@ Future<void> main() async {
   final bsky = Bluesky.anonymous();
 }
 ```
+<!-- /snippet -->
 
 :::info
 See **[Session Management](#session-management)** for more details about authentication.
 :::
+
+:::note
+Later examples abbreviate the block above as `await _session`, which simply stands for `(await createSession(...)).data`.
+:::
+
+### OAuth
+
+App passwords are convenient, but OAuth with **DPoP** is the authentication method the AT Protocol is moving to. Use `Bluesky.fromOAuth` with an `OAuthSessionManager`, which owns DPoP proof building and transparent token refresh, or `Bluesky.fromOAuthSession` when you already hold an `OAuthSession`.
+
+<!-- snippet: bluesky/auth_oauth.dart -->
+```dart title="oauth.dart"
+import 'dart:convert';
+
+import 'package:bluesky/atproto_oauth.dart';
+import 'package:bluesky/bluesky.dart';
+
+/// Runs the full authorization code flow, then builds a [Bluesky] from it.
+Future<Bluesky> signIn() async {
+  // Your own client metadata, served over HTTPS.
+  final metadata = await getClientMetadata(
+    'https://atprotodart.com/oauth/bluesky/atprotodart/client-metadata.json',
+  );
+
+  final oauth = OAuthClient(metadata);
+
+  // Resolves the identity, discovers its authorization server, performs the
+  // pushed authorization request, and persists the per-authorization state.
+  final authUrl = await oauth.authorize('shinyakato.dev');
+
+  // Send the user to `authUrl` (e.g. with `flutter_web_auth_2`) and feed the
+  // callback URL back in.
+  const callbackUrl =
+      'https://atprotodart.com/oauth/bluesky/auth.html'
+      '?iss=xxxx&state=xxxxxxx&code=xxxxxxx';
+
+  final session = await oauth.callback(callbackUrl);
+
+  // The manager owns DPoP header building and transparent token refresh.
+  final manager = OAuthSessionManager(oauth, sub: session.sub);
+
+  return Bluesky.fromOAuth(manager);
+}
+
+/// Restores a session you persisted earlier.
+Bluesky restore(final String storedJson) {
+  final restored = OAuthSession.fromJson(jsonDecode(storedJson));
+
+  // Equivalent to `Bluesky.fromOAuth(OAuthSessionManager.fromSession(...))`.
+  // Pass `oauthClient` to keep transparent token refresh working; without it
+  // the session is used as-is and cannot be refreshed.
+  return Bluesky.fromOAuthSession(restored);
+}
+```
+<!-- /snippet -->
+
+`BlueskyChat` and `OzoneTool` expose the same `fromOAuth` / `fromOAuthSession` constructors, and the resulting client reports its manager through the `oAuthSessionManager` getter (`session` stays `null`).
 
 ### Supported Services
 
@@ -185,11 +255,15 @@ See **[Session Management](#session-management)** for more details about authent
 | **[sync](https://pub.dev/documentation/atproto/latest/atproto/ATProto/sync.html)**                 | [SyncService](https://pub.dev/documentation/atproto/latest/atproto/SyncService-class.html)                 | [`com.atproto.sync.*`](https://github.com/bluesky-social/atproto/tree/main/lexicons/com/atproto/sync)             |
 | **[label](https://pub.dev/documentation/atproto/latest/atproto/ATProto/label.html)**               | [LabelService](https://pub.dev/documentation/atproto/latest/atproto/LabelService-class.html)               | [`com.atproto.label.*`](https://github.com/bluesky-social/atproto/tree/main/lexicons/com/atproto/label)           |
 | **[actor](https://pub.dev/documentation/bluesky/latest/bluesky/Bluesky/actor.html)**               | [ActorService](https://pub.dev/documentation/bluesky/latest/bluesky/ActorService-class.html)               | [`app.bsky.actor.*`](https://github.com/bluesky-social/atproto/tree/main/lexicons/app/bsky/actor)                 |
+| **ageassurance**                                                                                   | AgeassuranceService                                                                                        | [`app.bsky.ageassurance.*`](https://github.com/bluesky-social/atproto/tree/main/lexicons/app/bsky)                |
+| **bookmark**                                                                                       | BookmarkService                                                                                            | [`app.bsky.bookmark.*`](https://github.com/bluesky-social/atproto/tree/main/lexicons/app/bsky)                    |
+| **contact**                                                                                        | ContactService                                                                                             | [`app.bsky.contact.*`](https://github.com/bluesky-social/atproto/tree/main/lexicons/app/bsky)                     |
+| **draft**                                                                                          | DraftService                                                                                               | [`app.bsky.draft.*`](https://github.com/bluesky-social/atproto/tree/main/lexicons/app/bsky)                       |
 | **[feed](https://pub.dev/documentation/bluesky/latest/bluesky/Bluesky/feed.html)**                 | [FeedService](https://pub.dev/documentation/bluesky/latest/bluesky/FeedService-class.html)                 | [`app.bsky.feed.*`](https://github.com/bluesky-social/atproto/tree/main/lexicons/app/bsky/feed)                   |
 | **[notification](https://pub.dev/documentation/bluesky/latest/bluesky/Bluesky/notification.html)** | [NotificationService](https://pub.dev/documentation/bluesky/latest/bluesky/NotificationService-class.html) | [`app.bsky.notification.*`](https://github.com/bluesky-social/atproto/tree/main/lexicons/app/bsky/notification)   |
 | **[graph](https://pub.dev/documentation/bluesky/latest/bluesky/Bluesky/graph.html)**               | [GraphService](https://pub.dev/documentation/bluesky/latest/bluesky/GraphService-class.html)               | [`app.bsky.graph.*`](https://github.com/bluesky-social/atproto/tree/main/lexicons/app/bsky/graph)                 |
 | **[labeler](https://pub.dev/documentation/bluesky/latest/bluesky/Bluesky/labeler.html)**           | [LabelerService](https://pub.dev/documentation/bluesky/latest/bluesky/LabelerService-class.html)             | [`app.bsky.labeler.*`](https://github.com/bluesky-social/atproto/tree/main/lexicons/app/bsky/labeler)             |
-| **[video](https://pub.dev/documentation/bluesky/latest/bluesky/Bluesky/video.html)**               | [VideoService](https://pub.dev/documentation/bluesky/latest/bluesky/VideoService-class.html)               | [`app.bsky.video.*`](https://github.com/bluesky-social/atproto/tree/main/lexicons/app/bsky/video)                 |
+| **[video](https://pub.dev/documentation/bluesky/latest/bluesky/Bluesky/video.html)**               | VideoServiceImpl                                                                                            | [`app.bsky.video.*`](https://github.com/bluesky-social/atproto/tree/main/lexicons/app/bsky/video)                 |
 | **[unspecced](https://pub.dev/documentation/bluesky/latest/bluesky/Bluesky/unspecced.html)**       | [UnspeccedService](https://pub.dev/documentation/bluesky/latest/bluesky/UnspeccedService-class.html)       | [`app.bsky.unspecced.*`](https://github.com/bluesky-social/atproto/tree/main/lexicons/app/bsky/unspecced)         |
 
 ### Chat Services
@@ -202,11 +276,16 @@ For chat functionality, **[bluesky](https://pub.dev/packages/bluesky)** provides
 | **[convo](https://pub.dev/documentation/bluesky/latest/bluesky_chat/BlueskyChat/convo.html)**           | [ConvoService](https://pub.dev/documentation/bluesky/latest/bluesky_chat/ConvoService-class.html)           | [`chat.bsky.convo.*`](https://github.com/bluesky-social/atproto/tree/main/lexicons/chat/bsky/convo)           |
 | **[moderation](https://pub.dev/documentation/bluesky/latest/bluesky_chat/BlueskyChat/moderation.html)** | [ModerationService](https://pub.dev/documentation/bluesky/latest/bluesky_chat/ModerationService-class.html) | [`chat.bsky.moderation.*`](https://github.com/bluesky-social/atproto/tree/main/lexicons/chat/bsky/moderation) |
 
+:::note
+`chat.bsky.group.*` and `chat.bsky.notification.*` are generated and exported from `package:bluesky/chat_bsky_services.dart` as `GroupService` and `NotificationService`, but `BlueskyChat` does not yet surface them as properties. Construct them directly if you need those endpoints.
+:::
+
 To use chat services, create a **[BlueskyChat](https://pub.dev/documentation/bluesky/latest/bluesky_chat/BlueskyChat-class.html)** instance:
 
-```dart
+<!-- snippet: bluesky/chat_setup.dart -->
+```dart title="chat_setup.dart"
 import 'package:bluesky/atproto.dart';
-import 'package:bluesky/bluesky_chat.dart' as chat;
+import 'package:bluesky/bluesky_chat.dart';
 
 Future<void> main() async {
   final session = await createSession(
@@ -214,14 +293,15 @@ Future<void> main() async {
     password: 'YOUR_PASSWORD',
   );
 
-  // Create BlueskyChat instance for chat functionality
-  final bskyChat = chat.BlueskyChat.fromSession(session.data);
+  // Create BlueskyChat instance for chat functionality.
+  final chat = BlueskyChat.fromSession(session.data);
 
-  // Access chat services
-  final conversations = await bskyChat.convo.listConvos();
+  // Access chat services.
+  final conversations = await chat.convo.listConvos();
   print(conversations);
 }
 ```
+<!-- /snippet -->
 
 ### Ozone Services
 
@@ -236,9 +316,14 @@ For Ozone moderation tools, **[bluesky](https://pub.dev/packages/bluesky)** prov
 | **Team** | Manage moderation team members and roles |
 | **Additional Services** | Safelink, Set, Setting, Signature, and Verification services |
 
+:::note
+`tools.ozone.queue.*` and `tools.ozone.report.*` are generated as `QueueService` and `ReportService`, but `OzoneTool` does not yet surface them as properties.
+:::
+
 To use Ozone services, create an **[OzoneTool](https://pub.dev/documentation/bluesky/latest/ozone/OzoneTool-class.html)** instance:
 
-```dart
+<!-- snippet: bluesky/ozone_setup.dart -->
+```dart title="ozone_setup.dart"
 import 'package:bluesky/atproto.dart';
 import 'package:bluesky/ozone.dart';
 
@@ -248,23 +333,27 @@ Future<void> main() async {
     password: 'YOUR_PASSWORD',
   );
 
-  // Create OzoneTool instance for moderation tools
+  // Create OzoneTool instance for moderation tools.
   final ozone = OzoneTool.fromSession(session.data);
 
-  // Query moderation events
+  // Query moderation events.
   final events = await ozone.moderation.queryEvents(limit: 50);
-  
-  // Get moderation subjects
-  final subjects = await ozone.moderation.getSubjects();
-  
-  // Access team management
+
+  // Get details about specific subjects. `subjects` is required.
+  final subjects = await ozone.moderation.getSubjects(
+    subjects: ['did:plc:iijrtk7ocored6zuziwmqq3c'],
+  );
+
+  // Access team management.
   final teamMembers = await ozone.team.listMembers();
 }
 ```
+<!-- /snippet -->
 
 Once an instance of the **[Bluesky](https://pub.dev/documentation/bluesky/latest/bluesky/Bluesky-class.html)** object has been created, service endpoints can be used by accessing the `property` corresponding to each service as follows.
 
-```dart
+<!-- snippet: bluesky/service_access.dart -->
+```dart title="service_access.dart"
 import 'package:bluesky/atproto.dart';
 import 'package:bluesky/bluesky.dart';
 
@@ -282,6 +371,7 @@ Future<void> main() async {
   print(timeline);
 }
 ```
+<!-- /snippet -->
 
 :::tip
 See **[API Supported Matrix](../supported_api.md#bluesky)** for a list of endpoints supported by **[bluesky](https://pub.dev/packages/bluesky)**.
@@ -293,10 +383,10 @@ Okay then, let's try some endpoints!
 
 The following example first authenticates the user against `bsky.social`, sends the post to Bluesky, and then deletes it using a reference to the created record.
 
-```dart
+<!-- snippet: bluesky/post_and_delete.dart -->
+```dart title="post_and_delete.dart"
 import 'package:bluesky/atproto.dart';
 import 'package:bluesky/bluesky.dart';
-import 'package:bluesky/core.dart';
 
 Future<void> main() async {
   final session = await createSession(
@@ -310,11 +400,11 @@ Future<void> main() async {
   // Create a record to specific service like Bluesky.
   final strongRef = await bsky.feed.post.create(text: 'Hello, Bluesky!');
 
-  // And delete it.
-  final uri = AtUri(strongRef.data.uri);
-  await bsky.feed.post.delete(rkey: uri.rkey);
+  // And delete it. `uri` is already an `AtUri`.
+  await bsky.feed.post.delete(rkey: strongRef.data.uri.rkey);
 }
 ```
+<!-- /snippet -->
 
 :::tip
 See **[API Support Matrix](../supported_api.md#bluesky)** for all supported endpoints.
@@ -326,28 +416,27 @@ See **[API Support Matrix](../supported_api.md#bluesky)** for all supported endp
 
 #### Creating Posts
 
-```dart
+<!-- snippet: bluesky/create_posts.dart -->
+```dart title="create_posts.dart"
 import 'dart:io';
-import 'dart:typed_data';
 
 import 'package:bluesky/app_bsky_embed_external.dart';
 import 'package:bluesky/app_bsky_embed_images.dart';
 import 'package:bluesky/app_bsky_feed_post.dart';
 import 'package:bluesky/bluesky.dart';
-import 'package:bluesky/core.dart';
+import 'package:bluesky/cardyb.dart';
 
 Future<void> main() async {
   final bsky = Bluesky.fromSession(await _session);
 
-  // Simple text post
+  // Simple text post.
   final post = await bsky.feed.post.create(text: 'Hello, Bluesky! 🦋');
   print('Posted: ${post.data.uri}');
 
-  // Upload images
+  // Upload an image and embed it.
   final image = File('./cool_image.jpg').readAsBytesSync();
   final blob = await bsky.atproto.repo.uploadBlob(bytes: image);
 
-  // Post with images
   final imagePost = await bsky.feed.post.create(
     text: 'Check out this image!',
     embed: UFeedPostEmbed.embedImages(
@@ -357,207 +446,333 @@ Future<void> main() async {
     ),
   );
 
-  // Post with external link
+  // Post with an external link. `EmbedExternalExternal.uri` is a plain
+  // `String`, not an `AtUri`.
   final linkPost = await bsky.feed.post.create(
     text: 'Interesting article',
     embed: UFeedPostEmbed.embedExternal(
       data: EmbedExternal(
         external: EmbedExternalExternal(
-          uri: AtUri('https://example.com'),
+          uri: 'https://example.com',
           title: 'Article Title',
           description: 'Article description',
         ),
       ),
     ),
   );
+
+  // Or let `package:bluesky/cardyb.dart` build the card metadata for you.
+  final preview = await getLinkPreview(Uri.https('example.com'));
+
+  final cardPost = await bsky.feed.post.create(
+    text: 'Interesting article',
+    embed: UFeedPostEmbed.embedExternal(
+      data: EmbedExternal(
+        external: EmbedExternalExternal(
+          uri: preview.data.url ?? 'https://example.com',
+          title: preview.data.title ?? '',
+          description: preview.data.description ?? '',
+        ),
+      ),
+    ),
+  );
 }
 ```
+<!-- /snippet -->
+
+:::tip
+`package:bluesky/cardyb.dart` exposes `getLinkPreview(url)` and the `LinkPreview` model, so you do not have to scrape the page title and description yourself. Because cardyb answers `200` even on failure, check `preview.data.error` before trusting the result.
+:::
 
 #### Timeline and Feed Management
 
-```dart
-// Get user timeline
-final timeline = await bsky.feed.getTimeline(limit: 50);
-for (final post in timeline.data.feed) {
-  print('${post.post.author.displayName}: ${post.post.record}');
+<!-- snippet: bluesky/timeline.dart -->
+```dart title="timeline.dart"
+import 'package:bluesky/bluesky.dart';
+import 'package:bluesky/core.dart';
+
+Future<void> main() async {
+  final bsky = Bluesky.fromSession(await _session);
+
+  // Get user timeline.
+  final timeline = await bsky.feed.getTimeline(limit: 50);
+  for (final feed in timeline.data.feed) {
+    print('${feed.post.author.displayName}: ${feed.post.record}');
+  }
+
+  // Get author feed.
+  final authorFeed = await bsky.feed.getAuthorFeed(
+    actor: 'shinyakato.dev',
+    limit: 20,
+  );
+
+  // Get post thread. `uri` is an `AtUri`.
+  final thread = await bsky.feed.getPostThread(
+    uri: AtUri('at://did:plc:example/app.bsky.feed.post/example'),
+  );
 }
-
-// Get author feed
-final authorFeed = await bsky.feed.getAuthorFeed(
-  actor: 'shinyakato.dev',
-  limit: 20,
-);
-
-// Get post thread
-final thread = await bsky.feed.getPostThread(
-  uri: 'at://did:plc:example/app.bsky.feed.post/example',
-);
 ```
+<!-- /snippet -->
+
+:::caution
+Anything that identifies a record takes an **`AtUri`**, not a `String` — `getPostThread`, `getLikes`, `getRepostedBy`, `getQuotes`, `getPosts`, and `RepoStrongRef.uri` included. Values coming back from the API (`post.data.uri`, `data.uri` in Firehose handlers) are already `AtUri`, so pass them straight through.
+:::
 
 #### Interactions (Likes, Reposts, Replies)
 
-```dart
-// Like a post
-final like = await bsky.feed.like.create(
-  subject: RepoStrongRef(uri: uri, cid: cid),
-);
+<!-- snippet: bluesky/interactions.dart -->
+```dart title="interactions.dart"
+import 'package:bluesky/app_bsky_feed_post.dart';
+import 'package:bluesky/bluesky.dart';
+import 'package:bluesky/com_atproto_repo_strongref.dart';
+import 'package:bluesky/core.dart';
 
-// Repost
-final repost = await bsky.feed.repost.create(
-  subject: RepoStrongRef(uri: uri, cid: cid),
-);
+Future<void> main() async {
+  final bsky = Bluesky.fromSession(await _session);
 
-// Reply to a post
-final reply = await bsky.feed.post.create(
-  text: 'Great post!',
-  reply: ReplyRef(
-    root: RepoStrongRef(uri: originalPostUri, cid: originalPostCid),
-    parent: RepoStrongRef(uri: originalPostUri, cid: originalPostCid),
-  ),
-);
+  final postUri = AtUri('at://did:plc:example/app.bsky.feed.post/example');
+  const postCid = 'bafyreiexamplecid';
 
-// Get post likes
-final likes = await bsky.feed.getLikes(uri: postUri);
-for (final like in likes.data.likes) {
-  print('Liked by: ${like.actor.displayName}');
+  // `RepoStrongRef.uri` is an `AtUri`.
+  final subject = RepoStrongRef(uri: postUri, cid: postCid);
+
+  // Like a post.
+  final like = await bsky.feed.like.create(subject: subject);
+
+  // Repost.
+  final repost = await bsky.feed.repost.create(subject: subject);
+
+  // Reply to a post.
+  final reply = await bsky.feed.post.create(
+    text: 'Great post!',
+    reply: ReplyRef(root: subject, parent: subject),
+  );
+
+  // Get post likes.
+  final likes = await bsky.feed.getLikes(uri: postUri);
+  for (final like in likes.data.likes) {
+    print('Liked by: ${like.actor.displayName}');
+  }
+
+  // Get reposts.
+  final reposts = await bsky.feed.getRepostedBy(uri: postUri);
 }
-
-// Get reposts
-final reposts = await bsky.feed.getRepostedBy(uri: postUri);
 ```
+<!-- /snippet -->
 
 ### Chat Features
 
 **[bluesky](https://pub.dev/packages/bluesky)** provides full support for Bluesky's chat functionality through the **[BlueskyChat](https://pub.dev/documentation/bluesky/latest/bluesky_chat/BlueskyChat-class.html)** class.
 
-#### Setting Up Chat
+#### Conversation Management
 
-```dart
-import 'package:bluesky/atproto.dart';
+<!-- snippet: bluesky/chat_convos.dart -->
+```dart title="chat_convos.dart"
 import 'package:bluesky/bluesky_chat.dart';
 
 Future<void> main() async {
-  final session = await createSession(
-    identifier: 'YOUR_HANDLE_OR_EMAIL',
-    password: 'YOUR_PASSWORD',
+  final chat = BlueskyChat.fromSession(await _session);
+
+  // List all conversations.
+  final conversations = await chat.convo.listConvos(limit: 50);
+  for (final convo in conversations.data.convos) {
+    print(
+      'Conversation with: ${convo.members.map((m) => m.displayName).join(', ')}',
+    );
+    print('Last message: ${convo.lastMessage ?? 'No messages'}');
+  }
+
+  // Get a specific conversation.
+  final convo = await chat.convo.getConvo(convoId: 'convo-id');
+
+  // Get conversation for specific members.
+  final memberConvo = await chat.convo.getConvoForMembers(
+    members: ['did:plc:example1', 'did:plc:example2'],
   );
 
-  final chat = BlueskyChat.fromSession(session.data);
+  // Accept a conversation request.
+  await chat.convo.acceptConvo(convoId: 'convo-id');
+
+  // Leave a conversation.
+  await chat.convo.leaveConvo(convoId: 'convo-id');
+
+  // Mute/unmute conversations.
+  await chat.convo.muteConvo(convoId: 'convo-id');
+  await chat.convo.unmuteConvo(convoId: 'convo-id');
 }
 ```
+<!-- /snippet -->
 
-#### Conversation Management
+#### Messages and Reactions
 
-```dart
-// List all conversations
-final conversations = await chat.convo.listConvos(limit: 50);
-for (final convo in conversations.data.convos) {
-  print(
-    'Conversation with: ${convo.members.map((m) => m.displayName).join(', ')}',
+`MessageInput` comes from `package:bluesky/chat_bsky_convo_defs.dart` and `BatchItem` from `package:bluesky/chat_bsky_convo_sendmessagebatch.dart`.
+
+<!-- snippet: bluesky/chat_messages.dart -->
+```dart title="chat_messages.dart"
+import 'package:bluesky/bluesky_chat.dart';
+import 'package:bluesky/chat_bsky_convo_defs.dart';
+import 'package:bluesky/chat_bsky_convo_sendmessagebatch.dart';
+
+Future<void> main() async {
+  final chat = BlueskyChat.fromSession(await _session);
+
+  // Send a message.
+  final message = await chat.convo.sendMessage(
+    convoId: 'convo-id',
+    message: MessageInput(text: 'Hello! How are you doing?'),
   );
-  print('Last message: ${convo.lastMessage ?? 'No messages'}');
+
+  // Send multiple messages in batch.
+  await chat.convo.sendMessageBatch(
+    items: [
+      BatchItem(
+        convoId: 'convo-id-1',
+        message: MessageInput(text: 'Message 1'),
+      ),
+      BatchItem(
+        convoId: 'convo-id-2',
+        message: MessageInput(text: 'Message 2'),
+      ),
+    ],
+  );
+
+  // Get messages from a conversation.
+  final messages = await chat.convo.getMessages(convoId: 'convo-id', limit: 50);
+  for (final message in messages.data.messages) {
+    print('$message');
+  }
+
+  // Mark messages as read.
+  await chat.convo.updateRead(convoId: 'convo-id', messageId: 'message-id');
+
+  // Mark all conversations as read.
+  await chat.convo.updateAllRead();
+
+  // Delete a message for yourself only.
+  await chat.convo.deleteMessageForSelf(
+    convoId: 'convo-id',
+    messageId: 'message-id',
+  );
+
+  // Add and remove a reaction.
+  await chat.convo.addReaction(
+    convoId: 'convo-id',
+    messageId: 'message-id',
+    value: '👍',
+  );
+
+  await chat.convo.removeReaction(
+    convoId: 'convo-id',
+    messageId: 'message-id',
+    value: '👍',
+  );
 }
-
-// Get a specific conversation
-final convo = await chat.convo.getConvo(convoId: 'convo-id');
-
-// Get conversation for specific members
-final memberConvo = await chat.convo.getConvoForMembers(
-  members: ['did:plc:example1', 'did:plc:example2'],
-);
-
-// Accept a conversation request
-await chat.convo.acceptConvo(convoId: 'convo-id');
-
-// Leave a conversation
-await chat.convo.leaveConvo(convoId: 'convo-id');
-
-// Mute/unmute conversations
-await chat.convo.muteConvo(convoId: 'convo-id');
-await chat.convo.unmuteConvo(convoId: 'convo-id');
 ```
-
-#### Message Management
-
-```dart
-// Send a message
-final message = await chat.convo.sendMessage(
-  convoId: 'convo-id',
-  message: MessageInput(text: 'Hello! How are you doing?'),
-);
-
-// Send multiple messages in batch
-await chat.convo.sendMessageBatch(
-  items: [
-    BatchItem(
-      convoId: 'convo-id-1',
-      message: MessageInput(text: 'Message 1'),
-    ),
-    BatchItem(
-      convoId: 'convo-id-2',
-      message: MessageInput(text: 'Message 2'),
-    ),
-  ],
-);
-
-// Get messages from a conversation
-final messages = await chat.convo.getMessages(convoId: 'convo-id', limit: 50);
-
-for (final message in messages.data.messages) {
-  print('$message');
-}
-
-// Mark messages as read
-await chat.convo.updateRead(convoId: 'convo-id', messageId: 'message-id');
-
-// Mark all conversations as read
-await chat.convo.updateAllRead();
-
-// Delete message for self
-await chat.convo.deleteMessageForSelf(
-  convoId: 'convo-id',
-  messageId: 'message-id',
-);
-```
-
-#### Message Reactions
-
-```dart
-// Add reaction to a message
-await chat.convo.addReaction(
-  convoId: 'convo-id',
-  messageId: 'message-id',
-  value: '👍',
-);
-
-// Remove reaction from a message
-await chat.convo.removeReaction(
-  convoId: 'convo-id',
-  messageId: 'message-id',
-  value: '👍',
-);
-```
+<!-- /snippet -->
 
 #### Chat Moderation
 
-```dart
-// Get actor metadata for moderation
-final actorMeta = await chat.moderation.getActorMetadata(
-  actor: 'did:plc:example',
-);
+<!-- snippet: bluesky/chat_moderation.dart -->
+```dart title="chat_moderation.dart"
+import 'package:bluesky/bluesky_chat.dart';
 
-// Update actor access (for moderators)
-await chat.moderation.updateActorAccess(
-  actor: 'did:plc:example',
-  allowAccess: true,
-);
+Future<void> main() async {
+  final chat = BlueskyChat.fromSession(await _session);
 
-// Get message context for moderation
-final messageContext = await chat.moderation.getMessageContext(
-  convoId: 'convo-id',
-  messageId: 'message-id',
-);
+  // Get actor metadata for moderation.
+  final actorMeta = await chat.moderation.getActorMetadata(
+    actor: 'did:plc:example',
+  );
+
+  // Update actor access (for moderators).
+  await chat.moderation.updateActorAccess(
+    actor: 'did:plc:example',
+    allowAccess: true,
+  );
+
+  // Get message context for moderation.
+  final messageContext = await chat.moderation.getMessageContext(
+    convoId: 'convo-id',
+    messageId: 'message-id',
+  );
+}
 ```
+<!-- /snippet -->
+
+### Notification Grouping
+
+A raw notification list is unusable in a UI: fifty separate "X liked your post" rows should read as one. **[bluesky](https://pub.dev/packages/bluesky)** groups notifications client-side the same way the official Bluesky app does, through the `group()` extension on the `listNotifications` output.
+
+Since **v2.1.0** the default is official social-app parity: it groups `like`, `repost`, `follow`, `like-via-repost`, `repost-via-repost`, and `subscribed-post`; applies a 48-hour sliding window anchored on each group's newest item; separates follow-backs into their own groups; and marks a group unread if *any* of its notifications is unread.
+
+<!-- snippet: bluesky/notification_grouping.dart -->
+```dart title="notification_grouping.dart"
+import 'package:bluesky/app_bsky_notification_listnotifications.dart';
+import 'package:bluesky/bluesky.dart';
+
+Future<void> main() async {
+  final bsky = Bluesky.fromSession(await _session);
+
+  final notifications = await bsky.notification.listNotifications();
+
+  // Default: official Bluesky social-app parity — groups like / repost /
+  // follow / like-via-repost / repost-via-repost / subscribed-post within a
+  // 48h sliding window, separates follow-backs, and marks a group unread if
+  // any of its notifications is unread.
+  final grouped = notifications.data.group();
+
+  for (final group in grouped.notifications) {
+    print('${group.reason}: ${group.authors.length} author(s)');
+    print('Newest subject: ${group.uris.first}');
+    print('Unread: ${group.isRead == false}');
+  }
+
+  // Keep the legacy behavior from bluesky <= 2.x.
+  final legacy = notifications.data.group(
+    config: const NotificationsGrouperConfig.lenient(),
+  );
+
+  // Or fully customize the grouping.
+  final custom = notifications.data.group(
+    config: const NotificationsGrouperConfig(
+      groupableReasons: {
+        KnownNotificationReason.like,
+        KnownNotificationReason.repost,
+      },
+      window: Duration(hours: 24),
+      separateFollowBacks: true,
+      unreadIfAny: false,
+    ),
+  );
+
+  // Additionally bucket by wall-clock time before grouping.
+  final hourly = notifications.data.groupByHour(3);
+  final byMinute = notifications.data.groupByMinute(30);
+
+  // `GroupBy` can be combined with a config.
+  final legacyHourly = notifications.data.group(
+    by: GroupBy.hour(3),
+    config: const NotificationsGrouperConfig.lenient(),
+  );
+
+  // The grouper is also usable directly.
+  const grouper = NotificationsGrouper(
+    config: NotificationsGrouperConfig.official(),
+  );
+  final GroupedNotifications result = grouper.group(notifications.data);
+}
+```
+<!-- /snippet -->
+
+| Config | Grouped reasons | Window | Follow-backs | Unread |
+| --- | --- | --- | --- | --- |
+| `NotificationsGrouperConfig.official()` (default) | 6 reasons | 48h sliding | Separated | If any unread |
+| `NotificationsGrouperConfig.lenient()` | like / repost / follow | none | Merged | Newest item's `isRead` |
+| `NotificationsGrouperConfig(...)` | yours | yours | yours | yours |
+
+:::caution
+`v2.1.0` changed the default output. If you depended on the pre-2.1 behavior, pass `NotificationsGrouperConfig.lenient()` explicitly. This applies to `groupByHour` / `groupByMinute` too, which now also default to the official config.
+:::
 
 ## More Tips 🏄
 
@@ -583,7 +798,8 @@ Future<void> main() async {
 
 Then you can create **[Bluesky](https://pub.dev/documentation/bluesky/latest/bluesky/Bluesky-class.html)** object from authenticated session.
 
-```dart
+<!-- snippet: bluesky/session_management.dart -->
+```dart title="session_management.dart"
 import 'package:bluesky/atproto.dart';
 import 'package:bluesky/bluesky.dart';
 
@@ -598,12 +814,17 @@ Future<void> main() async {
   // You can create Bluesky object from authenticated session.
   final bsky = Bluesky.fromSession(session.data);
 
-  // Do something with bluesky
+  // Do something with bluesky.
   final did = await bsky.atproto.identity.resolveHandle(
     handle: session.data.handle,
   );
 }
 ```
+<!-- /snippet -->
+
+:::tip
+For OAuth-based authentication, see **[OAuth](#oauth)** above. A client built with `Bluesky.fromOAuth` reports `null` from `session` and exposes its manager through `oAuthSessionManager` instead.
+:::
 
 ### App Password
 
@@ -632,7 +853,8 @@ The endpoints provided by **[bluesky](https://pub.dev/packages/bluesky)** always
 
 You can specify any `service` as follows.
 
-```dart
+<!-- snippet: bluesky/custom_service.dart -->
+```dart title="custom_service.dart"
 import 'package:bluesky/atproto.dart';
 import 'package:bluesky/bluesky.dart';
 
@@ -653,39 +875,45 @@ Future<void> main() async {
   );
 }
 ```
+<!-- /snippet -->
+
+### Custom HTTP Clients
+
+Every constructor accepts `getClient` and `postClient` hooks, so you can route requests through your own `http` client for logging, proxying, or tests.
+
+```dart
+final bsky = Bluesky.anonymous(getClient: myGetClient, postClient: myPostClient);
+```
 
 ### De/Serialize
 
 All objects representing JSON objects returned from the API provided by **[bluesky](https://pub.dev/packages/bluesky)** are generated using [freezed](https://pub.dev/packages/freezed) and [json_serializable](https://pub.dev/packages/json_serializable). So, it allows for easy JSON-based de/serialize of these model objects based on the common contract between the `fromJson` and `toJson` methods.
 
-For example, if you have the following code:
+Note that every endpoint returns an **`XRPCResponse`**, which is a transport envelope and is *not* itself serializable. The model object lives in its `.data` property, and that is what carries `toJson` / `fromJson`.
 
-```dart
+<!-- snippet: bluesky/serialization.dart -->
+```dart title="serialization.dart"
 import 'package:bluesky/bluesky.dart';
+import 'package:bluesky/com_atproto_identity_resolvehandle.dart';
 
 Future<void> main() async {
   final bsky = Bluesky.anonymous();
 
-  // Just find the DID of `shinyakato.dev`
+  // Just find the DID of `shinyakato.dev`.
   final did = await bsky.atproto.identity.resolveHandle(
     handle: 'shinyakato.dev',
   );
+
+  // `did` is an `XRPCResponse`; the model object lives in `.data`.
+  // => {did: did:plc:iijrtk7ocored6zuziwmqq3c}
+  final json = did.data.toJson();
+  print(json);
+
+  // And back again.
+  final restored = IdentityResolveHandleOutput.fromJson(json);
 }
 ```
-
-Then you can deserialize `DID` object as JSON with `toJson` as follows:
-
-```dart
-print(did.toJson()); // => {did: did:plc:iijrtk7ocored6zuziwmqq3c}
-```
-
-And you can serialize JSON as `DID` object with `fromJson` as follows:
-
-```dart
-final json = did.toJson();
-
-final serializedDID = DID.fromJson(json);
-```
+<!-- /snippet -->
 
 ### Thrown Exceptions
 
@@ -720,7 +948,8 @@ The main purpose of setting a rate limit for the API is to prevent excessive req
 
 Rate limits in the AT Protocol are defined in a common specification for the protocol and are set and you can easily access this information as follows.
 
-```dart
+<!-- snippet: bluesky/rate_limits.dart -->
+```dart title="rate_limits.dart"
 import 'package:bluesky/bluesky.dart';
 
 Future<void> main() async {
@@ -729,8 +958,6 @@ Future<void> main() async {
   final response = await bsky.feed.getTimeline();
 
   // This is rate limit!
-  print(response.rateLimit);
-
   final rateLimit = response.rateLimit;
 
   // Available properties.
@@ -744,10 +971,11 @@ Future<void> main() async {
   print(rateLimit.isNotExceeded);
 
   // It waits until the rate limit is reset based on resetAt.
-  // If the rate limit is not exceeded, return immediately.
+  // If the rate limit is not exceeded, it returns immediately.
   await rateLimit.waitUntilReset();
 }
 ```
+<!-- /snippet -->
 
 As in the example above, the rate limits when using **[bluesky](https://pub.dev/packages/bluesky)** are **_always_** accessible from **[XRPCResponse](https://pub.dev/documentation/xrpc/latest/xrpc/XRPCResponse-class.html)**.
 In more detail, rate limit information is read from the HTTP response headers returned by the ATP server and can be accessed via the `rateLimit` property of the **[XRPCResponse](https://pub.dev/documentation/xrpc/latest/xrpc/XRPCResponse-class.html)** as a **[RateLimit](https://pub.dev/documentation/xrpc/latest/xrpc/RateLimit-class.html)** object.
@@ -797,16 +1025,20 @@ That is, **[RateLimit](https://pub.dev/documentation/xrpc/latest/xrpc/RateLimit-
 
 Since AT Protocol's Lexicon supports the Union type, there are several endpoints where multiple JSONs of different structures are returned at once. However, since Dart does not currently support Union as a language specification, there have been difficulties in marshaling JSON for this Union structure.
 
-**[bluesky](https://pub.dev/packages/bluesky)** solves this problem neatly by using **[freezed](https://pub.dev/packages/freezed)** to represent a pseudo-Union type. Besides it's type safe. And all the Union types provided by these **[atproto](https://pub.dev/packages/atproto)** are `.when(...)` methods to handle them cleanly.
+**[bluesky](https://pub.dev/packages/bluesky)** solves this problem by using **[freezed](https://pub.dev/packages/freezed)** to represent a pseudo-Union type, and it stays type safe. Every union is generated as a **sealed class**, so you can handle it two ways:
+
+- with the generated callback methods — `when` (every case required), plus `map`, `maybeWhen`, and `whenOrNull` for the partial variants; or
+- with a plain Dart `switch`, which the compiler checks for exhaustiveness because the class is sealed.
 
 See, for example, **[Firehose API](#firehose-api)** in the next section.
 
 #### Advanced Union Type Handling
 
-```dart
+<!-- snippet: bluesky/union_types.dart -->
+```dart title="union_types.dart"
 import 'package:bluesky/app_bsky_feed_defs.dart';
 
-// Example: Handling different embed types in posts
+// `when` requires a callback for every case, including `unknown`.
 void handlePostEmbed(UPostViewEmbed? embed) {
   embed?.when(
     embedImagesView: (images) {
@@ -814,6 +1046,13 @@ void handlePostEmbed(UPostViewEmbed? embed) {
       for (final image in images.images) {
         print('Image: ${image.alt} - ${image.thumb}');
       }
+    },
+    embedVideoView: (video) {
+      print('Video: ${video.playlist}');
+      print('Alt text: ${video.alt}');
+    },
+    embedGalleryView: (gallery) {
+      print('Gallery with ${gallery.items.length} item(s)');
     },
     embedExternalView: (external) {
       print('External link: ${external.external.title}');
@@ -825,35 +1064,41 @@ void handlePostEmbed(UPostViewEmbed? embed) {
     embedRecordWithMediaView: (recordWithMedia) {
       print('Quote post with media');
     },
-    embedVideoView: (video) {
-      print('Video: ${video.playlist}');
-      print('Alt text: ${video.alt}');
-    },
     unknown: (data) {
+      // Handle future embed types gracefully.
       print('Unknown embed type: ${data.runtimeType}');
-      // Handle future embed types gracefully
     },
   );
 }
 
-// Pattern matching approach (Dart 3+)
+// Union types are sealed classes, so a `switch` is exhaustive without a
+// `default` clause once every case is listed.
 void handlePostEmbedWithPatternMatching(UPostViewEmbed? embed) {
   switch (embed) {
     case UPostViewEmbedEmbedImagesView():
       print('Images embed with ${embed.data.images.length} images');
+    case UPostViewEmbedEmbedVideoView():
+      print('Video embed: ${embed.data.alt}');
+    case UPostViewEmbedEmbedGalleryView():
+      print('Gallery embed with ${embed.data.items.length} item(s)');
     case UPostViewEmbedEmbedExternalView():
       print('External link: ${embed.data.external.title}');
     case UPostViewEmbedEmbedRecordView():
       print('Record embed: ${embed.data.record}');
     case UPostViewEmbedEmbedRecordWithMediaView():
       print('Record with media embed');
-    case UPostViewEmbedEmbedVideoView():
-      print('Video embed: ${embed.data.alt}');
-    default:
-      print('Unknown or unsupported embed type');
+    case UPostViewEmbedUnknown():
+      print('Unknown embed: ${embed.data}');
+    case null:
+      print('No embed');
   }
 }
 ```
+<!-- /snippet -->
+
+:::caution
+`when` requires a callback for **every** case. When the AppView adds a new variant — `embedGalleryView` was added this way — a `when` call that omits it stops compiling. That is the point: the compiler tells you where to handle the new case. Use `whenOrNull` or `maybeWhen` if you genuinely only care about a subset.
+:::
 
 :::info
 All Union types provided by **[bluesky](https://pub.dev/packages/bluesky)** always have the property **`unknown`**. This is because Union types not supported by **[bluesky](https://pub.dev/packages/bluesky)** **cannot be converted** to specific model objects when returned from a particular endpoint.
@@ -862,36 +1107,7 @@ When an **`unknown`** event occurs, a raw JSON object that has not been marshall
 :::
 
 :::tip
-Alternatively, you can handle these union objects more easily using **_[pattern matching](https://dart.dev/language/patterns)_** supported by Dart3.
-For example, if pattern matching is used, the processing of `.when` when using the **[Firehose API](#firehose-api)** is replaced.
-
-And all union objects have defined class names prefixed with **_`U`_**.
-So, if you want the Firehose API to handle only `Commit` and `Handle` events, you can use the **`USubscribedRepoCommit`** and **`USubscribedRepoHandle`** objects for pattern matching as follows.
-
-```dart
-import 'package:bluesky/bluesky.dart';
-import 'package:bluesky/com_atproto_sync_subscriberepos.dart';
-import 'package:bluesky/firehose.dart';
-
-Future<void> main() async {
-  final bsky = Bluesky.anonymous();
-
-  final subscription = await bsky.atproto.sync.subscribeRepos();
-
-  await for (final event in subscription.data.stream) {
-    final repos = const SyncSubscribeReposAdaptor().execute(event);
-
-    // No need to use `.when` method.
-    switch (repos) {
-      // Specify an union object prefixed with `U` as the case.
-      case USyncSubscribeReposMessageCommit():
-        print(repos.data.ops);
-      case USyncSubscribeReposMessageIdentity():
-        print(repos.data.handle);
-    }
-  }
-}
-```
+All union classes are named with a **_`U`_** prefix, and each variant gets its own subclass — `USyncSubscribeReposMessageCommit`, `USyncSubscribeReposMessageIdentity`, and so on. That is what makes them usable directly as `switch` cases; see the **[Firehose API](#firehose-api)** below for a worked example.
 :::
 
 ### Firehose API
@@ -900,49 +1116,88 @@ Future<void> main() async {
 
 The **`Firehose API`** in AT Protocol allows you to get all events that occur on a specific service, such as `bsky.network`, **_in real time_**. This powerful and long-lived API can be used to calculate statistics using real-time data, develop interesting interactive BOTs, etc.
 
-Using **[bluesky](https://pub.dev/packages/bluesky)** to access the `Firehose API` is very simple, just execute the **[subscribeRepos](https://pub.dev/documentation/atproto/latest/com_atproto_services/SyncService/subscribeRepos.html)** method provided by the **[SyncService](https://pub.dev/documentation/atproto/latest/com_atproto_services/SyncService-class.html)** as shown in the following example. Also, user authentication is not required to access the `Firehose API`.
+Accessing the `Firehose API` requires no authentication. The simplest entry point is **`subscribeReposAsMessages()`**, which yields already-decoded, typed messages instead of raw binary frames.
 
-```dart
+<!-- snippet: bluesky/firehose_messages.dart -->
+```dart title="firehose_messages.dart"
 import 'package:bluesky/bluesky.dart';
 import 'package:bluesky/com_atproto_sync_subscriberepos.dart';
+
+Future<void> main() async {
+  // Authentication is not required.
+  final bsky = Bluesky.anonymous();
+
+  // Yields already-decoded, typed messages instead of raw binary frames, so
+  // no adaptor is needed.
+  final subscription = await bsky.atproto.sync.subscribeReposAsMessages();
+
+  await for (final message in subscription.data.stream) {
+    switch (message) {
+      // Occurs when an account committed records, such as Post and Like.
+      case USyncSubscribeReposMessageCommit():
+        // A single commit may contain multiple records.
+        for (final op in message.data.ops) {
+          if (op.action.isUnknown) continue;
+
+          switch (op.action.knownValue!) {
+            case KnownRepoOpAction.create:
+            case KnownRepoOpAction.update:
+              print(op);
+            case KnownRepoOpAction.delete:
+              print(op);
+          }
+        }
+
+      // Occurs when an account changed its handle.
+      case USyncSubscribeReposMessageIdentity():
+        print(message.data.handle);
+        print(message.data.did);
+
+      default:
+        print(message);
+    }
+  }
+}
+```
+<!-- /snippet -->
+
+The **[USyncSubscribeReposMessage](https://pub.dev/documentation/atproto/latest/com_atproto_sync_subscriberepos/USyncSubscribeReposMessage-class.html)** you receive is a **[Union](#union-types)**, so a `switch` over its `U`-prefixed subclasses handles each event.
+
+If you need the raw frames — to persist them, or to decode them on another isolate — use **`subscribeRepos()`** and run them through `SyncSubscribeReposAdaptor` yourself.
+
+<!-- snippet: bluesky/firehose_raw.dart -->
+```dart title="firehose_raw.dart"
+import 'package:bluesky/bluesky.dart';
 import 'package:bluesky/firehose.dart';
 
 Future<void> main() async {
   // Authentication is not required.
   final bsky = Bluesky.anonymous();
 
+  // Yields raw binary frames; decode them yourself with the adaptor.
   final subscription = await bsky.atproto.sync.subscribeRepos();
 
-  // Get events in real time.
   await for (final event in subscription.data.stream) {
     final repos = const SyncSubscribeReposAdaptor().execute(event);
 
     repos.when(
-      // Occurs when account committed records, such as Post and Like in Bluesky.
+      // Occurs when an account committed records, such as Post and Like.
       commit: (data) {
-        // A single commit may contain multiple records.
         for (final op in data.ops) {
           if (op.action.isUnknown) continue;
 
           switch (op.action.knownValue!) {
             case KnownRepoOpAction.create:
             case KnownRepoOpAction.update:
-              // Created/Updated operation.
               print(op);
-
-              break;
             case KnownRepoOpAction.delete:
-              // Deleted operation.
               print(op);
-
-              break;
           }
         }
       },
 
-      // Occurs when account changed handle.
+      // Occurs when an account changed its handle.
       identity: (data) {
-        // Updated handle.
         print(data.handle);
         print(data.did);
       },
@@ -955,127 +1210,120 @@ Future<void> main() async {
   }
 }
 ```
+<!-- /snippet -->
 
-The above example may seem a bit difficult, but the **[USyncSubscribeReposMessage](https://pub.dev/documentation/atproto/latest/com_atproto_sync_subscriberepos/USyncSubscribeReposMessage-class.html)** that can be retrieved in real-time from the Stream is of type **[Union](#union-types)**, so `.when(...)` method can be used to easily handle each event.
+:::tip
+Prefer `subscribeReposAsMessages()` unless you specifically need the bytes. It does the decoding for you, and a frame that fails to decode arrives as a stream error rather than tearing down the whole subscription.
+:::
 
-In addition, **[bluesky](https://pub.dev/packages/bluesky)** can easily filter and retrieve only specific commit data from the `Firehose API` by using **[RepoCommitHandler](https://pub.dev/documentation/bluesky/latest/firehose/RepoCommitHandler-class.html)**.
+In addition, **[bluesky](https://pub.dev/packages/bluesky)** can filter down to specific commit data using **[RepoCommitHandler](https://pub.dev/documentation/bluesky/latest/firehose/RepoCommitHandler-class.html)**.
 
-```dart
+<!-- snippet: bluesky/firehose_handler.dart -->
+```dart title="firehose_handler.dart"
 import 'package:bluesky/bluesky.dart';
-import 'package:bluesky/com_atproto_sync_subscriberepos.dart';
 import 'package:bluesky/firehose.dart';
 
 Future<void> main() async {
   // Authentication is not required.
   final bsky = Bluesky.anonymous();
 
-  final subscription = await bsky.atproto.sync.subscribeRepos();
-
-  // Use `RepoCommitHandler`.
+  // Use `RepoCommitHandler` to filter down to the records you care about.
   final handler = RepoCommitHandler(
-    // Occurs only when post record is created.
+    // Occurs only when a post record is created.
     onCreateFeedPost: (data) {
       print(data.uri);
       print(data.record);
     },
-    // Occurs only when profile record is updated.
+    // Occurs only when a profile record is updated.
     onUpdateActorProfile: (data) {
       print(data.uri);
       print(data.record);
     },
-    // Occurs only when follow record is deleted.
+    // Occurs only when a follow record is deleted.
     onDeleteGraphFollow: (data) {
       print(data.uri);
     },
   );
 
-  await for (final event in subscription.data.stream) {
-    final repos = const SyncSubscribeReposAdaptor().execute(event);
+  final subscription = await bsky.atproto.sync.subscribeReposAsMessages();
 
-    repos.when(
-      commit: handler.execute, // Execute like this.
-      identity: print,
-      account: print,
-      sync: print,
-      info: print,
-      unknown: print,
-    );
+  await for (final message in subscription.data.stream) {
+    if (message.isCommit) {
+      handler.execute(message.commit!);
+    }
   }
 }
 ```
+<!-- /snippet -->
 
 #### Advanced Firehose Usage
 
-```dart
+A mention bot is a handful of lines on top of `RepoCommitHandler`. Note that `data.uri` is already an `AtUri`, which is exactly what `RepoStrongRef` wants.
+
+<!-- snippet: bluesky/firehose_bot.dart -->
+```dart title="firehose_bot.dart"
 import 'package:bluesky/app_bsky_feed_post.dart';
 import 'package:bluesky/bluesky.dart';
 import 'package:bluesky/com_atproto_repo_strongref.dart';
-import 'package:bluesky/com_atproto_sync_subscriberepos.dart';
 import 'package:bluesky/firehose.dart';
 
-/// Mention Bot
+/// A bot that replies whenever it is mentioned.
 Future<void> main() async {
-  // Authentication is not required.
-  final bsky = Bluesky.anonymous();
+  final bsky = Bluesky.fromSession(await _session);
 
-  // Create a sophisticated bot that responds to mentions
   final mentionBot = RepoCommitHandler(
     onCreateFeedPost: (data) async {
-      final post = data.record;
-      final text = post.text.toLowerCase();
+      final text = data.record.text.toLowerCase();
+      if (!text.contains('@mybot.bsky.social')) return;
 
-      // Check if the bot is mentioned
-      if (text.contains('@mybot.bsky.social')) {
-        // Extract the mention and respond
-        final response = await generateResponse(text);
+      // `data.uri` is already an `AtUri`, which is what `RepoStrongRef`
+      // expects.
+      final ref = RepoStrongRef(uri: data.uri, cid: data.cid!);
 
-        await bsky.feed.post.create(
-          text: response,
-          reply: ReplyRef(
-            root: RepoStrongRef(uri: data.uri.toString(), cid: data.cid!),
-            parent: RepoStrongRef(uri: data.uri.toString(), cid: data.cid!),
-          ),
-        );
-      }
+      await bsky.feed.post.create(
+        text: 'Thanks for the mention!',
+        reply: ReplyRef(root: ref, parent: ref),
+      );
     },
   );
 
-  final subscription = await bsky.atproto.sync.subscribeRepos();
+  final subscription = await bsky.atproto.sync.subscribeReposAsMessages();
 
-  await for (final event in subscription.data.stream) {
-    final repos = const SyncSubscribeReposAdaptor().execute(event);
-
-    repos.whenOrNull(commit: mentionBot.execute);
+  await for (final message in subscription.data.stream) {
+    if (message.isCommit) {
+      mentionBot.execute(message.commit!);
+    }
   }
 }
 ```
+<!-- /snippet -->
 
-```dart
-import 'package:bluesky/com_atproto_sync_subscriberepos.dart';
+The same handler shape works for real-time analytics.
+
+<!-- snippet: bluesky/firehose_analytics.dart -->
+```dart title="firehose_analytics.dart"
 import 'package:bluesky/firehose.dart';
 
-// Real-time analytics example
+/// Real-time analytics over the Firehose.
 class FirehoseAnalytics {
   int postCount = 0;
   int likeCount = 0;
   final Map<String, int> languageStats = {};
 
-  void process(Commit data) {
+  void process(final Commit commit) {
     RepoCommitHandler(
       onCreateFeedPost: (data) {
         postCount++;
-        final post = data.record;
-        final langs = post.langs ?? ['unknown'];
-        for (final lang in langs) {
+        for (final lang in data.record.langs ?? const ['unknown']) {
           languageStats[lang] = (languageStats[lang] ?? 0) + 1;
         }
       },
       onCreateFeedLike: (data) {
         likeCount++;
       },
-    ).execute(data);
+    ).execute(commit);
 
-    // Print stats every 1000 posts
+    // Print stats every 1000 posts.
     if (postCount % 1000 == 0) {
       print('Posts: $postCount, Likes: $likeCount');
       print('Top languages: ${languageStats.entries.take(5).toList()}');
@@ -1083,6 +1331,7 @@ class FirehoseAnalytics {
   }
 }
 ```
+<!-- /snippet -->
 
 ### Timeout Duration
 
@@ -1092,16 +1341,18 @@ However, depending on system requirements, it may be necessary to set a time sho
 
 In that case, when creating an instance of the **[Bluesky](https://pub.dev/documentation/bluesky/latest/bluesky/Bluesky-class.html)** object, the timeout period can be specified as follows.
 
-```dart
+<!-- snippet: bluesky/timeout.dart -->
+```dart title="timeout.dart"
 import 'package:bluesky/bluesky.dart';
 
 Future<void> main() async {
-  final bluesky = Bluesky.anonymous(
+  final bsky = Bluesky.anonymous(
     // Add this.
     timeout: Duration(seconds: 20),
   );
 }
 ```
+<!-- /snippet -->
 
 ### Advanced Built-In Retry
 
@@ -1119,7 +1370,8 @@ The **[Exponential BackOff And Jitter](https://aws.amazon.com/blogs/architecture
 
 You can use this retry features as follows.
 
-```dart
+<!-- snippet: bluesky/retry.dart -->
+```dart title="retry.dart"
 import 'package:bluesky/bluesky.dart';
 import 'package:bluesky/core.dart' as core;
 
@@ -1136,6 +1388,12 @@ Future<void> main() async {
       jitter: core.Jitter(maxInSeconds: 10, minInSeconds: 5),
 
       // Optional.
+      // By default a procedure (`POST`) is *not* retried after an ambiguous
+      // failure the server may already have applied. Opt back in only if the
+      // request is safe to duplicate.
+      retryProcedureOnAmbiguousFailure: false,
+
+      // Optional.
       // You can define the events that occur when Retry is executed.
       onExecute: (event) => print(
         'Retry after ${event.intervalInSeconds} seconds...'
@@ -1145,6 +1403,7 @@ Future<void> main() async {
   );
 }
 ```
+<!-- /snippet -->
 
 **Then it retries:**
 
@@ -1152,17 +1411,59 @@ Future<void> main() async {
 - When the network is temporarily lost
 - When communication times out temporarily and a **`TimeoutException`** is thrown
 
+:::caution **Procedures are not retried after an ambiguous failure**
+A `5xx` or a post-send timeout is *ambiguous*: the server may already have applied your write. Retrying it could create a duplicate post, like, or follow. So `RetryConfig` retries queries (`GET`) and subscriptions freely, but by default it **refuses to retry a procedure (`POST`)** once the failure is ambiguous.
+
+Set `retryProcedureOnAmbiguousFailure: true` to restore unconditional retries — do this only when the request is genuinely idempotent, for instance because you supply your own `rkey`.
+:::
+
+:::tip **Bring your own strategy**
+`retryConfig` is typed as `RetryStrategy`, not `RetryConfig`. Implement the interface yourself when you want a different backoff curve, or different rules about what deserves a retry.
+
+<!-- snippet: bluesky/retry_strategy.dart -->
+```dart title="retry_strategy.dart"
+import 'package:bluesky/bluesky.dart';
+import 'package:bluesky/core.dart' as core;
+
+/// `retryConfig` accepts any `RetryStrategy`, so the backoff curve and the
+/// decision of *what* to retry are both yours to define.
+class FixedDelayRetry implements core.RetryStrategy {
+  const FixedDelayRetry({this.maxAttempts = 3});
+
+  final int maxAttempts;
+
+  @override
+  Duration? nextDelay(final core.RetryContext context) {
+    if (context.attempt > maxAttempts) return null;
+
+    // Never repeat a write the server may already have applied.
+    if (context.isProcedure && context.isAmbiguous) return null;
+
+    return const Duration(seconds: 2);
+  }
+}
+
+Future<void> main() async {
+  final bsky = Bluesky.anonymous(retryConfig: const FixedDelayRetry());
+}
+```
+<!-- /snippet -->
+:::
+
+A server-provided `Retry-After` or `ratelimit-reset` is honored as a lower bound on the delay, capped at 60 seconds so a hostile value cannot stall you indefinitely.
+
 #### Advanced Error Handling and Retry Patterns
 
-```dart
+<!-- snippet: bluesky/error_handling.dart -->
+```dart title="error_handling.dart"
 import 'package:bluesky/bluesky.dart';
 import 'package:bluesky/core.dart' as core;
 
 Future<void> main() async {
-  final maxAttempts = 5;
+  const maxAttempts = 5;
 
-  final bluesky = Bluesky.fromSession(
-    session,
+  final bsky = Bluesky.fromSession(
+    await _session,
     retryConfig: core.RetryConfig(
       maxAttempts: maxAttempts,
       jitter: core.Jitter(minInSeconds: 1, maxInSeconds: 30),
@@ -1174,51 +1475,53 @@ Future<void> main() async {
   );
 
   try {
-    // This will automatically retry on transient failures
-    final timeline = await bluesky.feed.getTimeline();
+    // This automatically retries transient failures.
+    final timeline = await bsky.feed.getTimeline();
     print('Successfully retrieved ${timeline.data.feed.length} posts');
   } on core.RateLimitExceededException catch (e) {
-    // Handle rate limiting specifically
     print('Rate limit exceeded. Reset at: ${e.response.rateLimit.resetAt}');
     await e.response.rateLimit.waitUntilReset();
 
-    // Retry after rate limit reset
-    final timeline = await bluesky.feed.getTimeline();
+    // Retry after the rate limit resets.
+    final timeline = await bsky.feed.getTimeline();
   } on core.UnauthorizedException catch (e) {
-    // Handle authentication errors
+    // Refresh the session or re-authenticate.
     print('Authentication failed: ${e.response}');
-    // Refresh session or re-authenticate
   } on core.XRPCException catch (e) {
-    // Handle other API errors
     print('API error: ${e.response}');
   } catch (e) {
-    // Handle unexpected errors
     print('Unexpected error: $e');
   }
 }
 ```
+<!-- /snippet -->
 
 ### Lexicon/Object IDs
 
 Some objects returned from AT Protocol's and Bluesky API are identified by IDs defined in Lexicon. The ID defined in Lexicon is also very important when sending a request to the API server.
 
-**[bluesky](https://pub.dev/packages/bluesky)** provides all the IDs defined in Lexicon for `com.atproto.*` and `app.bsky.*` as constants, and it can be easily used from `package:bluesky/ids.dart` as follows.
+**[bluesky](https://pub.dev/packages/bluesky)** provides the IDs defined in Lexicon for `com.atproto.*`, `app.bsky.*`, `chat.bsky.*`, and `tools.ozone.*` as constants, available from `package:bluesky/ids.dart` as follows.
 
-```dart
+<!-- snippet: bluesky/lexicon_ids.dart -->
+```dart title="lexicon_ids.dart"
 import 'package:bluesky/ids.dart' as ids;
 
 void main() {
-  // `blob`
-  ids.blob;
   // `com.atproto.sync.subscribeRepos#commit`
   ids.comAtprotoSyncSubscribeReposCommit;
 
-  // `app.bsky.feed.like`
-  ids.appBskyFeedLike;
+  // `app.bsky.feed.post`
+  ids.appBskyFeedPost;
   // `app.bsky.feed.defs#reasonRepost`
   ids.appBskyFeedDefsReasonRepost;
+
+  // `chat.bsky.convo.defs`
+  ids.chatBskyConvoDefs;
+  // `tools.ozone.moderation.defs`
+  ids.toolsOzoneModerationDefs;
 }
 ```
+<!-- /snippet -->
 
 :::note
 These ID constants are automatically maintained when a new Lexicon is officially added. [See script](https://github.com/myConsciousness/atproto.dart/blob/main/scripts/gen_lexicon_ids.dart).
@@ -1234,7 +1537,8 @@ For more details about design of pagination and `cursor` in the AT Protocol, [se
 
 **[bluesky](https://pub.dev/packages/bluesky)** also follows the common design of AT Protocol and allows paging by using `cursor`. It can be easily implemented as in the following example.
 
-```dart
+<!-- snippet: bluesky/pagination.dart -->
+```dart title="pagination.dart"
 import 'package:bluesky/bluesky.dart';
 
 Future<void> main() async {
@@ -1245,7 +1549,7 @@ Future<void> main() async {
 
   do {
     final actors = await bsky.actor.searchActors(
-      term: 'alf',
+      q: 'alf',
       cursor: nextCursor, // If null, it is ignored.
     );
 
@@ -1258,6 +1562,7 @@ Future<void> main() async {
   } while (nextCursor != null); // If there is no next page, it ends.
 }
 ```
+<!-- /snippet -->
 
 :::tip
 Endpoints that can be paged can be seen in [this matrix](../supported_api.md#bluesky).
@@ -1284,6 +1589,7 @@ If a structure or type different from the properties defined in Lexicon is detec
 
 To set unknown inputs in a request using **[bluesky](https://pub.dev/packages/bluesky)**, implement with `$unknown` parameter as follows.
 
+<!-- snippet: bluesky/unknown_inputs.dart -->
 ```dart title="Post with Via parameter"
 import 'package:bluesky/bluesky.dart';
 
@@ -1300,6 +1606,7 @@ Future<void> main() async {
   print(ref);
 }
 ```
+<!-- /snippet -->
 
 Executing this code will register a following record.
 
@@ -1330,155 +1637,290 @@ To make the name of a property unique, the following methods are possible.
 
 ### Moderation API
 
-**[bluesky](https://pub.dev/packages/bluesky)** provides comprehensive moderation capabilities for content filtering, labeling, and reporting.
+**[bluesky](https://pub.dev/packages/bluesky)** ships the same client-side moderation engine the official Bluesky app uses, plus the endpoints for reporting and labelling.
+
+:::caution **Import `moderation.dart` unprefixed**
+`getModerationPrefs`, `getLabelDefinitions`, and the `ViewerState` helpers are Dart **extensions**, and Dart does not apply extensions imported behind a prefix. `import 'package:bluesky/moderation.dart' as mod;` will compile the import but leave those members invisible.
+:::
 
 #### Content Moderation
 
-```dart
-import 'package:bluesky/bluesky.dart' ;
-import 'package:bluesky/moderation.dart' as mod;
+Moderation is a three-step pipeline: read the user's preferences, resolve the label definitions of the labelers they subscribe to, then ask for a decision per subject.
+
+<!-- snippet: bluesky/moderation_basics.dart -->
+```dart title="moderation_basics.dart"
+import 'package:bluesky/bluesky.dart';
+// `moderation.dart` ships extensions (`getModerationPrefs`,
+// `getLabelDefinitions`). Dart never applies extensions behind an import
+// prefix, so this import must stay unprefixed.
+import 'package:bluesky/moderation.dart';
 
 Future<void> main() async {
   final bsky = Bluesky.fromSession(await _session);
 
-  // First get the user's moderation prefs and their label definitions
+  // First get the user's moderation prefs and their label definitions.
   final preferences = await bsky.actor.getPreferences();
   final moderationPrefs = preferences.data.getModerationPrefs();
   final labelDefs = await bsky.labeler.getLabelDefinitions(moderationPrefs);
 
-  final moderationOpts = mod.ModerationOpts(
-    userDid: bsky.session?.did,
+  final moderationOpts = ModerationOpts(
+    userDid: bsky.session!.did,
     prefs: moderationPrefs,
     labelDefs: labelDefs,
   );
 
-  // Moderate different types of content
-  final postMod = mod.moderatePost(
-    mod.ModerationSubjectPost.postView(data: post),
-    moderationOpts,
+  // `getLabelerHeaders` tells the AppView which labelers to apply. Without it
+  // the feed comes back unlabelled and moderation has nothing to act on.
+  final feeds = await bsky.feed.getTimeline(
+    $headers: getLabelerHeaders(moderationPrefs),
   );
 
-  final profileMod = mod.moderateProfile(
-    mod.ModerationSubjectProfile.profileView(data: profile),
-    moderationOpts,
-  );
-
-  // Use moderation results to control rendering
-  final contentList = postMod.getUI(mod.ModerationBehaviorContext.contentList);
-  final contentView = postMod.getUI(mod.ModerationBehaviorContext.contentView);
-  final contentMedia = postMod.getUI(mod.ModerationBehaviorContext.contentMedia,
-  );
-
-  // Apply moderation decisions
-  if (contentList.filter) {
-    // Don't include in feeds
-    return;
-  }
-
-  if (contentList.blur) {
-    // Render behind a content warning
-    showContentWarning(
-      content: post,
-      canOverride: !contentList.noOverride,
-      warning: contentList.alert ? 'Content may be sensitive' : '',
+  for (final feed in feeds.data.feed) {
+    final decision = moderatePost(
+      ModerationSubjectPost.postView(data: feed.post),
+      moderationOpts,
     );
-  }
 
-  if (contentList.alert || contentList.inform) {
-    // Show warning labels
-    showModerationWarning(
-      contentList.alert || contentList.inform,
-    );
+    // Ask for the UI decision in the context you are rendering.
+    final contentList = decision.getUI(ModerationBehaviorContext.contentList);
+    final contentView = decision.getUI(ModerationBehaviorContext.contentView);
+    final contentMedia = decision.getUI(ModerationBehaviorContext.contentMedia);
+
+    if (contentList.filter) {
+      continue; // Don't include in feeds.
+    }
+
+    if (contentList.blur) {
+      // Render behind a content warning; `noOverride` means the user may not
+      // click through.
+      print('Blur (override allowed: ${!contentList.noOverride})');
+    }
+
+    if (contentList.alert || contentList.inform) {
+      print('Show a moderation notice');
+    }
   }
 }
 ```
+<!-- /snippet -->
+
+:::caution
+`getLabelerHeaders(prefs)` is not optional decoration. It sends the `atproto-accept-labelers` header that tells the AppView which labelers to apply. Omit it and the feed comes back unlabelled, so every moderation decision you compute from it is empty.
+:::
+
+`getUI` answers a different question per context, because the same label warrants different treatment in a scrolling feed than on a dedicated post page.
+
+| Context | Meaning |
+| --- | --- |
+| `ModerationBehaviorContext.contentList` | The subject as a row in a feed or list |
+| `ModerationBehaviorContext.contentView` | The subject on its own screen |
+| `ModerationBehaviorContext.contentMedia` | The subject's images or video |
+| `ModerationBehaviorContext.avatar` / `banner` / `displayName` | Profile chrome |
+
+The returned `ModerationUI` exposes `filter` (drop it entirely), `blur` (hide behind a warning), `alert` and `inform` (annotate it), and `noOverride` (the user may not click through).
+
+#### Moderating other subjects
+
+Posts are not the only thing worth moderating. Each subject has its own entry point.
+
+<!-- snippet: bluesky/moderation_subjects.dart -->
+```dart title="moderation_subjects.dart"
+import 'package:bluesky/moderation.dart';
+
+void main() {
+  final opts = _moderationOpts;
+
+  // Posts.
+  final post = moderatePost(
+    ModerationSubjectPost.postView(data: _postView),
+    opts,
+  );
+
+  // Profiles — merges the account and profile decisions.
+  final profile = moderateProfile(
+    ModerationSubjectProfile.profileViewDetailed(data: _profile),
+    opts,
+  );
+
+  // Live status (`app.bsky.actor.defs#statusView`).
+  final status = moderateStatus(
+    ModerationSubjectProfile.profileViewDetailed(data: _profile),
+    opts,
+  );
+
+  // Notifications.
+  final notification = moderateNotification(
+    ModerationSubjectNotification.notification(data: _notification),
+    opts,
+  );
+
+  // Feed generators.
+  final generator = moderateFeedGenerator(
+    ModerationSubjectFeedGenerator.generatorView(data: _generator),
+    opts,
+  );
+
+  // User lists.
+  final list = moderateUserList(
+    ModerationSubjectUserList.listView(data: _list),
+    opts,
+  );
+}
+```
+<!-- /snippet -->
+
+#### Muted words
+
+The engine applies the user's muted words as part of `moderatePost`, but the matcher is also public if you want to run it over your own text.
+
+<!-- snippet: bluesky/moderation_mute_words.dart -->
+```dart title="moderation_mute_words.dart"
+import 'package:bluesky/moderation.dart';
+
+void main() {
+  final mutedWords = _moderationPrefs.mutedWords;
+
+  // A boolean check.
+  final muted = hasMutedWord(
+    mutedWords: mutedWords,
+    text: 'this post mentions spoilers',
+    languages: ['en'],
+  );
+
+  // Or the individual matches, so you can explain *why* it was muted.
+  final matches = matchMuteWords(
+    mutedWords: mutedWords,
+    text: 'this post mentions spoilers',
+    languages: ['en'],
+  );
+
+  for (final MuteWordMatch match in matches) {
+    print('Matched "${match.predicate}" for ${match.word.value}');
+  }
+}
+```
+<!-- /snippet -->
+
+`matchMuteWords` returns the individual `MuteWordMatch`es, so you can tell the user *which* muted word hid a post. Both functions accept `facets`, `outlineTags`, `languages`, and an `actor` — the last one is what makes `actorTarget: exclude-following` work.
 
 #### Reporting Content
 
-```dart
-// Report a user account
-final report = await bsky.atproto.moderation.createReport(
-  reasonType: ReasonType.knownValue(
-    data: KnownReasonType.reasonSpam,
-  ), // or KnownReasonType.reasonViolation, etc.
-  subject: UModerationCreateReportSubject.repoRef(
-    data: RepoRef(did: 'did:plc:example'),
-  ),
-  reason: 'This post contains spam content',
-);
+<!-- snippet: bluesky/moderation_report.dart -->
+```dart title="moderation_report.dart"
+import 'package:bluesky/bluesky.dart';
+import 'package:bluesky/com_atproto_admin_defs.dart';
+import 'package:bluesky/com_atproto_moderation_createreport.dart';
+import 'package:bluesky/com_atproto_moderation_defs.dart';
+import 'package:bluesky/com_atproto_repo_strongref.dart';
+import 'package:bluesky/core.dart';
 
-// Report a post
-final accountReport = await bsky.atproto.moderation.createReport(
-  reasonType: ReasonType.knownValue(data: KnownReasonType.reasonViolation),
-  subject: UModerationCreateReportSubject.repoStrongRef(
-    data: RepoStrongRef(uri: post.uri, cid: post.cid),
-  ),
-  reason: 'This account is engaging in harassment',
-);
+Future<void> main() async {
+  final bsky = Bluesky.fromSession(await _session);
+
+  // Report an account.
+  final accountReport = await bsky.atproto.moderation.createReport(
+    reasonType: ReasonType.knownValue(
+      data: KnownReasonType.comAtprotoModerationDefsReasonSpam,
+    ),
+    subject: UModerationCreateReportSubject.repoRef(
+      data: RepoRef(did: 'did:plc:example'),
+    ),
+    reason: 'This account is engaging in harassment',
+  );
+
+  // Report a single record, such as a post.
+  final postReport = await bsky.atproto.moderation.createReport(
+    reasonType: ReasonType.knownValue(
+      data: KnownReasonType.comAtprotoModerationDefsReasonViolation,
+    ),
+    subject: UModerationCreateReportSubject.repoStrongRef(
+      data: RepoStrongRef(
+        uri: AtUri('at://did:plc:example/app.bsky.feed.post/example'),
+        cid: 'bafyreiexamplecid',
+      ),
+    ),
+    reason: 'This post contains spam content',
+  );
+}
 ```
+<!-- /snippet -->
+
+:::note
+`KnownReasonType` constants are named after their fully-qualified Lexicon ID, e.g. `KnownReasonType.comAtprotoModerationDefsReasonSpam`.
+:::
 
 #### Working with Labels
 
-```dart
-// Get labeler services
-final labelerServices = await bsky.labeler.getServices(
-  dids: ['did:plc:labeler-example'],
-  detailed: true,
-);
+<!-- snippet: bluesky/moderation_labels.dart -->
+```dart title="moderation_labels.dart"
+import 'package:bluesky/bluesky.dart';
 
-// Query labels for content
-final labels = await bsky.atproto.label.queryLabels(
-  uriPatterns: ['at://did:plc:example/app.bsky.feed.post/*'],
-  sources: ['did:plc:labeler-example'],
-);
+Future<void> main() async {
+  final bsky = Bluesky.anonymous();
 
-for (final label in labels.data.labels) {
-  print('Label: ${label.val} on ${label.uri}');
-  print('Created by: ${label.src}');
-  print('Created at: ${label.cts}');
+  // Get labeler services.
+  final labelerServices = await bsky.labeler.getServices(
+    dids: ['did:plc:labeler-example'],
+    detailed: true,
+  );
+
+  // Query labels for content.
+  final labels = await bsky.atproto.label.queryLabels(
+    uriPatterns: ['at://did:plc:example/app.bsky.feed.post/*'],
+    sources: ['did:plc:labeler-example'],
+  );
+
+  for (final label in labels.data.labels) {
+    print('Label: ${label.val} on ${label.uri}');
+    print('Created by: ${label.src}');
+    print('Created at: ${label.cts}');
+  }
 }
 ```
+<!-- /snippet -->
 
 #### Custom Moderation Workflows
 
-```dart
-import 'package:atproto/com_atproto_admin_defs.dart';
-import 'package:atproto/com_atproto_moderation_defs.dart';
+The built-in engine covers the official rules; anything beyond that is ordinary application code layered on top.
+
+<!-- snippet: bluesky/moderation_custom.dart -->
+```dart title="moderation_custom.dart"
+// `ViewerStateExtension` (`hasBlocking` / `isBlockedBy`) lives here, and Dart
+// never applies extensions behind an import prefix.
 import 'package:bluesky/app_bsky_actor_defs.dart';
 import 'package:bluesky/app_bsky_feed_defs.dart';
+import 'package:bluesky/app_bsky_feed_post.dart';
 import 'package:bluesky/app_bsky_graph_getrelationships.dart';
 import 'package:bluesky/bluesky.dart';
+import 'package:bluesky/com_atproto_admin_defs.dart';
 import 'package:bluesky/com_atproto_moderation_createreport.dart';
-import 'package:bluesky/src/services/codegen/app/bsky/feed/post/main.dart';
+import 'package:bluesky/com_atproto_moderation_defs.dart';
 
-// Create custom moderation logic
+/// Layer your own rules on top of the built-in moderation engine.
 class CustomModerationService {
+  const CustomModerationService(this.bsky, this.blockedKeywords);
+
   final Bluesky bsky;
   final Set<String> blockedKeywords;
 
-  CustomModerationService(this.bsky, this.blockedKeywords);
+  Future<bool> shouldFilterPost(final PostView post) async {
+    // `PostView.record` is raw JSON; marshal it into the typed record.
+    final record = FeedPostRecord.fromJson(post.record);
 
-  Future<bool> shouldFilterPost(PostView post) async {
-    // Check for blocked keywords
-    final postRecord = FeedPostRecord.fromJson(post.record);
+    final text = record.text.toLowerCase();
+    if (blockedKeywords.any(text.contains)) return true;
 
-    final text = postRecord.text.toLowerCase();
-    if (blockedKeywords.any((keyword) => text.contains(keyword))) {
-      return true;
-    }
-
-    // Check user's block/mute status
-    final authorDid = post.author.did;
-    final relationship = await bsky.graph.getRelationships(
+    // Check the viewer's block status against the author.
+    final relationships = await bsky.graph.getRelationships(
       actor: bsky.session!.did,
-      others: [authorDid],
+      others: [post.author.did],
     );
 
-    final rel = relationship.data.relationships.first;
+    final relationship = relationships.data.relationships.first;
 
-    switch (rel) {
+    switch (relationship) {
       case UGraphGetRelationshipsRelationshipsRelationship():
-        final actor = await bsky.actor.getProfile(actor: rel.data.did);
+        final actor = await bsky.actor.getProfile(actor: relationship.data.did);
 
         return (actor.data.viewer?.hasBlocking ?? false) ||
             (actor.data.viewer?.isBlockedBy ?? false);
@@ -1487,19 +1929,20 @@ class CustomModerationService {
     }
   }
 
-  Future<void> reportAndBlock(String did, String reason) async {
-    // Report the user
+  Future<void> reportAndBlock(final String did, final String reason) async {
     await bsky.atproto.moderation.createReport(
-      reasonType: ReasonType.knownValue(data: KnownReasonType.reasonViolation),
+      reasonType: ReasonType.knownValue(
+        data: KnownReasonType.comAtprotoModerationDefsReasonViolation,
+      ),
       subject: UModerationCreateReportSubject.repoRef(data: RepoRef(did: did)),
       reason: reason,
     );
 
-    // Block the user
     await bsky.graph.block.create(subject: did);
   }
 }
 ```
+<!-- /snippet -->
 
 ## Related Packages
 

--- a/website/docs/packages/bluesky_text.md
+++ b/website/docs/packages/bluesky_text.md
@@ -6,11 +6,12 @@ description: Utility for Bluesky's RichText.
 
 # bluesky_text [![pub package](https://img.shields.io/pub/v/bluesky_text.svg?logo=dart&logoColor=00b9fc)](https://pub.dev/packages/bluesky_text) [![Dart SDK Version](https://badgen.net/pub/sdk-version/bluesky_text)](https://pub.dev/packages/bluesky_text/)
 
-**bluesky_text** provides elegant rich text processing for Bluesky's `Facet` system, automatically extracting entities like handles (@) and links (http|https) from text and generating API-compliant facets.
+**bluesky_text** provides elegant rich text processing for Bluesky's `Facet` system, automatically extracting entities like handles (@), links (http|https), tags (#) and cashtags ($) from text and generating API-compliant facets.
 
 Text processing uses **Unicode Grapheme Clusters**, ensuring multibyte characters and emojis are counted as single characters, matching Bluesky's text handling behavior.
 
 - **[GitHub](https://github.com/myConsciousness/atproto.dart/tree/main/packages/bluesky_text)**
+- **[API Documentation](https://pub.dev/documentation/bluesky_text/latest/)**
 
 :::info
 For complete Bluesky API integration, see **[bluesky](./bluesky.md)**.
@@ -18,13 +19,13 @@ For complete Bluesky API integration, see **[bluesky](./bluesky.md)**.
 
 ## Features ⭐
 
-- ✅ **Zero Dependency**
-- ✅ **Automatic Detection of `Handle`, `Link`, `Tag`** in text
+- ✅ **Automatic Detection of `Handle`, `Link`, `Tag`, `Cashtag`** in text
 - ✅ Supports **Automatic Conversion** to **Facet**
 - ✅ **100% Compatible with [bluesky](./bluesky.md)**
-- ✅ Allows **Extraction of Custom Entities**
 - ✅ Supports **Unicode Grapheme Clusters**
-- ✅ Supports **Safe Text Splitting**
+- ✅ Supports **Safe Text Splitting** against both post limits
+- ✅ Reports the **overflowing range** and a ready-to-render **segmentation**
+- ✅ Renders **server-provided facets** for display
 - ✅ **Works in All Languages**
 - ✅ Supports **Markdown Style Links**
 - ✅ **Well Documented** and **Well Tested**
@@ -66,161 +67,183 @@ Import the package to access all text processing features:
 import 'package:bluesky_text/bluesky_text.dart';
 ```
 
-### Instantiate **BlueskyText**
+### Analyze text
 
-Create a **[BlueskyText](https://pub.dev/documentation/bluesky_text/latest/bluesky_text/BlueskyText-class.html)** object by passing your text for processing:
+Create a **[BlueskyText](https://pub.dev/documentation/bluesky_text/latest/bluesky_text/BlueskyText-class.html)** object by passing your text, then read whatever you need from it. Every derived value is memoized on first read, so construct the object once per text and reuse it rather than rebuilding it per property.
 
-```dart
+<!-- snippet: bluesky_text/basic.dart -->
+```dart title="basic.dart"
 import 'package:bluesky_text/bluesky_text.dart';
 
 void main() {
-  // You just need to pass text to parse.
+  // You just need to pass the text to analyze.
   final text = BlueskyText(
     'I speak 日本語 and English 🚀 @shinyakato.dev and @shinyakato.bsky.social. '
-    'Visit 🚀 https://shinyakato.dev.',
+    'Visit 🚀 https://shinyakato.dev #dart',
   );
 
-  print(text.value); // String equivalent to the string passed to BlueskyText.
-}
-```
+  print(text.value); // The original text.
+  print(text.length); // Counted in grapheme clusters, so 🚀 is 1.
 
-### Extract **Entities**
-
-The entities in the text passed to `BlueskyText` in the [above example](#instantiate-blueskytext) are as follows.
-
-- **Handles**
-  - `@shinyakato.dev`
-  - `@shinyakato.bsky.social`
-- **Links**
-  - `https://shinyakato.dev`
-
-To extract all of these entities, call the `entities` property as follows.
-
-```dart
-import 'dart:convert';
-
-import 'package:bluesky_text/bluesky_text.dart';
-
-void main() {
-  // You just need to pass text to parse.
-  final text = BlueskyText(
-    'I speak 日本語 and English 🚀 @shinyakato.dev and @shinyakato.bsky.social. '
-    'Visit 🚀 https://shinyakato.dev.',
-  );
-
-  // Extract all entities.
-  final entities = text.entities;
-
-  // Convert entities to JSON representation.
-  print(entities.map((e) => jsonEncode(e.toJson())).toList());
-}
-```
-
-Then you will then get the following result, which includes all the entities just listed.
-The response is formatted as JSON to make the structure of the response easier to understand.
-
-```json
-[
-  {
-    "type": "handle",
-    "value": "@shinyakato.dev",
-    "indices": { "start": 35, "end": 50 }
-  },
-  {
-    "type": "handle",
-    "value": "@shinyakato.bsky.social",
-    "indices": { "start": 55, "end": 78 }
-  },
-  {
-    "type": "link",
-    "value": "https://shinyakato.dev",
-    "indices": { "start": 91, "end": 113 }
+  for (final entity in text.entities) {
+    // `type` is a handle, link, tag, cashtag or markdownLink.
+    // `value` has its marker stripped: `shinyakato.dev`, not `@shinyakato.dev`.
+    // `indices` are UTF-8 byte offsets, ready for a facet `byteSlice`.
+    print(
+      '${entity.type}: ${entity.value} '
+      '(${entity.indices.start}-${entity.indices.end})',
+    );
   }
-]
-```
 
-As shown above, for each type of entity, you can correctly obtain the entity and the **Indices** of the location where the entity appears.
-This **Indices** is the position of occurrence expressed in bytes.
-
-:::tip
-If you want to extract **only Handles**, you can use the `handles` property. And if you want to extract **only Links**, you can use the `links` property.
-
-```dart
-import 'package:bluesky_text/bluesky_text.dart';
-
-void main() {
-  // You just need to pass text to parse.
-  final text = BlueskyText(
-    'I speak 日本語 and English 🚀 @shinyakato.dev and @shinyakato.bsky.social. '
-    'Visit 🚀 https://shinyakato.dev.',
-  );
-
-  print(text.handles); // Only handles.
-  print(text.links); // Only links.
+  // Or narrow it down to a single kind.
+  print(text.handles);
+  print(text.links);
+  print(text.tags);
+  print(text.cashtags);
 }
 ```
+<!-- /snippet -->
 
-And check following table.
+Each `Entity` exposes three fields — there is no `toJson`:
 
-| Method       | Description                                                              |
-| ------------ | ------------------------------------------------------------------------ |
-| **handles**  | Extracts all handles and byte string unit Indices in the text.           |
-| **links**    | Extracts all links and byte string unit Indices in the text.             |
-| **entities** | Extracts all handles and links and byte string unit Indices in the text. |
-:::
+| Field | Description |
+| --- | --- |
+| **type** | `EntityType.handle`, `.link`, `.tag`, `.cashtag` or `.markdownLink` |
+| **value** | The entity without its marker (`shinyakato.dev`, `dart`, `$AAPL`) |
+| **indices** | A `ByteIndices` with UTF-8 byte `start` and `end` offsets |
+
+The indices are counted in **UTF-8 bytes**, which is exactly what a Bluesky facet `byteSlice` expects, so they can be used as is.
+
+| Property | Description |
+| --- | --- |
+| **handles** | Every `@handle` and its byte indices |
+| **links** | Every link and its byte indices |
+| **tags** | Every `#tag` and its byte indices |
+| **cashtags** | Every `$TICKER` and its byte indices |
+| **entities** | All of the above, in document order |
+
+The constructor also accepts:
+
+| Parameter | Description |
+| --- | --- |
+| **enableMarkdown** | Whether `[label](url)` is treated as a link. Defaults to `true` |
+| **linkConfig** | A `LinkConfig` controlling protocol stripping and URL shortening when formatting |
+| **replacements** | The rewrites produced by `format()`. Set internally; you rarely pass it yourself |
 
 :::caution
-The current specification defines **_300 characters_** as the maximum number of characters for **[bluesky_text](https://pub.dev/packages/bluesky_text)**, which is the text limit defined in the Lexicon of **[app.bsky.feed.post](https://github.com/bluesky-social/atproto/blob/main/lexicons/app/bsky/feed/post.json)**.
-This means that you must check to see if the text you pass to the `BlueskyText` object exceeds the maximum number of characters and **[Split Text](#split-text)** if necessary.
+The `app.bsky.feed.post` lexicon enforces **two** limits: at most **300 graphemes** *and* at most **3000 UTF-8 bytes**. A text can trip either one first — 300 multi-byte emoji stay within the grapheme limit while blowing past the byte limit.
 
-You can check if the string passed to the `BlueskyText` object exceeds the maximum number of characters with `isLengthLimitExceeded` or `isNotLengthLimitExceeded` as follows.
+`isLengthLimitExceeded` (and its inverse `isNotLengthLimitExceeded`) returns true when **either** limit is exceeded. See **[Split Text](#split-text)** for what to do about it.
 
 ```dart
-import 'package:bluesky_text/bluesky_text.dart';
-
-Future<void> main() async {
-  final text = BlueskyText(
-    'I speak 日本語 and English 🚀 @shinyakato.dev and @shinyakato.bsky.social. '
-    'Visit 🚀 https://shinyakato.dev.',
-  );
-
-  print(text.isLengthLimitExceeded);
-  print(text.isNotLengthLimitExceeded);
+if (text.isLengthLimitExceeded) {
+  // Too long to post as is.
 }
 ```
 :::
 
-### Generate **Facets**
+### Create a post
 
-To generate **Facets** that can be used with the Bluesky API using the [extracted collection of facets](#extract-entities), use `toFacets` method as follows.
+`toPostData()` is the shortest correct path from text to a post. It formats the text, resolves the facets of the **formatted** entities, and reports any handles that failed to resolve.
 
-```dart
-import 'dart:convert';
-
+<!-- snippet: bluesky_text/post.dart -->
+```dart title="post.dart"
+import 'package:bluesky/app_bsky_richtext_facet.dart';
+import 'package:bluesky/atproto.dart';
+import 'package:bluesky/bluesky.dart';
 import 'package:bluesky_text/bluesky_text.dart';
 
 Future<void> main() async {
-  // You just need to pass text to parse.
-  final text = BlueskyText(
-    'I speak 日本語 and English 🚀 @shinyakato.dev and @shinyakato.bsky.social. '
-    'Visit 🚀 https://shinyakato.dev.',
+  final session = await createSession(
+    identifier: 'shinyakato.dev',
+    password: 'xxxxxxxx',
   );
 
-  final entities = text.entities;
+  final bsky = Bluesky.fromSession(session.data);
 
-  // Convert entities to collection of facets.
-  final facets = await entities.toFacets();
+  final text = BlueskyText(
+    'Hello, I am @shinyakato.dev! '
+    'wdyt about [this link](https://atprotodart.com)?',
+  );
 
-  // Convert to JSON representation.
-  print(jsonEncode(facets));
+  // Formats the text and resolves its facets in one call.
+  final post = await text.toPostData();
+
+  // Handles that could not be resolved to a DID are reported instead of being
+  // silently dropped, so you can warn the user before posting.
+  if (post.unresolvedHandles.isNotEmpty) {
+    print('Could not resolve: ${post.unresolvedHandles}');
+  }
+
+  await bsky.feed.post.create(
+    text: post.text,
+    facets: post.facets.map(RichtextFacet.fromJson).toList(),
+  );
 }
 ```
+<!-- /snippet -->
 
-The `toFacets` method involves asynchronous processing to resolve user handles as DIDs, so add the `Future` and `async` modifiers to the calling method.
-Then specify `await` when calling the `toFacets` method. If the Entity's collection contains only links, it will also be processed asynchronously.
+It returns a record with three fields:
 
-Executing the above example, you will get a JSON object converted to a Bluesky API compliant facets structure, as shown below.
-In the following example, the response is converted to JSON to make the structure of the response easier to understand.
+| Field | Description |
+| --- | --- |
+| **text** | The formatted value to post — markdown expanded, links shortened |
+| **facets** | The facets as JSON maps, for `RichtextFacet.fromJson` |
+| **unresolvedHandles** | Mentions whose handle did not resolve to a DID, and which were therefore dropped |
+
+`toPostData` also accepts `service` and `resolver`, the same as the lower-level API below.
+
+:::caution
+Order matters: facets must be resolved on the **formatted** text. Markdown links only become link facets after formatting, and formatting shifts every byte offset. `toPostData` gets this right for you; if you do it by hand, format first.
+:::
+
+### Generate **Facets** manually
+
+When you need the facets without creating the post — to preview them, cache them, or feed a different endpoint — go through `entities` directly.
+
+<!-- snippet: bluesky_text/facets.dart -->
+```dart title="facets.dart"
+import 'package:bluesky_text/bluesky_text.dart';
+
+Future<void> main() async {
+  final text = BlueskyText(
+    'I speak 日本語 and English 🚀 @shinyakato.dev and @shinyakato.bsky.social. '
+    'Visit 🚀 https://shinyakato.dev',
+  );
+
+  //! Format first: markdown links become link facets only after formatting,
+  //! and the byte offsets of the raw text do not match the posted text.
+  final post = text.formatted;
+
+  // Facets as JSON maps, ready for `RichtextFacet.fromJson`.
+  final facets = await post.entities.toFacets();
+  print(facets);
+
+  // The same call, plus the handles that failed to resolve to a DID.
+  final result = await post.entities.toFacetsResult();
+  print(result.facets);
+  print(result.unresolvedHandles);
+
+  // Resolution is a network lookup per mention, so inject your own resolver
+  // to serve cached DIDs (or to avoid network access entirely in tests).
+  final cached = await post.entities.toFacetsResult(
+    resolver: (handle) async => switch (handle) {
+      'shinyakato.dev' => 'did:plc:iijrtk7ocored6zuziwmqq3c',
+      _ => null,
+    },
+  );
+}
+```
+<!-- /snippet -->
+
+| Method | Returns |
+| --- | --- |
+| **toFacets()** | `List<Map<String, dynamic>>` — the facets only |
+| **toFacetsResult()** | The facets *and* `unresolvedHandles` |
+
+Both are asynchronous because a mention has to be resolved from a handle to a DID over the network, so `await` them even when the text contains no mention. Pass a `resolver` to answer from your own cache instead, and `service` to resolve against a specific PDS.
+
+The generated facets are plain JSON matching the Bluesky API shape:
 
 ```json
 [
@@ -230,15 +253,6 @@ In the following example, the response is converted to JSON to make the structur
       {
         "$type": "app.bsky.richtext.facet#mention",
         "did": "did:plc:iijrtk7ocored6zuziwmqq3c"
-      }
-    ]
-  },
-  {
-    "index": { "byteStart": 55, "byteEnd": 78 },
-    "features": [
-      {
-        "$type": "app.bsky.richtext.facet#mention",
-        "did": "did:plc:wpyvghtrmnflwxmknbz67vct"
       }
     ]
   },
@@ -258,95 +272,175 @@ In the following example, the response is converted to JSON to make the structur
 
 ### Unicode Grapheme Clusters
 
-Text in Bluesky is counted as **Unicode Grapheme Clusters**.
-So, even multibyte characters such as Japanese and emoji are counted as one character.
-
-**[bluesky_text](https://pub.dev/packages/bluesky_text)** also counts characters in Grapheme Cluster units.
-The count of characters related to the text interpreted by **[bluesky_text](https://pub.dev/packages/bluesky_text)** can be obtained with the `.length` property as follows.
+Text in Bluesky is counted as **Unicode Grapheme Clusters**, so even multibyte characters such as Japanese and emoji count as one character. `.length` on a `BlueskyText` follows the same rule, and the top-level `getGraphemeLength` applies it to any raw string.
 
 ```dart
-import 'package:bluesky_text/bluesky_text.dart';
-
-Future<void> main() async {
-  final text = BlueskyText(
-    'I speak 日本語 and English 🚀 @shinyakato.dev and @shinyakato.bsky.social. '
-    'Visit 🚀 https://shinyakato.dev.',
-  );
-
-  // Japanese and emojis are counted as one character.
-  print(text.length);
-}
+print(BlueskyText('🚀🚀🚀').length); // 3
+print(getGraphemeLength('日本語')); // 3
+print(isEmojiOnly('🚀🚀')); // true
 ```
+
+`BlueskyText` also exposes `isEmojiOnly` / `isNotEmojiOnly` (useful for the big-emoji rendering Bluesky clients do) and `isEmpty` / `isNotEmpty`.
 
 :::tip
 If you want to know about Grapheme Clusters, check [this page](https://unicode.org/reports/tr29/).
 :::
 
-### Use with [bluesky](./bluesky.md)
+### Markdown links and formatting
 
-**Facet** generated by **[bluesky_text](https://pub.dev/packages/bluesky_text)** can be easily integrated into the **[bluesky](https://pub.dev/packages/bluesky)** package.
-There are several endpoints that use Facet in the Bluesky API, but we will use the endpoint that creates a post as an example.
+`format()` — and the equivalent memoized `formatted` getter — produces the text as it will actually be posted: markdown links are expanded to their URL and links are rewritten according to `LinkConfig`.
 
-:::info
-The **[bluesky](https://pub.dev/packages/bluesky)** package is a powerful wrapper library that supports the AT Protocol and Bluesky APIs. See the [bluesky package documentation](./bluesky.md) for more details.
-:::
-
-You can integrate **[bluesky_text](https://pub.dev/packages/bluesky_text)** and **[bluesky](https://pub.dev/packages/bluesky)** as follows.
-
-```dart
-import 'package:bluesky/bluesky.dart' as bsky;
+<!-- snippet: bluesky_text/formatting.dart -->
+```dart title="formatting.dart"
 import 'package:bluesky_text/bluesky_text.dart';
 
-Future<void> main() async {
+void main() {
   final text = BlueskyText(
-    'I speak 日本語 and English 🚀 @shinyakato.dev and @shinyakato.bsky.social. '
-    'Visit 🚀 https://shinyakato.dev.',
+    'Check [this link](https://atprotodart.com/docs/packages/bluesky_text)!',
+    // Drops `https://` and shortens long URLs when formatting.
+    linkConfig: const LinkConfig(excludeProtocol: true, enableShortening: true),
   );
 
-  // Bluesky object.
-  final bluesky = bsky.Bluesky.fromSession(await _session);
-  // Convert entities to facets representation.
-  final facets = await text.entities.toFacets();
+  // The raw text still contains the markdown syntax and the full URL.
+  print(text.value);
 
-  await bluesky.feed.createPost(
-    text: text.value,
+  // `formatted` is the posting-ready form: markdown expanded, links shortened.
+  // `format()` returns the same memoized instance.
+  print(text.formatted.value);
 
-    // Convert JSON to Facet object like this.
-    facets: facets.map(bsky.Facet.fromJson).toList(),
+  // Markdown handling can be turned off entirely.
+  final plain = BlueskyText(
+    'Check [this link](https://atprotodart.com)!',
+    enableMarkdown: false,
   );
+  print(plain.formatted.value);
 }
 ```
+<!-- /snippet -->
 
-You see that there is nothing difficult to implement here.
-Extracting and faceting entities using **[bluesky_text](https://pub.dev/packages/bluesky_text)** is implemented as described in [Getting Started](#getting-started-).
-
-And the `bluesky.feed.createPost` used as an example is a fairly basic method for creating a post using the **[bluesky](https://pub.dev/packages/bluesky)** package.
-But, this is where **[bluesky_text](https://pub.dev/packages/bluesky_text)** is most powerful, as it can be converted into a `Facet` object in the **[bluesky](https://pub.dev/packages/bluesky)** package without any difficult processing.
-With **[bluesky_text](https://pub.dev/packages/bluesky_text)**, you can create Facets that are difficult to structure when creating a post using the Bluesky API without having to think about it.
+Because formatting changes the value, anything measured against the post — length, overflow, facets — must be measured on `formatted`, not on the raw instance.
 
 ### Split Text
 
-As mentioned in the section describing [entity extraction](#extract-entities), the `BlueskyText` object has a maximum number of characters for text.
-This is because the maximum number of characters allowed for each text in the Bluesky API is clearly defined, and any operation on a text that exceeds the maximum number of characters is meaningless.
+Text longer than either post limit cannot be posted, so split it into chunks and post them as a thread. `split()` is token-aware: it never cuts a handle, link or tag in half, and every chunk respects **both** the 300-grapheme and 3000-byte limits.
 
-So do you always need to be aware of the number of characters of text you pass to the `BlueskyText` object in units of Grapheme Cluster? **No, you don't need it**. Instead, just call `.split()` as follows.
-You can also use `isLengthLimitExceeded` or `isNotLengthLimitExceeded` to determine if the text exceeds the maximum number of characters.
-
-```dart
+<!-- snippet: bluesky_text/split.dart -->
+```dart title="split.dart"
+import 'package:bluesky/app_bsky_richtext_facet.dart';
+import 'package:bluesky/bluesky.dart';
 import 'package:bluesky_text/bluesky_text.dart';
 
-Future<void> main() async {
+Future<void> post(final Bluesky bsky) async {
   final text = BlueskyText('a' * 301);
 
-  // Whether the maximum number of characters is exceeded.
-  if (text.isLengthLimitExceeded) {
-    // Split based on the maximum number of characters.
-    // Returns new collection of BlueskyText.
-    final texts = text.split();
+  // True when the text exceeds 300 graphemes *or* 3000 UTF-8 bytes.
+  if (text.isNotLengthLimitExceeded) return;
 
-    for (final _text in texts) {
-      print(_text.entities);
+  // Splits on token boundaries, respecting both limits. Each chunk is a raw,
+  // independently formattable `BlueskyText`.
+  for (final chunk in text.split()) {
+    final data = await chunk.toPostData();
+
+    await bsky.feed.post.create(
+      text: data.text,
+      facets: data.facets.map(RichtextFacet.fromJson).toList(),
+    );
+  }
+}
+```
+<!-- /snippet -->
+
+:::tip
+Split **before** formatting. Each chunk is a raw, independently formattable `BlueskyText`, which is why the example calls `toPostData()` on the chunk. Calling `split()` on an already-formatted instance is safe — it transparently splits the original text — but posting chunks of a formatted value directly would corrupt the facets.
+:::
+
+### Composing UI: overflow and segments
+
+For a composer that reacts on every keystroke, `overflow` tells you exactly which part of the text is over the limit and `segments` gives you a gap-free partition you can turn straight into a `TextSpan` tree.
+
+<!-- snippet: bluesky_text/compose_ui.dart -->
+```dart title="compose_ui.dart"
+import 'package:bluesky_text/bluesky_text.dart';
+
+void main() {
+  final text = BlueskyText('Hello @shinyakato.dev ${'a' * 320}');
+
+  // Measure what is actually posted, not the raw input.
+  final post = text.formatted;
+
+  final overflow = post.overflow;
+  if (overflow != null) {
+    // Which limit was hit first: `LengthLimit.grapheme` or `LengthLimit.byte`.
+    print(overflow.limit);
+
+    //! The offsets index into `post.value`, whose offsets differ from the raw
+    //! `text.value` after formatting.
+    final within = post.value.substring(0, overflow.utf16Start);
+    final exceeded = post.value.substring(overflow.utf16Start);
+  }
+
+  // A gap-free partition of the value, ready to become a `TextSpan` tree:
+  // every segment knows whether it is an entity and whether it overflows.
+  for (final segment in post.segments) {
+    if (segment.isOverflow) {
+      print('over limit: ${segment.text}');
+    } else if (segment.isEntity) {
+      print('${segment.type}: ${segment.text}');
     }
   }
 }
 ```
+<!-- /snippet -->
+
+`TextLengthOverflow` reports the boundary in three coordinate systems — `utf16Start` for `String.substring` and Flutter, `byteStart` on the same axis as `Entity.indices`, and `graphemeStart` matching `length` — plus `limit`, which says whether the grapheme or the byte cap was hit first. The boundary always lands on a grapheme boundary and is snapped back to the start of any entity it would otherwise cut through.
+
+Each `TextSegment` carries its `text`, its UTF-16 offsets, the `entity` it belongs to (if any) and `isOverflow`. Concatenating every `text` reproduces the value, so styling entities blue and the overflowing tail red is a single pass.
+
+### Rendering a fetched post
+
+The counterpart of the compose path: when you already have a post's `text` and `facets` from the API, use `renderFacets` instead of re-detecting entities. The author's facets are authoritative and mentions already carry their DID.
+
+<!-- snippet: bluesky_text/render_facets.dart -->
+```dart title="render_facets.dart"
+import 'package:bluesky_text/bluesky_text.dart';
+
+void main() {
+  // The `text` and `facets` of a post you fetched from the API.
+  const postText = 'Hello, I am shinyakato.dev!';
+  final rawFacets = <Map<String, dynamic>>[
+    {
+      'index': {'byteStart': 12, 'byteEnd': 26},
+      'features': [
+        {
+          r'$type': 'app.bsky.richtext.facet#mention',
+          'did': 'did:plc:iijrtk7ocored6zuziwmqq3c',
+        },
+      ],
+    },
+  ];
+
+  final facets = rawFacets.map(PostFacet.fromJson).toList();
+
+  // Partitions the text using the author's own facets instead of re-detecting
+  // entities, so mentions already carry their resolved DID.
+  for (final segment in renderFacets(postText, facets)) {
+    final feature = segment.feature;
+
+    if (feature == null) {
+      print('plain: ${segment.text}');
+    } else {
+      print('${feature.type}: ${segment.text} -> ${feature.value}');
+    }
+  }
+}
+```
+<!-- /snippet -->
+
+`renderFacets` returns the same `TextSegment` type as `segments`, but each styled segment carries a `feature` (the resolved DID, URI or tag) rather than a re-detected `entity`. `TextSegment.type` works for both paths, so one `TextSpan` builder can serve your composer and your timeline.
+
+## Related Packages
+
+| Package | Use it for |
+| --- | --- |
+| **[bluesky](./bluesky.md)** | Creating the posts these facets belong to |
+| **[atproto](./atproto.md)** | Core AT Protocol (`com.atproto.*`) endpoints |

--- a/website/pubspec.yaml
+++ b/website/pubspec.yaml
@@ -4,12 +4,17 @@ environment:
   sdk: ">=3.8.0 <4.0.0"
 
 dependencies:
+  atproto:
+    path: ../packages/atproto
   did_plc:
     path: ../packages/did_plc
   bluesky:
     path: ../packages/bluesky
   bluesky_text:
     path: ../packages/bluesky_text
+  # Named directly by the `GetClient` / `PostClient` injection snippets, which
+  # must return an `http.Response`.
+  http: ^1.4.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/website/static/snippets/atproto/anonymous.dart
+++ b/website/static/snippets/atproto/anonymous.dart
@@ -1,0 +1,14 @@
+// ignore_for_file: unused_local_variable, avoid_print
+
+/* SNIPPET START */
+
+import 'package:atproto/atproto.dart';
+
+Future<void> main() async {
+  // Create anonymous instance.
+  final atproto = ATProto.anonymous();
+
+  // Use public endpoints.
+  final did = await atproto.identity.resolveHandle(handle: 'bsky.app');
+  print(did.data.did);
+}

--- a/website/static/snippets/atproto/app_password.dart
+++ b/website/static/snippets/atproto/app_password.dart
@@ -1,0 +1,15 @@
+// ignore_for_file: unused_local_variable, avoid_print
+
+/* SNIPPET START */
+
+import 'package:atproto/core.dart' as core;
+
+void main() {
+  // Valid app password format.
+  print(core.isValidAppPassword('abcd-efgh-ijkl-mnop')); // => true
+
+  // Invalid formats.
+  print(core.isValidAppPassword('regular-password')); // => false
+  print(core.isValidAppPassword('abcd-efgh-ijkl')); // => false (too short)
+  print(core.isValidAppPassword('abcdefghijklmnop')); // => false (no dashes)
+}

--- a/website/static/snippets/atproto/app_password_best_practice.dart
+++ b/website/static/snippets/atproto/app_password_best_practice.dart
@@ -1,0 +1,24 @@
+// ignore_for_file: unused_local_variable, avoid_print
+
+/* SNIPPET START */
+
+import 'package:atproto/atproto.dart' as atp;
+import 'package:atproto/core.dart' as core;
+
+Future<void> authenticateUser(String identifier, String password) async {
+  // Check if user provided an app password.
+  if (!core.isValidAppPassword(password)) {
+    print('Warning: Consider using an app password for better security');
+  }
+
+  try {
+    final session = await atp.createSession(
+      identifier: identifier,
+      password: password,
+    );
+
+    print('Successfully authenticated as ${session.data.handle}');
+  } catch (e) {
+    print('Authentication failed: $e');
+  }
+}

--- a/website/static/snippets/atproto/auto_session_refresh.dart
+++ b/website/static/snippets/atproto/auto_session_refresh.dart
@@ -1,0 +1,26 @@
+// ignore_for_file: unused_local_variable, avoid_print
+
+/* SNIPPET START */
+
+import 'package:atproto/atproto.dart' as atp;
+
+Future<void> main() async {
+  final session = await atp.createSession(
+    identifier: 'your.handle.com',
+    password: 'your-app-password',
+  );
+
+  final atproto = atp.ATProto.fromSession(session.data);
+
+  // If the access token has expired, this call transparently refreshes the
+  // session and retries once. Nothing extra to write.
+  await atproto.repo.listRecords(
+    repo: session.data.did,
+    collection: 'app.bsky.feed.post',
+  );
+
+  // `atproto.session` always reflects the *current* credentials, so persist
+  // from here rather than from the session you passed in.
+  print(atproto.session?.accessJwt);
+  print(atproto.session?.refreshJwt);
+}

--- a/website/static/snippets/atproto/create_and_delete_record.dart
+++ b/website/static/snippets/atproto/create_and_delete_record.dart
@@ -1,0 +1,33 @@
+// ignore_for_file: unused_local_variable, avoid_print
+
+/* SNIPPET START */
+
+import 'package:atproto/atproto.dart' as atp;
+
+Future<void> main() async {
+  final session = await atp.createSession(
+    identifier: 'YOUR_HANDLE_OR_EMAIL', // Like "shinyakato.dev"
+    password: 'YOUR_PASSWORD',
+  );
+
+  final atproto = atp.ATProto.fromSession(session.data);
+
+  // Create a record to specific service like Bluesky.
+  final strongRef = await atproto.repo.createRecord(
+    repo: session.data.did,
+    collection: 'app.bsky.feed.post',
+    record: {
+      'text': 'Hello, Bluesky!',
+      'createdAt': DateTime.now().toUtc().toIso8601String(),
+    },
+  );
+
+  // And delete it. `uri` is already an `AtUri`, so it can be destructured
+  // directly.
+  final uri = strongRef.data.uri;
+  await atproto.repo.deleteRecord(
+    repo: uri.hostname,
+    collection: uri.collection.toString(),
+    rkey: uri.rkey,
+  );
+}

--- a/website/static/snippets/atproto/create_session.dart
+++ b/website/static/snippets/atproto/create_session.dart
@@ -1,0 +1,20 @@
+// ignore_for_file: unused_local_variable, avoid_print
+
+/* SNIPPET START */
+
+import 'package:atproto/atproto.dart' as atp;
+
+Future<void> main() async {
+  try {
+    final session = await atp.createSession(
+      identifier: 'your.handle.com', // Handle or email
+      password: 'your-app-password', // App password recommended
+      service: 'bsky.social', // Optional: specify service
+    );
+
+    print('Authenticated as: ${session.data.handle}');
+    print('DID: ${session.data.did}');
+  } catch (e) {
+    print('Authentication failed: $e');
+  }
+}

--- a/website/static/snippets/atproto/custom_service.dart
+++ b/website/static/snippets/atproto/custom_service.dart
@@ -1,0 +1,29 @@
+// ignore_for_file: unused_local_variable, avoid_print
+
+/* SNIPPET START */
+
+import 'package:atproto/atproto.dart' as atp;
+
+Future<void> main() async {
+  final session = await atp.createSession(
+    // Add this.
+    service: 'boobee.blue',
+
+    identifier: 'YOUR_HANDLE_OR_EMAIL',
+    password: 'YOUR_PASSWORD',
+  );
+
+  final atproto = atp.ATProto.fromSession(
+    session.data,
+
+    // Add this, or resolve dynamically based on session.
+    service: 'boobee.blue',
+
+    // Firehose and other relay-backed endpoints use this instead of `service`.
+    // Defaults to `bsky.network`.
+    relayService: 'relay.example.com',
+  );
+
+  print(atproto.service); // => boobee.blue
+  print(atproto.relayService); // => relay.example.com
+}

--- a/website/static/snippets/atproto/firehose_basic.dart
+++ b/website/static/snippets/atproto/firehose_basic.dart
@@ -1,0 +1,44 @@
+// ignore_for_file: unused_local_variable, avoid_print
+
+/* SNIPPET START */
+
+import 'package:atproto/atproto.dart' as atp;
+import 'package:atproto/firehose.dart';
+
+Future<void> main() async {
+  final atproto = atp.ATProto.anonymous();
+
+  // Frames arrive already CBOR/CAR-decoded and typed.
+  final subscription = await atproto.sync.subscribeReposAsMessages();
+
+  print('Firehose connected! Listening for events...');
+
+  await for (final message in subscription.data.stream) {
+    switch (message) {
+      case USyncSubscribeReposMessageCommit(:final data):
+        print('Commit from ${data.repo} with ${data.ops.length} operations');
+
+        for (final op in data.ops) {
+          switch (op.action.knownValue) {
+            case KnownRepoOpAction.create:
+              print('  Created: ${op.path}');
+            case KnownRepoOpAction.update:
+              print('  Updated: ${op.path}');
+            case KnownRepoOpAction.delete:
+              print('  Deleted: ${op.path}');
+            case null:
+              print('  Unknown action: ${op.action}');
+          }
+        }
+
+      case USyncSubscribeReposMessageIdentity(:final data):
+        print('Identity: ${data.handle} -> ${data.did}');
+
+      case USyncSubscribeReposMessageInfo(:final data):
+        print('Info: ${data.name}');
+
+      default:
+        print('Other event: $message');
+    }
+  }
+}

--- a/website/static/snippets/atproto/firehose_filter.dart
+++ b/website/static/snippets/atproto/firehose_filter.dart
@@ -1,0 +1,33 @@
+// ignore_for_file: unused_local_variable, avoid_print
+
+/* SNIPPET START */
+
+import 'package:atproto/atproto.dart' as atp;
+import 'package:atproto/core.dart';
+import 'package:atproto/firehose.dart';
+
+Future<void> main() async {
+  final atproto = atp.ATProto.anonymous();
+
+  final subscription = await atproto.sync.subscribeReposAsMessages();
+
+  await for (final message in subscription.data.stream) {
+    if (message case USyncSubscribeReposMessageCommit(:final data)) {
+      for (final op in data.ops) {
+        if (op.action.knownValue != KnownRepoOpAction.create) continue;
+
+        // Filtering early keeps the per-event work small, which matters at
+        // firehose volume.
+        switch (_getUri(data, op).collection.toString()) {
+          case 'app.bsky.feed.post':
+            print('New post: ${op.path}');
+          case 'app.bsky.actor.profile':
+            print('New profile: ${op.path}');
+        }
+      }
+    }
+  }
+}
+
+AtUri _getUri(final Commit commit, final RepoOp op) =>
+    AtUri('at://${commit.repo}/${op.path}');

--- a/website/static/snippets/atproto/firehose_manual.dart
+++ b/website/static/snippets/atproto/firehose_manual.dart
@@ -1,0 +1,21 @@
+// ignore_for_file: unused_local_variable, avoid_print
+
+/* SNIPPET START */
+
+import 'package:atproto/atproto.dart' as atp;
+import 'package:atproto/firehose.dart';
+
+Future<void> main() async {
+  final atproto = atp.ATProto.anonymous();
+
+  // Yields the raw binary frames; decoding is yours to drive.
+  final subscription = await atproto.sync.subscribeRepos();
+
+  await for (final event in subscription.data.stream) {
+    final message = const SyncSubscribeReposAdaptor().execute(event);
+
+    if (message case USyncSubscribeReposMessageCommit(:final data)) {
+      print('Commit from ${data.repo}');
+    }
+  }
+}

--- a/website/static/snippets/atproto/firehose_robust.dart
+++ b/website/static/snippets/atproto/firehose_robust.dart
@@ -1,0 +1,64 @@
+// ignore_for_file: unused_local_variable, avoid_print
+
+/* SNIPPET START */
+
+import 'package:atproto/atproto.dart' as atp;
+import 'package:atproto/firehose.dart';
+
+Future<void> robustFirehose() async {
+  // Resume from where the last run stopped instead of replaying everything.
+  int? cursor;
+
+  while (true) {
+    try {
+      final atproto = atp.ATProto.anonymous();
+      final subscription = await atproto.sync.subscribeReposAsMessages(
+        cursor: cursor,
+      );
+
+      print('Firehose connected');
+
+      await for (final message in subscription.data.stream) {
+        if (message case USyncSubscribeReposMessageCommit(:final data)) {
+          cursor = data.seq;
+        }
+
+        await processEvent(message);
+      }
+    } on FirehoseErrorException catch (e) {
+      // The relay rejected the stream itself, e.g. `FutureCursor` or
+      // `ConsumerTooSlow`. A cursor from the future never becomes valid, so
+      // drop it and reconnect from the live tip.
+      print('Relay error: ${e.error}');
+      if (e.error == 'FutureCursor') cursor = null;
+    } on FirehoseFrameException catch (e) {
+      // A single malformed frame. Decoding errors are delivered as stream
+      // errors and do not tear down the subscription.
+      print('Malformed frame: ${e.message}');
+    } catch (e) {
+      print('Firehose error: $e');
+    }
+
+    print('Reconnecting in 5 seconds...');
+    await Future<void>.delayed(const Duration(seconds: 5));
+  }
+}
+
+Future<void> processEvent(final USyncSubscribeReposMessage message) async {
+  switch (message) {
+    case USyncSubscribeReposMessageCommit(:final data):
+      for (final op in data.ops) {
+        // Handle operations.
+      }
+    case USyncSubscribeReposMessageIdentity(:final data):
+    // Process identity changes.
+    case USyncSubscribeReposMessageAccount(:final data):
+    // Process account changes.
+    case USyncSubscribeReposMessageSync(:final data):
+    // Process sync events.
+    case USyncSubscribeReposMessageInfo(:final data):
+    // Process info messages.
+    case USyncSubscribeReposMessageUnknown(:final data):
+    // Handle forward-compatible unknown events.
+  }
+}

--- a/website/static/snippets/atproto/http_client_injection.dart
+++ b/website/static/snippets/atproto/http_client_injection.dart
@@ -1,0 +1,36 @@
+// ignore_for_file: unused_local_variable, avoid_print
+
+/* SNIPPET START */
+
+import 'package:atproto/atproto.dart' as atp;
+import 'package:http/http.dart' as http;
+
+Future<void> main() async {
+  final atproto = atp.ATProto.anonymous(
+    // Swap in your own transport: a mock in tests, a proxy, a client that
+    // adds tracing headers, or one backed by a connection pool.
+    getClient: (url, {headers}) async {
+      print('GET $url');
+      return await http.get(url, headers: headers);
+    },
+    postClient: (url, {headers, body, encoding}) async {
+      print('POST $url');
+      return await http.post(
+        url,
+        headers: headers,
+        body: body,
+        encoding: encoding,
+      );
+    },
+  );
+
+  // The same hooks are typed as `core.GetClient` / `core.PostClient`, so a
+  // shared fake can be declared once and reused across tests.
+  final offline = atp.ATProto.anonymous(getClient: _alwaysEmpty);
+}
+
+/// A stand-in transport for tests: every GET resolves to an empty JSON body.
+Future<http.Response> _alwaysEmpty(
+  final Uri url, {
+  final Map<String, String>? headers,
+}) async => http.Response('{}', 200);

--- a/website/static/snippets/atproto/ids.dart
+++ b/website/static/snippets/atproto/ids.dart
@@ -1,0 +1,12 @@
+// ignore_for_file: unused_local_variable, avoid_print
+
+/* SNIPPET START */
+
+import 'package:atproto/ids.dart' as ids;
+
+void main() {
+  // `com.atproto.repo.strongRef`
+  print(ids.comAtprotoRepoStrongRef);
+  // `com.atproto.sync.subscribeRepos#commit`
+  print(ids.comAtprotoSyncSubscribeReposCommit);
+}

--- a/website/static/snippets/atproto/oauth.dart
+++ b/website/static/snippets/atproto/oauth.dart
@@ -1,0 +1,50 @@
+// ignore_for_file: unused_local_variable, avoid_print
+
+/* SNIPPET START */
+
+import 'package:atproto/atproto.dart' as atp;
+import 'package:atproto/atproto_oauth.dart';
+
+Future<void> main() async {
+  // Use your client metadata.
+  final metadata = await getClientMetadata(
+    'https://atprotodart.com/oauth/bluesky/atprotodart/client-metadata.json',
+  );
+
+  final client = OAuthClient(metadata);
+
+  // Resolve the account and get the authorization URL. Returns a plain Uri;
+  // the per-authorization state is stored in the client's OAuthStateStore.
+  final authUrl = await client.authorize('shinyakato.dev');
+  print(authUrl);
+
+  // Make user visit authUrl
+  // final callback = await FlutterWebAuth2.authenticate(
+  //   url: authUrl.toString(),
+  //   callbackUrlScheme: 'https',
+  // );
+
+  // Complete the exchange with only the callback URL. The `state` parameter in
+  // it is used to recover the stored context.
+  final session = await client.callback(
+    'https://atprotodart.com/oauth/bluesky/auth.html'
+    '?iss=xxxx&state=xxxxxxx&code=xxxxxxx',
+  );
+  print(session.accessToken);
+  print(session.pds);
+
+  // Later, restore the stored session (refreshing it if it has expired), or
+  // refresh/revoke it explicitly.
+  final restored = await client.restore(session.sub);
+  // final refreshed = await client.refresh(session);
+  // await client.revoke(session);
+
+  // The primary constructor takes an OAuthSessionManager, which owns DPoP
+  // header building and transparent token refresh.
+  final atproto = atp.ATProto.fromOAuth(
+    OAuthSessionManager.fromSession(restored!, client: client),
+  );
+
+  // `fromOAuthSession` is a thin wrapper over the above.
+  final same = atp.ATProto.fromOAuthSession(restored, oauthClient: client);
+}

--- a/website/static/snippets/atproto/pagination.dart
+++ b/website/static/snippets/atproto/pagination.dart
@@ -1,0 +1,27 @@
+// ignore_for_file: unused_local_variable, avoid_print
+
+/* SNIPPET START */
+
+import 'package:atproto/atproto.dart' as atp;
+
+Future<void> main() async {
+  final atproto = atp.ATProto.anonymous();
+
+  // Pagination is performed on a per-cursor basis.
+  String? nextCursor;
+
+  do {
+    final records = await atproto.repo.listRecords(
+      repo: 'shinyakato.dev',
+      collection: 'app.bsky.graph.follow',
+      cursor: nextCursor, // If null, it is ignored.
+    );
+
+    for (final record in records.data.records) {
+      print(record);
+    }
+
+    // Update pagination cursor.
+    nextCursor = records.data.cursor;
+  } while (nextCursor != null); // If there is no next page, it ends.
+}

--- a/website/static/snippets/atproto/rate_limit.dart
+++ b/website/static/snippets/atproto/rate_limit.dart
@@ -1,0 +1,40 @@
+// ignore_for_file: unused_local_variable, avoid_print
+
+/* SNIPPET START */
+
+import 'package:atproto/atproto.dart' as atp;
+
+Future<void> main() async {
+  final session = await atp.createSession(
+    service: 'SERVICE_NAME',
+    identifier: 'YOUR_HANDLE_OR_EMAIL',
+    password: 'YOUR_PASSWORD',
+  );
+
+  final atproto = atp.ATProto.fromSession(session.data);
+
+  final response = await atproto.repo.createRecord(
+    repo: session.data.did,
+    collection: 'app.bsky.feed.post',
+    record: {'text': 'Hello!'},
+  );
+
+  // This is rate limit!
+  print(response.rateLimit);
+
+  final rateLimit = response.rateLimit;
+
+  // Available properties.
+  print(rateLimit.limitCount);
+  print(rateLimit.remainingCount);
+  print(rateLimit.resetAt);
+  print(rateLimit.policy);
+
+  // When you need to handle rate limits.
+  print(rateLimit.isExceeded);
+  print(rateLimit.isNotExceeded);
+
+  // It waits until the rate limit is reset based on resetAt.
+  // If the rate limit is not exceeded, return immediately.
+  await rateLimit.waitUntilReset();
+}

--- a/website/static/snippets/atproto/retry.dart
+++ b/website/static/snippets/atproto/retry.dart
@@ -1,0 +1,39 @@
+// ignore_for_file: unused_local_variable, avoid_print
+
+/* SNIPPET START */
+
+import 'package:atproto/atproto.dart' as atp;
+import 'package:atproto/core.dart' as core;
+
+Future<void> main() async {
+  final maxAttempts = 3;
+
+  final atproto = atp.ATProto.anonymous(
+    retryConfig: core.RetryConfig(
+      // Maximum number of retry attempts.
+      maxAttempts: maxAttempts,
+
+      // Jitter configuration for randomized delays.
+      jitter: core.Jitter(
+        minInSeconds: 1, // Minimum delay
+        maxInSeconds: 5, // Maximum delay
+      ),
+
+      // Optional: Monitor retry events.
+      onExecute: (event) {
+        print(
+          'Retry ${event.retryCount}/$maxAttempts '
+          'after ${event.intervalInSeconds}s delay',
+        );
+      },
+    ),
+  );
+
+  try {
+    // This request will automatically retry on temporary failures.
+    final result = await atproto.identity.resolveHandle(handle: 'bsky.app');
+    print('Success: ${result.data.did}');
+  } catch (e) {
+    print('Failed after all retries: $e');
+  }
+}

--- a/website/static/snippets/atproto/retry_idempotency.dart
+++ b/website/static/snippets/atproto/retry_idempotency.dart
@@ -1,0 +1,30 @@
+// ignore_for_file: unused_local_variable, avoid_print
+
+/* SNIPPET START */
+
+import 'package:atproto/atproto.dart' as atp;
+import 'package:atproto/core.dart' as core;
+
+Future<void> main() async {
+  final session = await atp.createSession(
+    identifier: 'YOUR_HANDLE_OR_EMAIL',
+    password: 'YOUR_PASSWORD',
+  );
+
+  // Default: a `createRecord` that fails with a 500 or a post-send timeout is
+  // NOT retried, because the server may already have created the record.
+  final safe = atp.ATProto.fromSession(
+    session.data,
+    retryConfig: core.RetryConfig(maxAttempts: 3),
+  );
+
+  // Opt out when duplicate writes are acceptable or your records carry an
+  // idempotency key of their own. This restores pre-2.0.0 behavior.
+  final atMostOnceIsFine = atp.ATProto.fromSession(
+    session.data,
+    retryConfig: core.RetryConfig(
+      maxAttempts: 3,
+      retryProcedureOnAmbiguousFailure: true,
+    ),
+  );
+}

--- a/website/static/snippets/atproto/retry_production.dart
+++ b/website/static/snippets/atproto/retry_production.dart
@@ -1,0 +1,30 @@
+// ignore_for_file: unused_local_variable, avoid_print
+
+/* SNIPPET START */
+
+import 'package:atproto/atproto.dart' as atp;
+import 'package:atproto/core.dart' as core;
+
+void configure(final core.Session session) {
+  // Conservative retry for user-facing operations.
+  final userFacingClient = atp.ATProto.fromSession(
+    session,
+    retryConfig: core.RetryConfig(
+      maxAttempts: 2,
+      jitter: core.Jitter(minInSeconds: 1, maxInSeconds: 3),
+    ),
+  );
+
+  // Aggressive retry for background operations.
+  final backgroundClient = atp.ATProto.fromSession(
+    session,
+    retryConfig: core.RetryConfig(
+      maxAttempts: 5,
+      jitter: core.Jitter(minInSeconds: 2, maxInSeconds: 10),
+      onExecute: (event) => print('Retrying background operation'),
+    ),
+  );
+
+  // No retry at all for time-sensitive operations.
+  final realTimeClient = atp.ATProto.fromSession(session, retryConfig: null);
+}

--- a/website/static/snippets/atproto/retry_strategy.dart
+++ b/website/static/snippets/atproto/retry_strategy.dart
@@ -1,0 +1,42 @@
+// ignore_for_file: unused_local_variable, avoid_print
+
+/* SNIPPET START */
+
+import 'dart:async';
+
+import 'package:atproto/atproto.dart' as atp;
+import 'package:atproto/core.dart' as core;
+
+/// Waits a constant second between attempts, never retries a write that may
+/// already have been applied, and gives up on anything but a network blip.
+final class ConstantBackoff implements core.RetryStrategy {
+  const ConstantBackoff({this.maxAttempts = 3});
+
+  final int maxAttempts;
+
+  @override
+  FutureOr<Duration?> nextDelay(final core.RetryContext context) {
+    // Returning null stops retrying and lets the original error propagate.
+    if (context.attempt > maxAttempts) return null;
+    if (context.isProcedure && context.isAmbiguous) return null;
+
+    // Everything the decision needs is on the context.
+    print('${context.nsid} failed: ${context.reason} (${context.statusCode})');
+
+    return switch (context.reason) {
+      // Honor the server's own wait when it sent one.
+      core.RetryReason.rateLimited =>
+        context.retryAfter ?? const Duration(seconds: 5),
+      core.RetryReason.network ||
+      core.RetryReason.timeout => const Duration(seconds: 1),
+      core.RetryReason.serverError => const Duration(seconds: 2),
+    };
+  }
+}
+
+Future<void> main() async {
+  final atproto = atp.ATProto.anonymous(
+    // Any RetryStrategy is accepted here, not just RetryConfig.
+    retryConfig: const ConstantBackoff(maxAttempts: 5),
+  );
+}

--- a/website/static/snippets/atproto/serialize.dart
+++ b/website/static/snippets/atproto/serialize.dart
@@ -1,0 +1,22 @@
+// ignore_for_file: unused_local_variable, avoid_print
+
+/* SNIPPET START */
+
+import 'package:atproto/atproto.dart';
+import 'package:atproto/com_atproto_identity_resolvehandle.dart';
+
+Future<void> main() async {
+  final atproto = ATProto.anonymous();
+
+  // Just find the DID of `shinyakato.dev`.
+  final did = await atproto.identity.resolveHandle(handle: 'shinyakato.dev');
+
+  // Serialize the model to JSON. `did` is an `XRPCResponse`, and the model
+  // itself lives in `.data`.
+  final json = did.data.toJson();
+  print(json); // => {did: did:plc:iijrtk7ocored6zuziwmqq3c}
+
+  // And back again.
+  final decoded = IdentityResolveHandleOutput.fromJson(json);
+  print(decoded.did);
+}

--- a/website/static/snippets/atproto/services_authenticated.dart
+++ b/website/static/snippets/atproto/services_authenticated.dart
@@ -1,0 +1,33 @@
+// ignore_for_file: unused_local_variable, avoid_print
+
+/* SNIPPET START */
+
+import 'package:atproto/atproto.dart' as atp;
+
+Future<void> main() async {
+  final session = await atp.createSession(
+    identifier: 'your.handle.com',
+    password: 'your-app-password',
+  );
+
+  final atproto = atp.ATProto.fromSession(session.data);
+
+  // Repo Service - Create a record.
+  final record = await atproto.repo.createRecord(
+    repo: session.data.did,
+    collection: 'app.bsky.feed.post',
+    record: {
+      'text': 'Hello from AT Protocol!',
+      'createdAt': DateTime.now().toUtc().toIso8601String(),
+    },
+  );
+
+  // Repo Service - List your records.
+  final records = await atproto.repo.listRecords(
+    repo: session.data.did,
+    collection: 'app.bsky.feed.post',
+  );
+
+  print('Created record: ${record.data.uri}');
+  print('Total posts: ${records.data.records.length}');
+}

--- a/website/static/snippets/atproto/services_public.dart
+++ b/website/static/snippets/atproto/services_public.dart
@@ -1,0 +1,23 @@
+// ignore_for_file: unused_local_variable, avoid_print
+
+/* SNIPPET START */
+
+import 'package:atproto/atproto.dart' as atp;
+
+Future<void> main() async {
+  final atproto = atp.ATProto.anonymous();
+
+  // Identity Service - Resolve handles to DIDs.
+  final didResult = await atproto.identity.resolveHandle(handle: 'bsky.app');
+  print('DID: ${didResult.data.did}');
+
+  // Server Service - Get server information.
+  final serverInfo = await atproto.server.describeServer();
+  print('Server: ${serverInfo.data.availableUserDomains}');
+
+  // Label Service - Query content labels.
+  final labels = await atproto.label.queryLabels(
+    uriPatterns: ['at://did:plc:example'],
+  );
+  print('Labels found: ${labels.data.labels.length}');
+}

--- a/website/static/snippets/atproto/session.dart
+++ b/website/static/snippets/atproto/session.dart
@@ -1,0 +1,24 @@
+// ignore_for_file: unused_local_variable, avoid_print
+
+/* SNIPPET START */
+
+import 'package:atproto/atproto.dart' as atp;
+
+Future<void> main() async {
+  // Create session with your credentials.
+  final session = await atp.createSession(
+    identifier: 'your.handle.com', // Your handle or email
+    password: 'your-app-password', // App password recommended
+  );
+
+  // Create ATProto instance from session. An expired access token is
+  // refreshed transparently using the session's refresh token.
+  final atproto = atp.ATProto.fromSession(session.data);
+
+  // Now you can use authenticated endpoints.
+  final profile = await atproto.repo.getRecord(
+    repo: session.data.did,
+    collection: 'app.bsky.actor.profile',
+    rkey: 'self',
+  );
+}

--- a/website/static/snippets/atproto/session_refresh.dart
+++ b/website/static/snippets/atproto/session_refresh.dart
@@ -1,0 +1,26 @@
+// ignore_for_file: unused_local_variable, avoid_print
+
+/* SNIPPET START */
+
+import 'package:atproto/atproto.dart' as atp;
+
+Future<void> main() async {
+  final session = await atp.createSession(
+    identifier: 'your.handle.com',
+    password: 'your-app-password',
+  );
+
+  // Refresh explicitly. `ATProto.fromSession` already does this for you when a
+  // request fails with 401, so reach for it only when you manage the tokens
+  // yourself, e.g. to persist them before the instance is created.
+  final refreshed = await atp.refreshSession(
+    refreshJwt: session.data.refreshJwt,
+  );
+
+  final atproto = atp.ATProto.fromSession(refreshed.data);
+
+  final result = await atproto.repo.listRecords(
+    repo: refreshed.data.did,
+    collection: 'app.bsky.feed.post',
+  );
+}

--- a/website/static/snippets/atproto/timeout.dart
+++ b/website/static/snippets/atproto/timeout.dart
@@ -1,0 +1,12 @@
+// ignore_for_file: unused_local_variable, avoid_print
+
+/* SNIPPET START */
+
+import 'package:atproto/atproto.dart';
+
+Future<void> main() async {
+  final atproto = ATProto.anonymous(
+    // Add this.
+    timeout: Duration(seconds: 20),
+  );
+}

--- a/website/static/snippets/atproto/union_helpers.dart
+++ b/website/static/snippets/atproto/union_helpers.dart
@@ -1,0 +1,20 @@
+// ignore_for_file: unused_local_variable, avoid_print
+
+/* SNIPPET START */
+
+import 'package:atproto/atproto.dart' as atp;
+import 'package:atproto/firehose.dart';
+
+Future<void> main() async {
+  final atproto = atp.ATProto.anonymous();
+  final subscription = await atproto.sync.subscribeReposAsMessages();
+
+  await for (final message in subscription.data.stream) {
+    // Every union exposes `isX` / `isNotX` predicates and a nullable `x`
+    // accessor, which read well when you care about a single variant.
+    if (message.isNotCommit) continue;
+
+    final commit = message.commit!;
+    print('Commit from ${commit.repo} at seq ${commit.seq}');
+  }
+}

--- a/website/static/snippets/atproto/union_pattern.dart
+++ b/website/static/snippets/atproto/union_pattern.dart
@@ -1,0 +1,30 @@
+// ignore_for_file: unused_local_variable, avoid_print
+
+/* SNIPPET START */
+
+import 'package:atproto/atproto.dart' as atp;
+import 'package:atproto/firehose.dart';
+
+Future<void> main() async {
+  final atproto = atp.ATProto.anonymous();
+  final subscription = await atproto.sync.subscribeReposAsMessages();
+
+  await for (final message in subscription.data.stream) {
+    // The union is a `sealed` class, so the compiler checks the switch for you
+    // once every variant is listed.
+    switch (message) {
+      case USyncSubscribeReposMessageCommit(:final data):
+        print('Commit: ${data.ops.length} operations');
+      case USyncSubscribeReposMessageIdentity(:final data):
+        print('Identity: ${data.did}');
+      case USyncSubscribeReposMessageAccount(:final data):
+        print('Account: ${data.did}');
+      case USyncSubscribeReposMessageSync(:final data):
+        print('Sync: ${data.did}');
+      case USyncSubscribeReposMessageInfo(:final data):
+        print('Info: ${data.name}');
+      case USyncSubscribeReposMessageUnknown(:final data):
+        print('Unknown event: $data');
+    }
+  }
+}

--- a/website/static/snippets/bluesky/auth_anonymous.dart
+++ b/website/static/snippets/bluesky/auth_anonymous.dart
@@ -1,0 +1,10 @@
+// ignore_for_file: unused_local_variable, avoid_print
+
+/* SNIPPET START */
+
+import 'package:bluesky/bluesky.dart';
+
+Future<void> main() async {
+  // Just call anonymous constructor.
+  final bsky = Bluesky.anonymous();
+}

--- a/website/static/snippets/bluesky/auth_oauth.dart
+++ b/website/static/snippets/bluesky/auth_oauth.dart
@@ -1,0 +1,45 @@
+// ignore_for_file: unused_local_variable, avoid_print
+
+/* SNIPPET START */
+
+import 'dart:convert';
+
+import 'package:bluesky/atproto_oauth.dart';
+import 'package:bluesky/bluesky.dart';
+
+/// Runs the full authorization code flow, then builds a [Bluesky] from it.
+Future<Bluesky> signIn() async {
+  // Your own client metadata, served over HTTPS.
+  final metadata = await getClientMetadata(
+    'https://atprotodart.com/oauth/bluesky/atprotodart/client-metadata.json',
+  );
+
+  final oauth = OAuthClient(metadata);
+
+  // Resolves the identity, discovers its authorization server, performs the
+  // pushed authorization request, and persists the per-authorization state.
+  final authUrl = await oauth.authorize('shinyakato.dev');
+
+  // Send the user to `authUrl` (e.g. with `flutter_web_auth_2`) and feed the
+  // callback URL back in.
+  const callbackUrl =
+      'https://atprotodart.com/oauth/bluesky/auth.html'
+      '?iss=xxxx&state=xxxxxxx&code=xxxxxxx';
+
+  final session = await oauth.callback(callbackUrl);
+
+  // The manager owns DPoP header building and transparent token refresh.
+  final manager = OAuthSessionManager(oauth, sub: session.sub);
+
+  return Bluesky.fromOAuth(manager);
+}
+
+/// Restores a session you persisted earlier.
+Bluesky restore(final String storedJson) {
+  final restored = OAuthSession.fromJson(jsonDecode(storedJson));
+
+  // Equivalent to `Bluesky.fromOAuth(OAuthSessionManager.fromSession(...))`.
+  // Pass `oauthClient` to keep transparent token refresh working; without it
+  // the session is used as-is and cannot be refreshed.
+  return Bluesky.fromOAuthSession(restored);
+}

--- a/website/static/snippets/bluesky/auth_session.dart
+++ b/website/static/snippets/bluesky/auth_session.dart
@@ -1,0 +1,19 @@
+// ignore_for_file: unused_local_variable, avoid_print
+
+/* SNIPPET START */
+
+import 'package:bluesky/atproto.dart';
+import 'package:bluesky/bluesky.dart';
+
+Future<void> main() async {
+  // Let's authenticate here.
+  final session = await createSession(
+    identifier: 'YOUR_HANDLE_OR_EMAIL', // Like "shinyakato.dev"
+    password: 'YOUR_PASSWORD',
+  );
+
+  print(session);
+
+  // Just pass created session data.
+  final bsky = Bluesky.fromSession(session.data);
+}

--- a/website/static/snippets/bluesky/chat_convos.dart
+++ b/website/static/snippets/bluesky/chat_convos.dart
@@ -1,0 +1,51 @@
+// ignore_for_file: unused_local_variable, avoid_print
+
+// Imports used only by the `_session` helper below the snippet.
+import 'package:bluesky/atproto.dart';
+import 'package:bluesky/core.dart';
+
+/* SNIPPET START */
+
+import 'package:bluesky/bluesky_chat.dart';
+
+Future<void> main() async {
+  final chat = BlueskyChat.fromSession(await _session);
+
+  // List all conversations.
+  final conversations = await chat.convo.listConvos(limit: 50);
+  for (final convo in conversations.data.convos) {
+    print(
+      'Conversation with: ${convo.members.map((m) => m.displayName).join(', ')}',
+    );
+    print('Last message: ${convo.lastMessage ?? 'No messages'}');
+  }
+
+  // Get a specific conversation.
+  final convo = await chat.convo.getConvo(convoId: 'convo-id');
+
+  // Get conversation for specific members.
+  final memberConvo = await chat.convo.getConvoForMembers(
+    members: ['did:plc:example1', 'did:plc:example2'],
+  );
+
+  // Accept a conversation request.
+  await chat.convo.acceptConvo(convoId: 'convo-id');
+
+  // Leave a conversation.
+  await chat.convo.leaveConvo(convoId: 'convo-id');
+
+  // Mute/unmute conversations.
+  await chat.convo.muteConvo(convoId: 'convo-id');
+  await chat.convo.unmuteConvo(convoId: 'convo-id');
+}
+
+/* SNIPPET END */
+
+Future<Session> get _session async {
+  final session = await createSession(
+    identifier: 'YOUR_HANDLE_OR_EMAIL',
+    password: 'YOUR_PASSWORD',
+  );
+
+  return session.data;
+}

--- a/website/static/snippets/bluesky/chat_messages.dart
+++ b/website/static/snippets/bluesky/chat_messages.dart
@@ -1,0 +1,77 @@
+// ignore_for_file: unused_local_variable, avoid_print
+
+// Imports used only by the `_session` helper below the snippet.
+import 'package:bluesky/atproto.dart';
+import 'package:bluesky/core.dart';
+
+/* SNIPPET START */
+
+import 'package:bluesky/bluesky_chat.dart';
+import 'package:bluesky/chat_bsky_convo_defs.dart';
+import 'package:bluesky/chat_bsky_convo_sendmessagebatch.dart';
+
+Future<void> main() async {
+  final chat = BlueskyChat.fromSession(await _session);
+
+  // Send a message.
+  final message = await chat.convo.sendMessage(
+    convoId: 'convo-id',
+    message: MessageInput(text: 'Hello! How are you doing?'),
+  );
+
+  // Send multiple messages in batch.
+  await chat.convo.sendMessageBatch(
+    items: [
+      BatchItem(
+        convoId: 'convo-id-1',
+        message: MessageInput(text: 'Message 1'),
+      ),
+      BatchItem(
+        convoId: 'convo-id-2',
+        message: MessageInput(text: 'Message 2'),
+      ),
+    ],
+  );
+
+  // Get messages from a conversation.
+  final messages = await chat.convo.getMessages(convoId: 'convo-id', limit: 50);
+  for (final message in messages.data.messages) {
+    print('$message');
+  }
+
+  // Mark messages as read.
+  await chat.convo.updateRead(convoId: 'convo-id', messageId: 'message-id');
+
+  // Mark all conversations as read.
+  await chat.convo.updateAllRead();
+
+  // Delete a message for yourself only.
+  await chat.convo.deleteMessageForSelf(
+    convoId: 'convo-id',
+    messageId: 'message-id',
+  );
+
+  // Add and remove a reaction.
+  await chat.convo.addReaction(
+    convoId: 'convo-id',
+    messageId: 'message-id',
+    value: '👍',
+  );
+
+  await chat.convo.removeReaction(
+    convoId: 'convo-id',
+    messageId: 'message-id',
+    value: '👍',
+  );
+}
+
+/* SNIPPET END */
+
+Future<Session> get _session async {
+  final session = await createSession(
+    identifier: 'YOUR_HANDLE_OR_EMAIL',
+    password: 'YOUR_PASSWORD',
+  );
+
+  return session.data;
+}

--- a/website/static/snippets/bluesky/chat_moderation.dart
+++ b/website/static/snippets/bluesky/chat_moderation.dart
@@ -1,0 +1,41 @@
+// ignore_for_file: unused_local_variable, avoid_print
+
+// Imports used only by the `_session` helper below the snippet.
+import 'package:bluesky/atproto.dart';
+import 'package:bluesky/core.dart';
+
+/* SNIPPET START */
+
+import 'package:bluesky/bluesky_chat.dart';
+
+Future<void> main() async {
+  final chat = BlueskyChat.fromSession(await _session);
+
+  // Get actor metadata for moderation.
+  final actorMeta = await chat.moderation.getActorMetadata(
+    actor: 'did:plc:example',
+  );
+
+  // Update actor access (for moderators).
+  await chat.moderation.updateActorAccess(
+    actor: 'did:plc:example',
+    allowAccess: true,
+  );
+
+  // Get message context for moderation.
+  final messageContext = await chat.moderation.getMessageContext(
+    convoId: 'convo-id',
+    messageId: 'message-id',
+  );
+}
+
+/* SNIPPET END */
+
+Future<Session> get _session async {
+  final session = await createSession(
+    identifier: 'YOUR_HANDLE_OR_EMAIL',
+    password: 'YOUR_PASSWORD',
+  );
+
+  return session.data;
+}

--- a/website/static/snippets/bluesky/chat_setup.dart
+++ b/website/static/snippets/bluesky/chat_setup.dart
@@ -1,0 +1,20 @@
+// ignore_for_file: unused_local_variable, avoid_print
+
+/* SNIPPET START */
+
+import 'package:bluesky/atproto.dart';
+import 'package:bluesky/bluesky_chat.dart';
+
+Future<void> main() async {
+  final session = await createSession(
+    identifier: 'YOUR_HANDLE_OR_EMAIL',
+    password: 'YOUR_PASSWORD',
+  );
+
+  // Create BlueskyChat instance for chat functionality.
+  final chat = BlueskyChat.fromSession(session.data);
+
+  // Access chat services.
+  final conversations = await chat.convo.listConvos();
+  print(conversations);
+}

--- a/website/static/snippets/bluesky/create_posts.dart
+++ b/website/static/snippets/bluesky/create_posts.dart
@@ -1,0 +1,78 @@
+// ignore_for_file: unused_local_variable, avoid_print
+
+// Imports used only by the `_session` helper below the snippet.
+import 'package:bluesky/atproto.dart';
+import 'package:bluesky/core.dart';
+
+/* SNIPPET START */
+
+import 'dart:io';
+
+import 'package:bluesky/app_bsky_embed_external.dart';
+import 'package:bluesky/app_bsky_embed_images.dart';
+import 'package:bluesky/app_bsky_feed_post.dart';
+import 'package:bluesky/bluesky.dart';
+import 'package:bluesky/cardyb.dart';
+
+Future<void> main() async {
+  final bsky = Bluesky.fromSession(await _session);
+
+  // Simple text post.
+  final post = await bsky.feed.post.create(text: 'Hello, Bluesky! 🦋');
+  print('Posted: ${post.data.uri}');
+
+  // Upload an image and embed it.
+  final image = File('./cool_image.jpg').readAsBytesSync();
+  final blob = await bsky.atproto.repo.uploadBlob(bytes: image);
+
+  final imagePost = await bsky.feed.post.create(
+    text: 'Check out this image!',
+    embed: UFeedPostEmbed.embedImages(
+      data: EmbedImages(
+        images: [EmbedImagesImage(image: blob.data.blob, alt: 'Cool image!')],
+      ),
+    ),
+  );
+
+  // Post with an external link. `EmbedExternalExternal.uri` is a plain
+  // `String`, not an `AtUri`.
+  final linkPost = await bsky.feed.post.create(
+    text: 'Interesting article',
+    embed: UFeedPostEmbed.embedExternal(
+      data: EmbedExternal(
+        external: EmbedExternalExternal(
+          uri: 'https://example.com',
+          title: 'Article Title',
+          description: 'Article description',
+        ),
+      ),
+    ),
+  );
+
+  // Or let `package:bluesky/cardyb.dart` build the card metadata for you.
+  final preview = await getLinkPreview(Uri.https('example.com'));
+
+  final cardPost = await bsky.feed.post.create(
+    text: 'Interesting article',
+    embed: UFeedPostEmbed.embedExternal(
+      data: EmbedExternal(
+        external: EmbedExternalExternal(
+          uri: preview.data.url ?? 'https://example.com',
+          title: preview.data.title ?? '',
+          description: preview.data.description ?? '',
+        ),
+      ),
+    ),
+  );
+}
+
+/* SNIPPET END */
+
+Future<Session> get _session async {
+  final session = await createSession(
+    identifier: 'YOUR_HANDLE_OR_EMAIL',
+    password: 'YOUR_PASSWORD',
+  );
+
+  return session.data;
+}

--- a/website/static/snippets/bluesky/custom_service.dart
+++ b/website/static/snippets/bluesky/custom_service.dart
@@ -1,0 +1,23 @@
+// ignore_for_file: unused_local_variable, avoid_print
+
+/* SNIPPET START */
+
+import 'package:bluesky/atproto.dart';
+import 'package:bluesky/bluesky.dart';
+
+Future<void> main() async {
+  final session = await createSession(
+    // Add this.
+    service: 'boobee.blue',
+
+    identifier: 'YOUR_HANDLE_OR_EMAIL',
+    password: 'YOUR_PASSWORD',
+  );
+
+  final bsky = Bluesky.fromSession(
+    session.data,
+
+    // Add this, or resolve dynamically based on session.
+    service: 'boobee.blue',
+  );
+}

--- a/website/static/snippets/bluesky/error_handling.dart
+++ b/website/static/snippets/bluesky/error_handling.dart
@@ -1,0 +1,55 @@
+// ignore_for_file: unused_local_variable, avoid_print
+
+// Imports used only by the `_session` helper below the snippet.
+import 'package:bluesky/atproto.dart';
+
+/* SNIPPET START */
+
+import 'package:bluesky/bluesky.dart';
+import 'package:bluesky/core.dart' as core;
+
+Future<void> main() async {
+  const maxAttempts = 5;
+
+  final bsky = Bluesky.fromSession(
+    await _session,
+    retryConfig: core.RetryConfig(
+      maxAttempts: maxAttempts,
+      jitter: core.Jitter(minInSeconds: 1, maxInSeconds: 30),
+      onExecute: (event) {
+        print('Retry attempt ${event.retryCount}/$maxAttempts');
+        print('Waiting ${event.intervalInSeconds}s before retry...');
+      },
+    ),
+  );
+
+  try {
+    // This automatically retries transient failures.
+    final timeline = await bsky.feed.getTimeline();
+    print('Successfully retrieved ${timeline.data.feed.length} posts');
+  } on core.RateLimitExceededException catch (e) {
+    print('Rate limit exceeded. Reset at: ${e.response.rateLimit.resetAt}');
+    await e.response.rateLimit.waitUntilReset();
+
+    // Retry after the rate limit resets.
+    final timeline = await bsky.feed.getTimeline();
+  } on core.UnauthorizedException catch (e) {
+    // Refresh the session or re-authenticate.
+    print('Authentication failed: ${e.response}');
+  } on core.XRPCException catch (e) {
+    print('API error: ${e.response}');
+  } catch (e) {
+    print('Unexpected error: $e');
+  }
+}
+
+/* SNIPPET END */
+
+Future<core.Session> get _session async {
+  final session = await createSession(
+    identifier: 'YOUR_HANDLE_OR_EMAIL',
+    password: 'YOUR_PASSWORD',
+  );
+
+  return session.data;
+}

--- a/website/static/snippets/bluesky/firehose_analytics.dart
+++ b/website/static/snippets/bluesky/firehose_analytics.dart
@@ -1,0 +1,32 @@
+// ignore_for_file: unused_local_variable, avoid_print
+
+/* SNIPPET START */
+
+import 'package:bluesky/firehose.dart';
+
+/// Real-time analytics over the Firehose.
+class FirehoseAnalytics {
+  int postCount = 0;
+  int likeCount = 0;
+  final Map<String, int> languageStats = {};
+
+  void process(final Commit commit) {
+    RepoCommitHandler(
+      onCreateFeedPost: (data) {
+        postCount++;
+        for (final lang in data.record.langs ?? const ['unknown']) {
+          languageStats[lang] = (languageStats[lang] ?? 0) + 1;
+        }
+      },
+      onCreateFeedLike: (data) {
+        likeCount++;
+      },
+    ).execute(commit);
+
+    // Print stats every 1000 posts.
+    if (postCount % 1000 == 0) {
+      print('Posts: $postCount, Likes: $likeCount');
+      print('Top languages: ${languageStats.entries.take(5).toList()}');
+    }
+  }
+}

--- a/website/static/snippets/bluesky/firehose_bot.dart
+++ b/website/static/snippets/bluesky/firehose_bot.dart
@@ -1,0 +1,52 @@
+// ignore_for_file: unused_local_variable, avoid_print
+
+// Imports used only by the `_session` helper below the snippet.
+import 'package:bluesky/atproto.dart';
+import 'package:bluesky/core.dart';
+
+/* SNIPPET START */
+
+import 'package:bluesky/app_bsky_feed_post.dart';
+import 'package:bluesky/bluesky.dart';
+import 'package:bluesky/com_atproto_repo_strongref.dart';
+import 'package:bluesky/firehose.dart';
+
+/// A bot that replies whenever it is mentioned.
+Future<void> main() async {
+  final bsky = Bluesky.fromSession(await _session);
+
+  final mentionBot = RepoCommitHandler(
+    onCreateFeedPost: (data) async {
+      final text = data.record.text.toLowerCase();
+      if (!text.contains('@mybot.bsky.social')) return;
+
+      // `data.uri` is already an `AtUri`, which is what `RepoStrongRef`
+      // expects.
+      final ref = RepoStrongRef(uri: data.uri, cid: data.cid!);
+
+      await bsky.feed.post.create(
+        text: 'Thanks for the mention!',
+        reply: ReplyRef(root: ref, parent: ref),
+      );
+    },
+  );
+
+  final subscription = await bsky.atproto.sync.subscribeReposAsMessages();
+
+  await for (final message in subscription.data.stream) {
+    if (message.isCommit) {
+      mentionBot.execute(message.commit!);
+    }
+  }
+}
+
+/* SNIPPET END */
+
+Future<Session> get _session async {
+  final session = await createSession(
+    identifier: 'YOUR_HANDLE_OR_EMAIL',
+    password: 'YOUR_PASSWORD',
+  );
+
+  return session.data;
+}

--- a/website/static/snippets/bluesky/firehose_handler.dart
+++ b/website/static/snippets/bluesky/firehose_handler.dart
@@ -1,0 +1,37 @@
+// ignore_for_file: unused_local_variable, avoid_print
+
+/* SNIPPET START */
+
+import 'package:bluesky/bluesky.dart';
+import 'package:bluesky/firehose.dart';
+
+Future<void> main() async {
+  // Authentication is not required.
+  final bsky = Bluesky.anonymous();
+
+  // Use `RepoCommitHandler` to filter down to the records you care about.
+  final handler = RepoCommitHandler(
+    // Occurs only when a post record is created.
+    onCreateFeedPost: (data) {
+      print(data.uri);
+      print(data.record);
+    },
+    // Occurs only when a profile record is updated.
+    onUpdateActorProfile: (data) {
+      print(data.uri);
+      print(data.record);
+    },
+    // Occurs only when a follow record is deleted.
+    onDeleteGraphFollow: (data) {
+      print(data.uri);
+    },
+  );
+
+  final subscription = await bsky.atproto.sync.subscribeReposAsMessages();
+
+  await for (final message in subscription.data.stream) {
+    if (message.isCommit) {
+      handler.execute(message.commit!);
+    }
+  }
+}

--- a/website/static/snippets/bluesky/firehose_messages.dart
+++ b/website/static/snippets/bluesky/firehose_messages.dart
@@ -1,0 +1,42 @@
+// ignore_for_file: unused_local_variable, avoid_print
+
+/* SNIPPET START */
+
+import 'package:bluesky/bluesky.dart';
+import 'package:bluesky/com_atproto_sync_subscriberepos.dart';
+
+Future<void> main() async {
+  // Authentication is not required.
+  final bsky = Bluesky.anonymous();
+
+  // Yields already-decoded, typed messages instead of raw binary frames, so
+  // no adaptor is needed.
+  final subscription = await bsky.atproto.sync.subscribeReposAsMessages();
+
+  await for (final message in subscription.data.stream) {
+    switch (message) {
+      // Occurs when an account committed records, such as Post and Like.
+      case USyncSubscribeReposMessageCommit():
+        // A single commit may contain multiple records.
+        for (final op in message.data.ops) {
+          if (op.action.isUnknown) continue;
+
+          switch (op.action.knownValue!) {
+            case KnownRepoOpAction.create:
+            case KnownRepoOpAction.update:
+              print(op);
+            case KnownRepoOpAction.delete:
+              print(op);
+          }
+        }
+
+      // Occurs when an account changed its handle.
+      case USyncSubscribeReposMessageIdentity():
+        print(message.data.handle);
+        print(message.data.did);
+
+      default:
+        print(message);
+    }
+  }
+}

--- a/website/static/snippets/bluesky/firehose_raw.dart
+++ b/website/static/snippets/bluesky/firehose_raw.dart
@@ -1,0 +1,46 @@
+// ignore_for_file: unused_local_variable, avoid_print
+
+/* SNIPPET START */
+
+import 'package:bluesky/bluesky.dart';
+import 'package:bluesky/firehose.dart';
+
+Future<void> main() async {
+  // Authentication is not required.
+  final bsky = Bluesky.anonymous();
+
+  // Yields raw binary frames; decode them yourself with the adaptor.
+  final subscription = await bsky.atproto.sync.subscribeRepos();
+
+  await for (final event in subscription.data.stream) {
+    final repos = const SyncSubscribeReposAdaptor().execute(event);
+
+    repos.when(
+      // Occurs when an account committed records, such as Post and Like.
+      commit: (data) {
+        for (final op in data.ops) {
+          if (op.action.isUnknown) continue;
+
+          switch (op.action.knownValue!) {
+            case KnownRepoOpAction.create:
+            case KnownRepoOpAction.update:
+              print(op);
+            case KnownRepoOpAction.delete:
+              print(op);
+          }
+        }
+      },
+
+      // Occurs when an account changed its handle.
+      identity: (data) {
+        print(data.handle);
+        print(data.did);
+      },
+
+      account: print,
+      sync: print,
+      info: print,
+      unknown: print,
+    );
+  }
+}

--- a/website/static/snippets/bluesky/interactions.dart
+++ b/website/static/snippets/bluesky/interactions.dart
@@ -1,0 +1,53 @@
+// ignore_for_file: unused_local_variable, avoid_print
+
+// Imports used only by the `_session` helper below the snippet.
+import 'package:bluesky/atproto.dart';
+
+/* SNIPPET START */
+
+import 'package:bluesky/app_bsky_feed_post.dart';
+import 'package:bluesky/bluesky.dart';
+import 'package:bluesky/com_atproto_repo_strongref.dart';
+import 'package:bluesky/core.dart';
+
+Future<void> main() async {
+  final bsky = Bluesky.fromSession(await _session);
+
+  final postUri = AtUri('at://did:plc:example/app.bsky.feed.post/example');
+  const postCid = 'bafyreiexamplecid';
+
+  // `RepoStrongRef.uri` is an `AtUri`.
+  final subject = RepoStrongRef(uri: postUri, cid: postCid);
+
+  // Like a post.
+  final like = await bsky.feed.like.create(subject: subject);
+
+  // Repost.
+  final repost = await bsky.feed.repost.create(subject: subject);
+
+  // Reply to a post.
+  final reply = await bsky.feed.post.create(
+    text: 'Great post!',
+    reply: ReplyRef(root: subject, parent: subject),
+  );
+
+  // Get post likes.
+  final likes = await bsky.feed.getLikes(uri: postUri);
+  for (final like in likes.data.likes) {
+    print('Liked by: ${like.actor.displayName}');
+  }
+
+  // Get reposts.
+  final reposts = await bsky.feed.getRepostedBy(uri: postUri);
+}
+
+/* SNIPPET END */
+
+Future<Session> get _session async {
+  final session = await createSession(
+    identifier: 'YOUR_HANDLE_OR_EMAIL',
+    password: 'YOUR_PASSWORD',
+  );
+
+  return session.data;
+}

--- a/website/static/snippets/bluesky/lexicon_ids.dart
+++ b/website/static/snippets/bluesky/lexicon_ids.dart
@@ -1,0 +1,20 @@
+// ignore_for_file: unused_local_variable, avoid_print
+
+/* SNIPPET START */
+
+import 'package:bluesky/ids.dart' as ids;
+
+void main() {
+  // `com.atproto.sync.subscribeRepos#commit`
+  ids.comAtprotoSyncSubscribeReposCommit;
+
+  // `app.bsky.feed.post`
+  ids.appBskyFeedPost;
+  // `app.bsky.feed.defs#reasonRepost`
+  ids.appBskyFeedDefsReasonRepost;
+
+  // `chat.bsky.convo.defs`
+  ids.chatBskyConvoDefs;
+  // `tools.ozone.moderation.defs`
+  ids.toolsOzoneModerationDefs;
+}

--- a/website/static/snippets/bluesky/moderation_basics.dart
+++ b/website/static/snippets/bluesky/moderation_basics.dart
@@ -1,0 +1,71 @@
+// ignore_for_file: unused_local_variable, avoid_print
+
+// Imports used only by the `_session` helper below the snippet.
+import 'package:bluesky/atproto.dart';
+import 'package:bluesky/core.dart';
+
+/* SNIPPET START */
+
+import 'package:bluesky/bluesky.dart';
+// `moderation.dart` ships extensions (`getModerationPrefs`,
+// `getLabelDefinitions`). Dart never applies extensions behind an import
+// prefix, so this import must stay unprefixed.
+import 'package:bluesky/moderation.dart';
+
+Future<void> main() async {
+  final bsky = Bluesky.fromSession(await _session);
+
+  // First get the user's moderation prefs and their label definitions.
+  final preferences = await bsky.actor.getPreferences();
+  final moderationPrefs = preferences.data.getModerationPrefs();
+  final labelDefs = await bsky.labeler.getLabelDefinitions(moderationPrefs);
+
+  final moderationOpts = ModerationOpts(
+    userDid: bsky.session!.did,
+    prefs: moderationPrefs,
+    labelDefs: labelDefs,
+  );
+
+  // `getLabelerHeaders` tells the AppView which labelers to apply. Without it
+  // the feed comes back unlabelled and moderation has nothing to act on.
+  final feeds = await bsky.feed.getTimeline(
+    $headers: getLabelerHeaders(moderationPrefs),
+  );
+
+  for (final feed in feeds.data.feed) {
+    final decision = moderatePost(
+      ModerationSubjectPost.postView(data: feed.post),
+      moderationOpts,
+    );
+
+    // Ask for the UI decision in the context you are rendering.
+    final contentList = decision.getUI(ModerationBehaviorContext.contentList);
+    final contentView = decision.getUI(ModerationBehaviorContext.contentView);
+    final contentMedia = decision.getUI(ModerationBehaviorContext.contentMedia);
+
+    if (contentList.filter) {
+      continue; // Don't include in feeds.
+    }
+
+    if (contentList.blur) {
+      // Render behind a content warning; `noOverride` means the user may not
+      // click through.
+      print('Blur (override allowed: ${!contentList.noOverride})');
+    }
+
+    if (contentList.alert || contentList.inform) {
+      print('Show a moderation notice');
+    }
+  }
+}
+
+/* SNIPPET END */
+
+Future<Session> get _session async {
+  final session = await createSession(
+    identifier: 'YOUR_HANDLE_OR_EMAIL',
+    password: 'YOUR_PASSWORD',
+  );
+
+  return session.data;
+}

--- a/website/static/snippets/bluesky/moderation_custom.dart
+++ b/website/static/snippets/bluesky/moderation_custom.dart
@@ -1,0 +1,60 @@
+// ignore_for_file: unused_local_variable, avoid_print
+
+/* SNIPPET START */
+
+// `ViewerStateExtension` (`hasBlocking` / `isBlockedBy`) lives here, and Dart
+// never applies extensions behind an import prefix.
+import 'package:bluesky/app_bsky_actor_defs.dart';
+import 'package:bluesky/app_bsky_feed_defs.dart';
+import 'package:bluesky/app_bsky_feed_post.dart';
+import 'package:bluesky/app_bsky_graph_getrelationships.dart';
+import 'package:bluesky/bluesky.dart';
+import 'package:bluesky/com_atproto_admin_defs.dart';
+import 'package:bluesky/com_atproto_moderation_createreport.dart';
+import 'package:bluesky/com_atproto_moderation_defs.dart';
+
+/// Layer your own rules on top of the built-in moderation engine.
+class CustomModerationService {
+  const CustomModerationService(this.bsky, this.blockedKeywords);
+
+  final Bluesky bsky;
+  final Set<String> blockedKeywords;
+
+  Future<bool> shouldFilterPost(final PostView post) async {
+    // `PostView.record` is raw JSON; marshal it into the typed record.
+    final record = FeedPostRecord.fromJson(post.record);
+
+    final text = record.text.toLowerCase();
+    if (blockedKeywords.any(text.contains)) return true;
+
+    // Check the viewer's block status against the author.
+    final relationships = await bsky.graph.getRelationships(
+      actor: bsky.session!.did,
+      others: [post.author.did],
+    );
+
+    final relationship = relationships.data.relationships.first;
+
+    switch (relationship) {
+      case UGraphGetRelationshipsRelationshipsRelationship():
+        final actor = await bsky.actor.getProfile(actor: relationship.data.did);
+
+        return (actor.data.viewer?.hasBlocking ?? false) ||
+            (actor.data.viewer?.isBlockedBy ?? false);
+      default:
+        return false;
+    }
+  }
+
+  Future<void> reportAndBlock(final String did, final String reason) async {
+    await bsky.atproto.moderation.createReport(
+      reasonType: ReasonType.knownValue(
+        data: KnownReasonType.comAtprotoModerationDefsReasonViolation,
+      ),
+      subject: UModerationCreateReportSubject.repoRef(data: RepoRef(did: did)),
+      reason: reason,
+    );
+
+    await bsky.graph.block.create(subject: did);
+  }
+}

--- a/website/static/snippets/bluesky/moderation_labels.dart
+++ b/website/static/snippets/bluesky/moderation_labels.dart
@@ -1,0 +1,27 @@
+// ignore_for_file: unused_local_variable, avoid_print
+
+/* SNIPPET START */
+
+import 'package:bluesky/bluesky.dart';
+
+Future<void> main() async {
+  final bsky = Bluesky.anonymous();
+
+  // Get labeler services.
+  final labelerServices = await bsky.labeler.getServices(
+    dids: ['did:plc:labeler-example'],
+    detailed: true,
+  );
+
+  // Query labels for content.
+  final labels = await bsky.atproto.label.queryLabels(
+    uriPatterns: ['at://did:plc:example/app.bsky.feed.post/*'],
+    sources: ['did:plc:labeler-example'],
+  );
+
+  for (final label in labels.data.labels) {
+    print('Label: ${label.val} on ${label.uri}');
+    print('Created by: ${label.src}');
+    print('Created at: ${label.cts}');
+  }
+}

--- a/website/static/snippets/bluesky/moderation_mute_words.dart
+++ b/website/static/snippets/bluesky/moderation_mute_words.dart
@@ -1,0 +1,31 @@
+// ignore_for_file: unused_local_variable, avoid_print
+
+/* SNIPPET START */
+
+import 'package:bluesky/moderation.dart';
+
+void main() {
+  final mutedWords = _moderationPrefs.mutedWords;
+
+  // A boolean check.
+  final muted = hasMutedWord(
+    mutedWords: mutedWords,
+    text: 'this post mentions spoilers',
+    languages: ['en'],
+  );
+
+  // Or the individual matches, so you can explain *why* it was muted.
+  final matches = matchMuteWords(
+    mutedWords: mutedWords,
+    text: 'this post mentions spoilers',
+    languages: ['en'],
+  );
+
+  for (final MuteWordMatch match in matches) {
+    print('Matched "${match.predicate}" for ${match.word.value}');
+  }
+}
+
+/* SNIPPET END */
+
+late final ModerationPrefs _moderationPrefs;

--- a/website/static/snippets/bluesky/moderation_report.dart
+++ b/website/static/snippets/bluesky/moderation_report.dart
@@ -1,0 +1,53 @@
+// ignore_for_file: unused_local_variable, avoid_print
+
+// Imports used only by the `_session` helper below the snippet.
+import 'package:bluesky/atproto.dart';
+
+/* SNIPPET START */
+
+import 'package:bluesky/bluesky.dart';
+import 'package:bluesky/com_atproto_admin_defs.dart';
+import 'package:bluesky/com_atproto_moderation_createreport.dart';
+import 'package:bluesky/com_atproto_moderation_defs.dart';
+import 'package:bluesky/com_atproto_repo_strongref.dart';
+import 'package:bluesky/core.dart';
+
+Future<void> main() async {
+  final bsky = Bluesky.fromSession(await _session);
+
+  // Report an account.
+  final accountReport = await bsky.atproto.moderation.createReport(
+    reasonType: ReasonType.knownValue(
+      data: KnownReasonType.comAtprotoModerationDefsReasonSpam,
+    ),
+    subject: UModerationCreateReportSubject.repoRef(
+      data: RepoRef(did: 'did:plc:example'),
+    ),
+    reason: 'This account is engaging in harassment',
+  );
+
+  // Report a single record, such as a post.
+  final postReport = await bsky.atproto.moderation.createReport(
+    reasonType: ReasonType.knownValue(
+      data: KnownReasonType.comAtprotoModerationDefsReasonViolation,
+    ),
+    subject: UModerationCreateReportSubject.repoStrongRef(
+      data: RepoStrongRef(
+        uri: AtUri('at://did:plc:example/app.bsky.feed.post/example'),
+        cid: 'bafyreiexamplecid',
+      ),
+    ),
+    reason: 'This post contains spam content',
+  );
+}
+
+/* SNIPPET END */
+
+Future<Session> get _session async {
+  final session = await createSession(
+    identifier: 'YOUR_HANDLE_OR_EMAIL',
+    password: 'YOUR_PASSWORD',
+  );
+
+  return session.data;
+}

--- a/website/static/snippets/bluesky/moderation_subjects.dart
+++ b/website/static/snippets/bluesky/moderation_subjects.dart
@@ -1,0 +1,60 @@
+// ignore_for_file: unused_local_variable, avoid_print
+
+// Imports used only by the helpers below the snippet.
+import 'package:bluesky/app_bsky_actor_defs.dart';
+import 'package:bluesky/app_bsky_feed_defs.dart';
+import 'package:bluesky/app_bsky_graph_defs.dart';
+import 'package:bluesky/app_bsky_notification_listnotifications.dart';
+
+/* SNIPPET START */
+
+import 'package:bluesky/moderation.dart';
+
+void main() {
+  final opts = _moderationOpts;
+
+  // Posts.
+  final post = moderatePost(
+    ModerationSubjectPost.postView(data: _postView),
+    opts,
+  );
+
+  // Profiles — merges the account and profile decisions.
+  final profile = moderateProfile(
+    ModerationSubjectProfile.profileViewDetailed(data: _profile),
+    opts,
+  );
+
+  // Live status (`app.bsky.actor.defs#statusView`).
+  final status = moderateStatus(
+    ModerationSubjectProfile.profileViewDetailed(data: _profile),
+    opts,
+  );
+
+  // Notifications.
+  final notification = moderateNotification(
+    ModerationSubjectNotification.notification(data: _notification),
+    opts,
+  );
+
+  // Feed generators.
+  final generator = moderateFeedGenerator(
+    ModerationSubjectFeedGenerator.generatorView(data: _generator),
+    opts,
+  );
+
+  // User lists.
+  final list = moderateUserList(
+    ModerationSubjectUserList.listView(data: _list),
+    opts,
+  );
+}
+
+/* SNIPPET END */
+
+late final ModerationOpts _moderationOpts;
+late final PostView _postView;
+late final ProfileViewDetailed _profile;
+late final Notification _notification;
+late final GeneratorView _generator;
+late final ListView _list;

--- a/website/static/snippets/bluesky/notification_grouping.dart
+++ b/website/static/snippets/bluesky/notification_grouping.dart
@@ -1,0 +1,73 @@
+// ignore_for_file: unused_local_variable, avoid_print
+
+// Imports used only by the `_session` helper below the snippet.
+import 'package:bluesky/atproto.dart';
+import 'package:bluesky/core.dart';
+
+/* SNIPPET START */
+
+import 'package:bluesky/app_bsky_notification_listnotifications.dart';
+import 'package:bluesky/bluesky.dart';
+
+Future<void> main() async {
+  final bsky = Bluesky.fromSession(await _session);
+
+  final notifications = await bsky.notification.listNotifications();
+
+  // Default: official Bluesky social-app parity — groups like / repost /
+  // follow / like-via-repost / repost-via-repost / subscribed-post within a
+  // 48h sliding window, separates follow-backs, and marks a group unread if
+  // any of its notifications is unread.
+  final grouped = notifications.data.group();
+
+  for (final group in grouped.notifications) {
+    print('${group.reason}: ${group.authors.length} author(s)');
+    print('Newest subject: ${group.uris.first}');
+    print('Unread: ${group.isRead == false}');
+  }
+
+  // Keep the legacy behavior from bluesky <= 2.x.
+  final legacy = notifications.data.group(
+    config: const NotificationsGrouperConfig.lenient(),
+  );
+
+  // Or fully customize the grouping.
+  final custom = notifications.data.group(
+    config: const NotificationsGrouperConfig(
+      groupableReasons: {
+        KnownNotificationReason.like,
+        KnownNotificationReason.repost,
+      },
+      window: Duration(hours: 24),
+      separateFollowBacks: true,
+      unreadIfAny: false,
+    ),
+  );
+
+  // Additionally bucket by wall-clock time before grouping.
+  final hourly = notifications.data.groupByHour(3);
+  final byMinute = notifications.data.groupByMinute(30);
+
+  // `GroupBy` can be combined with a config.
+  final legacyHourly = notifications.data.group(
+    by: GroupBy.hour(3),
+    config: const NotificationsGrouperConfig.lenient(),
+  );
+
+  // The grouper is also usable directly.
+  const grouper = NotificationsGrouper(
+    config: NotificationsGrouperConfig.official(),
+  );
+  final GroupedNotifications result = grouper.group(notifications.data);
+}
+
+/* SNIPPET END */
+
+Future<Session> get _session async {
+  final session = await createSession(
+    identifier: 'YOUR_HANDLE_OR_EMAIL',
+    password: 'YOUR_PASSWORD',
+  );
+
+  return session.data;
+}

--- a/website/static/snippets/bluesky/ozone_setup.dart
+++ b/website/static/snippets/bluesky/ozone_setup.dart
@@ -1,0 +1,27 @@
+// ignore_for_file: unused_local_variable, avoid_print
+
+/* SNIPPET START */
+
+import 'package:bluesky/atproto.dart';
+import 'package:bluesky/ozone.dart';
+
+Future<void> main() async {
+  final session = await createSession(
+    identifier: 'YOUR_HANDLE_OR_EMAIL',
+    password: 'YOUR_PASSWORD',
+  );
+
+  // Create OzoneTool instance for moderation tools.
+  final ozone = OzoneTool.fromSession(session.data);
+
+  // Query moderation events.
+  final events = await ozone.moderation.queryEvents(limit: 50);
+
+  // Get details about specific subjects. `subjects` is required.
+  final subjects = await ozone.moderation.getSubjects(
+    subjects: ['did:plc:iijrtk7ocored6zuziwmqq3c'],
+  );
+
+  // Access team management.
+  final teamMembers = await ozone.team.listMembers();
+}

--- a/website/static/snippets/bluesky/pagination.dart
+++ b/website/static/snippets/bluesky/pagination.dart
@@ -1,0 +1,41 @@
+// ignore_for_file: unused_local_variable, avoid_print
+
+// Imports used only by the `_session` helper below the snippet.
+import 'package:bluesky/atproto.dart';
+import 'package:bluesky/core.dart';
+
+/* SNIPPET START */
+
+import 'package:bluesky/bluesky.dart';
+
+Future<void> main() async {
+  final bsky = Bluesky.fromSession(await _session);
+
+  // Pagination is performed on a per-cursor basis.
+  String? nextCursor;
+
+  do {
+    final actors = await bsky.actor.searchActors(
+      q: 'alf',
+      cursor: nextCursor, // If null, it is ignored.
+    );
+
+    for (final actor in actors.data.actors) {
+      print(actor);
+    }
+
+    // Update pagination cursor.
+    nextCursor = actors.data.cursor;
+  } while (nextCursor != null); // If there is no next page, it ends.
+}
+
+/* SNIPPET END */
+
+Future<Session> get _session async {
+  final session = await createSession(
+    identifier: 'YOUR_HANDLE_OR_EMAIL',
+    password: 'YOUR_PASSWORD',
+  );
+
+  return session.data;
+}

--- a/website/static/snippets/bluesky/post_and_delete.dart
+++ b/website/static/snippets/bluesky/post_and_delete.dart
@@ -1,0 +1,22 @@
+// ignore_for_file: unused_local_variable, avoid_print
+
+/* SNIPPET START */
+
+import 'package:bluesky/atproto.dart';
+import 'package:bluesky/bluesky.dart';
+
+Future<void> main() async {
+  final session = await createSession(
+    identifier: 'YOUR_HANDLE_OR_EMAIL',
+    password: 'YOUR_PASSWORD',
+  );
+
+  // Just pass created session data.
+  final bsky = Bluesky.fromSession(session.data);
+
+  // Create a record to specific service like Bluesky.
+  final strongRef = await bsky.feed.post.create(text: 'Hello, Bluesky!');
+
+  // And delete it. `uri` is already an `AtUri`.
+  await bsky.feed.post.delete(rkey: strongRef.data.uri.rkey);
+}

--- a/website/static/snippets/bluesky/rate_limits.dart
+++ b/website/static/snippets/bluesky/rate_limits.dart
@@ -1,0 +1,43 @@
+// ignore_for_file: unused_local_variable, avoid_print
+
+// Imports used only by the `_session` helper below the snippet.
+import 'package:bluesky/atproto.dart';
+import 'package:bluesky/core.dart';
+
+/* SNIPPET START */
+
+import 'package:bluesky/bluesky.dart';
+
+Future<void> main() async {
+  final bsky = Bluesky.fromSession(await _session);
+
+  final response = await bsky.feed.getTimeline();
+
+  // This is rate limit!
+  final rateLimit = response.rateLimit;
+
+  // Available properties.
+  print(rateLimit.limitCount);
+  print(rateLimit.remainingCount);
+  print(rateLimit.resetAt);
+  print(rateLimit.policy);
+
+  // When you need to handle rate limits.
+  print(rateLimit.isExceeded);
+  print(rateLimit.isNotExceeded);
+
+  // It waits until the rate limit is reset based on resetAt.
+  // If the rate limit is not exceeded, it returns immediately.
+  await rateLimit.waitUntilReset();
+}
+
+/* SNIPPET END */
+
+Future<Session> get _session async {
+  final session = await createSession(
+    identifier: 'YOUR_HANDLE_OR_EMAIL',
+    password: 'YOUR_PASSWORD',
+  );
+
+  return session.data;
+}

--- a/website/static/snippets/bluesky/retry.dart
+++ b/website/static/snippets/bluesky/retry.dart
@@ -1,0 +1,34 @@
+// ignore_for_file: unused_local_variable, avoid_print
+
+/* SNIPPET START */
+
+import 'package:bluesky/bluesky.dart';
+import 'package:bluesky/core.dart' as core;
+
+Future<void> main() async {
+  final bsky = Bluesky.anonymous(
+    // Add this.
+    retryConfig: core.RetryConfig(
+      // Required.
+      // You can set count of attempts.
+      maxAttempts: 3,
+
+      // Optional.
+      // Jitter can be specified as you want.
+      jitter: core.Jitter(maxInSeconds: 10, minInSeconds: 5),
+
+      // Optional.
+      // By default a procedure (`POST`) is *not* retried after an ambiguous
+      // failure the server may already have applied. Opt back in only if the
+      // request is safe to duplicate.
+      retryProcedureOnAmbiguousFailure: false,
+
+      // Optional.
+      // You can define the events that occur when Retry is executed.
+      onExecute: (event) => print(
+        'Retry after ${event.intervalInSeconds} seconds...'
+        '[${event.retryCount} times]',
+      ),
+    ),
+  );
+}

--- a/website/static/snippets/bluesky/retry_strategy.dart
+++ b/website/static/snippets/bluesky/retry_strategy.dart
@@ -1,0 +1,28 @@
+// ignore_for_file: unused_local_variable, avoid_print
+
+/* SNIPPET START */
+
+import 'package:bluesky/bluesky.dart';
+import 'package:bluesky/core.dart' as core;
+
+/// `retryConfig` accepts any `RetryStrategy`, so the backoff curve and the
+/// decision of *what* to retry are both yours to define.
+class FixedDelayRetry implements core.RetryStrategy {
+  const FixedDelayRetry({this.maxAttempts = 3});
+
+  final int maxAttempts;
+
+  @override
+  Duration? nextDelay(final core.RetryContext context) {
+    if (context.attempt > maxAttempts) return null;
+
+    // Never repeat a write the server may already have applied.
+    if (context.isProcedure && context.isAmbiguous) return null;
+
+    return const Duration(seconds: 2);
+  }
+}
+
+Future<void> main() async {
+  final bsky = Bluesky.anonymous(retryConfig: const FixedDelayRetry());
+}

--- a/website/static/snippets/bluesky/serialization.dart
+++ b/website/static/snippets/bluesky/serialization.dart
@@ -1,0 +1,23 @@
+// ignore_for_file: unused_local_variable, avoid_print
+
+/* SNIPPET START */
+
+import 'package:bluesky/bluesky.dart';
+import 'package:bluesky/com_atproto_identity_resolvehandle.dart';
+
+Future<void> main() async {
+  final bsky = Bluesky.anonymous();
+
+  // Just find the DID of `shinyakato.dev`.
+  final did = await bsky.atproto.identity.resolveHandle(
+    handle: 'shinyakato.dev',
+  );
+
+  // `did` is an `XRPCResponse`; the model object lives in `.data`.
+  // => {did: did:plc:iijrtk7ocored6zuziwmqq3c}
+  final json = did.data.toJson();
+  print(json);
+
+  // And back again.
+  final restored = IdentityResolveHandleOutput.fromJson(json);
+}

--- a/website/static/snippets/bluesky/service_access.dart
+++ b/website/static/snippets/bluesky/service_access.dart
@@ -1,0 +1,20 @@
+// ignore_for_file: unused_local_variable, avoid_print
+
+/* SNIPPET START */
+
+import 'package:bluesky/atproto.dart';
+import 'package:bluesky/bluesky.dart';
+
+Future<void> main() async {
+  final session = await createSession(
+    identifier: 'YOUR_HANDLE_OR_EMAIL',
+    password: 'YOUR_PASSWORD',
+  );
+
+  // Just pass created session data.
+  final bsky = Bluesky.fromSession(session.data);
+
+  final timeline = await bsky.feed.getTimeline();
+
+  print(timeline);
+}

--- a/website/static/snippets/bluesky/session_management.dart
+++ b/website/static/snippets/bluesky/session_management.dart
@@ -1,0 +1,23 @@
+// ignore_for_file: unused_local_variable, avoid_print
+
+/* SNIPPET START */
+
+import 'package:bluesky/atproto.dart';
+import 'package:bluesky/bluesky.dart';
+
+Future<void> main() async {
+  final session = await createSession(
+    identifier: 'HANDLE_OR_EMAIL', // Like shinyakato.dev
+    password: 'PASSWORD', // App Password is recommended
+  );
+
+  print(session);
+
+  // You can create Bluesky object from authenticated session.
+  final bsky = Bluesky.fromSession(session.data);
+
+  // Do something with bluesky.
+  final did = await bsky.atproto.identity.resolveHandle(
+    handle: session.data.handle,
+  );
+}

--- a/website/static/snippets/bluesky/timeline.dart
+++ b/website/static/snippets/bluesky/timeline.dart
@@ -1,0 +1,41 @@
+// ignore_for_file: unused_local_variable, avoid_print
+
+// Imports used only by the `_session` helper below the snippet.
+import 'package:bluesky/atproto.dart';
+
+/* SNIPPET START */
+
+import 'package:bluesky/bluesky.dart';
+import 'package:bluesky/core.dart';
+
+Future<void> main() async {
+  final bsky = Bluesky.fromSession(await _session);
+
+  // Get user timeline.
+  final timeline = await bsky.feed.getTimeline(limit: 50);
+  for (final feed in timeline.data.feed) {
+    print('${feed.post.author.displayName}: ${feed.post.record}');
+  }
+
+  // Get author feed.
+  final authorFeed = await bsky.feed.getAuthorFeed(
+    actor: 'shinyakato.dev',
+    limit: 20,
+  );
+
+  // Get post thread. `uri` is an `AtUri`.
+  final thread = await bsky.feed.getPostThread(
+    uri: AtUri('at://did:plc:example/app.bsky.feed.post/example'),
+  );
+}
+
+/* SNIPPET END */
+
+Future<Session> get _session async {
+  final session = await createSession(
+    identifier: 'YOUR_HANDLE_OR_EMAIL',
+    password: 'YOUR_PASSWORD',
+  );
+
+  return session.data;
+}

--- a/website/static/snippets/bluesky/timeout.dart
+++ b/website/static/snippets/bluesky/timeout.dart
@@ -1,0 +1,12 @@
+// ignore_for_file: unused_local_variable, avoid_print
+
+/* SNIPPET START */
+
+import 'package:bluesky/bluesky.dart';
+
+Future<void> main() async {
+  final bsky = Bluesky.anonymous(
+    // Add this.
+    timeout: Duration(seconds: 20),
+  );
+}

--- a/website/static/snippets/bluesky/union_types.dart
+++ b/website/static/snippets/bluesky/union_types.dart
@@ -1,0 +1,61 @@
+// ignore_for_file: unused_local_variable, avoid_print
+
+/* SNIPPET START */
+
+import 'package:bluesky/app_bsky_feed_defs.dart';
+
+// `when` requires a callback for every case, including `unknown`.
+void handlePostEmbed(UPostViewEmbed? embed) {
+  embed?.when(
+    embedImagesView: (images) {
+      print('Post has ${images.images.length} images');
+      for (final image in images.images) {
+        print('Image: ${image.alt} - ${image.thumb}');
+      }
+    },
+    embedVideoView: (video) {
+      print('Video: ${video.playlist}');
+      print('Alt text: ${video.alt}');
+    },
+    embedGalleryView: (gallery) {
+      print('Gallery with ${gallery.items.length} item(s)');
+    },
+    embedExternalView: (external) {
+      print('External link: ${external.external.title}');
+      print('URL: ${external.external.uri}');
+    },
+    embedRecordView: (record) {
+      print('Quoted post: ${record.record}');
+    },
+    embedRecordWithMediaView: (recordWithMedia) {
+      print('Quote post with media');
+    },
+    unknown: (data) {
+      // Handle future embed types gracefully.
+      print('Unknown embed type: ${data.runtimeType}');
+    },
+  );
+}
+
+// Union types are sealed classes, so a `switch` is exhaustive without a
+// `default` clause once every case is listed.
+void handlePostEmbedWithPatternMatching(UPostViewEmbed? embed) {
+  switch (embed) {
+    case UPostViewEmbedEmbedImagesView():
+      print('Images embed with ${embed.data.images.length} images');
+    case UPostViewEmbedEmbedVideoView():
+      print('Video embed: ${embed.data.alt}');
+    case UPostViewEmbedEmbedGalleryView():
+      print('Gallery embed with ${embed.data.items.length} item(s)');
+    case UPostViewEmbedEmbedExternalView():
+      print('External link: ${embed.data.external.title}');
+    case UPostViewEmbedEmbedRecordView():
+      print('Record embed: ${embed.data.record}');
+    case UPostViewEmbedEmbedRecordWithMediaView():
+      print('Record with media embed');
+    case UPostViewEmbedUnknown():
+      print('Unknown embed: ${embed.data}');
+    case null:
+      print('No embed');
+  }
+}

--- a/website/static/snippets/bluesky/unknown_inputs.dart
+++ b/website/static/snippets/bluesky/unknown_inputs.dart
@@ -1,0 +1,33 @@
+// ignore_for_file: unused_local_variable, avoid_print
+
+// Imports used only by the `_session` helper below the snippet.
+import 'package:bluesky/atproto.dart';
+import 'package:bluesky/core.dart';
+
+/* SNIPPET START */
+
+import 'package:bluesky/bluesky.dart';
+
+Future<void> main() async {
+  final bsky = Bluesky.fromSession(await _session);
+
+  final ref = await bsky.feed.post.create(
+    text: 'This is where I post from',
+
+    // Use `$unknown` parameter.
+    $unknown: {r'$via': 'atproto.dart'},
+  );
+
+  print(ref);
+}
+
+/* SNIPPET END */
+
+Future<Session> get _session async {
+  final session = await createSession(
+    identifier: 'YOUR_HANDLE_OR_EMAIL',
+    password: 'YOUR_PASSWORD',
+  );
+
+  return session.data;
+}

--- a/website/static/snippets/bluesky_text/basic.dart
+++ b/website/static/snippets/bluesky_text/basic.dart
@@ -1,0 +1,32 @@
+// ignore_for_file: unused_local_variable, avoid_print
+
+/* SNIPPET START */
+
+import 'package:bluesky_text/bluesky_text.dart';
+
+void main() {
+  // You just need to pass the text to analyze.
+  final text = BlueskyText(
+    'I speak 日本語 and English 🚀 @shinyakato.dev and @shinyakato.bsky.social. '
+    'Visit 🚀 https://shinyakato.dev #dart',
+  );
+
+  print(text.value); // The original text.
+  print(text.length); // Counted in grapheme clusters, so 🚀 is 1.
+
+  for (final entity in text.entities) {
+    // `type` is a handle, link, tag, cashtag or markdownLink.
+    // `value` has its marker stripped: `shinyakato.dev`, not `@shinyakato.dev`.
+    // `indices` are UTF-8 byte offsets, ready for a facet `byteSlice`.
+    print(
+      '${entity.type}: ${entity.value} '
+      '(${entity.indices.start}-${entity.indices.end})',
+    );
+  }
+
+  // Or narrow it down to a single kind.
+  print(text.handles);
+  print(text.links);
+  print(text.tags);
+  print(text.cashtags);
+}

--- a/website/static/snippets/bluesky_text/compose_ui.dart
+++ b/website/static/snippets/bluesky_text/compose_ui.dart
@@ -1,0 +1,33 @@
+// ignore_for_file: unused_local_variable, avoid_print
+
+/* SNIPPET START */
+
+import 'package:bluesky_text/bluesky_text.dart';
+
+void main() {
+  final text = BlueskyText('Hello @shinyakato.dev ${'a' * 320}');
+
+  // Measure what is actually posted, not the raw input.
+  final post = text.formatted;
+
+  final overflow = post.overflow;
+  if (overflow != null) {
+    // Which limit was hit first: `LengthLimit.grapheme` or `LengthLimit.byte`.
+    print(overflow.limit);
+
+    //! The offsets index into `post.value`, whose offsets differ from the raw
+    //! `text.value` after formatting.
+    final within = post.value.substring(0, overflow.utf16Start);
+    final exceeded = post.value.substring(overflow.utf16Start);
+  }
+
+  // A gap-free partition of the value, ready to become a `TextSpan` tree:
+  // every segment knows whether it is an entity and whether it overflows.
+  for (final segment in post.segments) {
+    if (segment.isOverflow) {
+      print('over limit: ${segment.text}');
+    } else if (segment.isEntity) {
+      print('${segment.type}: ${segment.text}');
+    }
+  }
+}

--- a/website/static/snippets/bluesky_text/facets.dart
+++ b/website/static/snippets/bluesky_text/facets.dart
@@ -1,0 +1,34 @@
+// ignore_for_file: unused_local_variable, avoid_print
+
+/* SNIPPET START */
+
+import 'package:bluesky_text/bluesky_text.dart';
+
+Future<void> main() async {
+  final text = BlueskyText(
+    'I speak 日本語 and English 🚀 @shinyakato.dev and @shinyakato.bsky.social. '
+    'Visit 🚀 https://shinyakato.dev',
+  );
+
+  //! Format first: markdown links become link facets only after formatting,
+  //! and the byte offsets of the raw text do not match the posted text.
+  final post = text.formatted;
+
+  // Facets as JSON maps, ready for `RichtextFacet.fromJson`.
+  final facets = await post.entities.toFacets();
+  print(facets);
+
+  // The same call, plus the handles that failed to resolve to a DID.
+  final result = await post.entities.toFacetsResult();
+  print(result.facets);
+  print(result.unresolvedHandles);
+
+  // Resolution is a network lookup per mention, so inject your own resolver
+  // to serve cached DIDs (or to avoid network access entirely in tests).
+  final cached = await post.entities.toFacetsResult(
+    resolver: (handle) async => switch (handle) {
+      'shinyakato.dev' => 'did:plc:iijrtk7ocored6zuziwmqq3c',
+      _ => null,
+    },
+  );
+}

--- a/website/static/snippets/bluesky_text/formatting.dart
+++ b/website/static/snippets/bluesky_text/formatting.dart
@@ -1,0 +1,27 @@
+// ignore_for_file: unused_local_variable, avoid_print
+
+/* SNIPPET START */
+
+import 'package:bluesky_text/bluesky_text.dart';
+
+void main() {
+  final text = BlueskyText(
+    'Check [this link](https://atprotodart.com/docs/packages/bluesky_text)!',
+    // Drops `https://` and shortens long URLs when formatting.
+    linkConfig: const LinkConfig(excludeProtocol: true, enableShortening: true),
+  );
+
+  // The raw text still contains the markdown syntax and the full URL.
+  print(text.value);
+
+  // `formatted` is the posting-ready form: markdown expanded, links shortened.
+  // `format()` returns the same memoized instance.
+  print(text.formatted.value);
+
+  // Markdown handling can be turned off entirely.
+  final plain = BlueskyText(
+    'Check [this link](https://atprotodart.com)!',
+    enableMarkdown: false,
+  );
+  print(plain.formatted.value);
+}

--- a/website/static/snippets/bluesky_text/post.dart
+++ b/website/static/snippets/bluesky_text/post.dart
@@ -1,0 +1,36 @@
+// ignore_for_file: unused_local_variable, avoid_print
+
+/* SNIPPET START */
+
+import 'package:bluesky/app_bsky_richtext_facet.dart';
+import 'package:bluesky/atproto.dart';
+import 'package:bluesky/bluesky.dart';
+import 'package:bluesky_text/bluesky_text.dart';
+
+Future<void> main() async {
+  final session = await createSession(
+    identifier: 'shinyakato.dev',
+    password: 'xxxxxxxx',
+  );
+
+  final bsky = Bluesky.fromSession(session.data);
+
+  final text = BlueskyText(
+    'Hello, I am @shinyakato.dev! '
+    'wdyt about [this link](https://atprotodart.com)?',
+  );
+
+  // Formats the text and resolves its facets in one call.
+  final post = await text.toPostData();
+
+  // Handles that could not be resolved to a DID are reported instead of being
+  // silently dropped, so you can warn the user before posting.
+  if (post.unresolvedHandles.isNotEmpty) {
+    print('Could not resolve: ${post.unresolvedHandles}');
+  }
+
+  await bsky.feed.post.create(
+    text: post.text,
+    facets: post.facets.map(RichtextFacet.fromJson).toList(),
+  );
+}

--- a/website/static/snippets/bluesky_text/render_facets.dart
+++ b/website/static/snippets/bluesky_text/render_facets.dart
@@ -1,0 +1,35 @@
+// ignore_for_file: unused_local_variable, avoid_print
+
+/* SNIPPET START */
+
+import 'package:bluesky_text/bluesky_text.dart';
+
+void main() {
+  // The `text` and `facets` of a post you fetched from the API.
+  const postText = 'Hello, I am shinyakato.dev!';
+  final rawFacets = <Map<String, dynamic>>[
+    {
+      'index': {'byteStart': 12, 'byteEnd': 26},
+      'features': [
+        {
+          r'$type': 'app.bsky.richtext.facet#mention',
+          'did': 'did:plc:iijrtk7ocored6zuziwmqq3c',
+        },
+      ],
+    },
+  ];
+
+  final facets = rawFacets.map(PostFacet.fromJson).toList();
+
+  // Partitions the text using the author's own facets instead of re-detecting
+  // entities, so mentions already carry their resolved DID.
+  for (final segment in renderFacets(postText, facets)) {
+    final feature = segment.feature;
+
+    if (feature == null) {
+      print('plain: ${segment.text}');
+    } else {
+      print('${feature.type}: ${segment.text} -> ${feature.value}');
+    }
+  }
+}

--- a/website/static/snippets/bluesky_text/split.dart
+++ b/website/static/snippets/bluesky_text/split.dart
@@ -1,0 +1,25 @@
+// ignore_for_file: unused_local_variable, avoid_print
+
+/* SNIPPET START */
+
+import 'package:bluesky/app_bsky_richtext_facet.dart';
+import 'package:bluesky/bluesky.dart';
+import 'package:bluesky_text/bluesky_text.dart';
+
+Future<void> post(final Bluesky bsky) async {
+  final text = BlueskyText('a' * 301);
+
+  // True when the text exceeds 300 graphemes *or* 3000 UTF-8 bytes.
+  if (text.isNotLengthLimitExceeded) return;
+
+  // Splits on token boundaries, respecting both limits. Each chunk is a raw,
+  // independently formattable `BlueskyText`.
+  for (final chunk in text.split()) {
+    final data = await chunk.toPostData();
+
+    await bsky.feed.post.create(
+      text: data.text,
+      facets: data.facets.map(RichtextFacet.fromJson).toList(),
+    );
+  }
+}


### PR DESCRIPTION
Stacked on #2483, which introduced the snippet mechanism this PR uses. Review that one first.

Converts the three remaining hand-written package pages to verified snippets and fixes what the audit found. 78 new snippets, every one compiled by `dart analyze`.

## Code

Roughly one example in four across these pages did not compile. The dominant cause was the **`String` → `AtUri` migration** in generated signatures: `RepoCreateRecordOutput.uri` is already an `AtUri`, so wrapping it in `AtUri(...)` is a type error, while `getPostThread`, `getLikes` and `getRepostedBy` require `AtUri` where the docs passed strings — and `EmbedExternalExternal.uri` is the reverse.

The rest:

- Symbols that never existed: a `DID` class, `ids.blob`, `KnownReasonType.reasonSpam`
- `UPostViewEmbed.when` omitted the required `embedGalleryView` case
- `ozone.moderation.getSubjects` was called without its required `subjects`
- Extensions imported behind a prefix never apply in Dart, so the moderation and viewer-state examples referenced members the compiler could not see
- A private `package:bluesky/src/...` import where a public library exists
- Chat examples that were never self-contained

## Prose drifted further than the code

The **retry documentation was materially wrong in four ways**, which matters because it is what readers use to reason about data durability:

| Claim | Reality |
|---|---|
| Retry is fixed built-in behavior | `RetryStrategy` is pluggable; `RetryConfig` is just the default impl |
| 429 is not retried | It is — `challenge.dart` maps it to `RetryReason.rateLimited` and honors `Retry-After` |
| `SocketException` is not retried | It is — `RetryReason.network` |
| (unmentioned) | The idempotency guard: a POST is **not** retried after an ambiguous failure. A reader would expect `createRecord` to retry on a 500; by default it does not |

One further correction surfaced during the work: retries are **opt-in**, not always-on. `Challenge` holds a nullable strategy and skips retrying entirely when `retryConfig` is omitted, but the pages read as though exponential backoff was always active.

Also drops the false **"Zero Dependency"** claim from all three pages (`atproto` has 4 runtime deps, `bluesky` 5, `bluesky_text` 4), completes the service tables (`admin`, `lexicon`, `ageassurance`, `bookmark`, `contact`, `draft`; `sync` and `video` are the `*Impl` types), and softens the "all endpoints" claims that `BlueskyChat` and `OzoneTool` do not actually meet.

## Shipped features the docs never mentioned

Notification grouping (a headline 2.1.0 feature with zero coverage), the OAuth constructors, `subscribeReposAsMessages` — which replaces the manual adaptor pattern both Firehose examples taught — `RetryStrategy`, the `getClient`/`postClient` injection hooks, `cardyb` link previews, `toPostData()`, and `getLabelerHeaders`, without which the documented moderation flow silently returns unlabelled feeds.

## The mechanism earned its keep immediately

Two defects were found **only because the snippets now compile**: `KnownReasonType.reasonSpam` (the real constant is `comAtprotoModerationDefsReasonSpam`) and an extension-visibility trap on `hasBlocking`/`isBlockedBy`. Neither appeared in the manual audit that preceded this work.

## Verification

- `dart analyze` clean across all 86 snippets; `dart format` clean
- `gen_doc_snippets.dart` re-runs with zero diff, so the committed markdown matches its sources
- `npm run build` passes

`website/pubspec.yaml` gains `atproto` (path) and `http`, the latter because `GetClient`/`PostClient` are typed to return `http.Response` and the injection snippet cannot compile without naming it.

## Remaining

PR-3 covers structure: the missing `bluesky_cli` and `at_primitives` pages, the `overview.md` dependency graph (which omits the `atproto_oauth → atproto_core` edge and renders the identity packages as a disconnected island), and the ~600 lines of cross-cutting content duplicated between `atproto.md` and `bluesky.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)