### PR TITLE
fix(bluesky): refresh expired sessions on app.bsky.* calls

### DIFF
--- a/packages/atproto/CHANGELOG.md
+++ b/packages/atproto/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Note
 
+## v2.1.0
+
+- feat: added `ATProto.ctx`, exposing the `ServiceContext` that backs every service. A wrapping client can now drive its own services from the same context instead of constructing a second one, which is required for correct session refresh because refresh tokens are single-use.
+
 ## v2.0.1
 
 - docs: documented OAuth authentication in the README — `ATProto.fromOAuth(OAuthSessionManager)`, `ATProto.fromOAuthSession(session, {oauthClient})`, and the renamed `oAuthSessionManager` getter.

--- a/packages/atproto/lib/src/atproto.dart
+++ b/packages/atproto/lib/src/atproto.dart
@@ -164,6 +164,16 @@ sealed class ATProto {
   /// Defaults to `bsky.network`.
   String get relayService;
 
+  /// Returns the context backing every service on this instance.
+  ///
+  /// Exposed so a wrapping client — `bluesky` in particular — can drive its
+  /// own services from this same context instead of building a second one.
+  /// That matters for [ATProto.fromSession]: the context owns the current
+  /// session and the `refreshSession` call that rotates it, and refresh
+  /// tokens are single-use. Two contexts would each hold their own copy of
+  /// the session, so whichever refreshed second would present a spent token.
+  core.ServiceContext get ctx;
+
   /// Returns the admin service.
   /// This service represents `com.atproto.admin.*`.
   AdminService get admin;
@@ -301,6 +311,9 @@ final class _ATProto implements ATProto {
   final TempService temp;
 
   final core.ServiceContext _ctx;
+
+  @override
+  core.ServiceContext get ctx => _ctx;
 
   @override
   Future<core.XRPCResponse<T>> get<T>(

--- a/packages/atproto/pubspec.yaml
+++ b/packages/atproto/pubspec.yaml
@@ -1,7 +1,7 @@
 name: atproto
 resolution: workspace
 description: The most famous and powerful Dart/Flutter library for AT Protocol.
-version: 2.0.1
+version: 2.1.0
 homepage: https://atprotodart.com
 documentation: https://atprotodart.com/docs/packages/atproto
 repository: https://github.com/myConsciousness/atproto.dart/tree/main/packages/atproto

--- a/packages/bluesky/CHANGELOG.md
+++ b/packages/bluesky/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release Note
 
+## v2.1.2
+
+- fix: `app.bsky.*` and `chat.bsky.*` calls now refresh an expired access token instead of throwing `UnauthorizedException`. `Bluesky.fromSession` built a second `ServiceContext` for those services and never gave it the refresh hook, so only calls made through `bsky.atproto` recovered from an expired token. Every factory now shares the context owned by the nested `ATProto`, which also makes `bsky.session` reflect a refresh — previously it kept returning the spent credentials, so persisting it signed the user out on next launch. The OAuth factories were unaffected, since both contexts already shared one `OAuthSessionManager`.
+- chore: bump `atproto` to `^2.1.0`.
+
 ## v2.1.1
 
 - feat: added `app.bsky.graph.searchStarterPacksV2`

--- a/packages/bluesky/lib/src/bluesky.dart
+++ b/packages/bluesky/lib/src/bluesky.dart
@@ -24,18 +24,7 @@ sealed class Bluesky {
     final core.RetryStrategy? retryConfig,
     final core.GetClient? getClient,
     final core.PostClient? postClient,
-  }) => _Bluesky(
-    core.ServiceContext(
-      headers: headers,
-      protocol: protocol,
-      service: service,
-      relayService: relayService,
-      session: session,
-      timeout: timeout,
-      retryConfig: retryConfig,
-      getClient: getClient,
-      postClient: postClient,
-    ),
+  }) => _Bluesky.fromAtproto(
     atp.ATProto.fromSession(
       headers: headers,
       session,
@@ -61,18 +50,7 @@ sealed class Bluesky {
     final core.RetryStrategy? retryConfig,
     final core.GetClient? getClient,
     final core.PostClient? postClient,
-  }) => _Bluesky(
-    core.ServiceContext(
-      headers: headers,
-      protocol: protocol,
-      service: service,
-      relayService: relayService,
-      oAuthSessionManager: manager,
-      timeout: timeout,
-      retryConfig: retryConfig,
-      getClient: getClient,
-      postClient: postClient,
-    ),
+  }) => _Bluesky.fromAtproto(
     atp.ATProto.fromOAuth(
       manager,
       headers: headers,
@@ -123,17 +101,7 @@ sealed class Bluesky {
     final core.RetryStrategy? retryConfig,
     final core.GetClient? getClient,
     final core.PostClient? postClient,
-  }) => _Bluesky(
-    core.ServiceContext(
-      headers: headers,
-      protocol: protocol,
-      service: service,
-      relayService: relayService,
-      timeout: timeout,
-      retryConfig: retryConfig,
-      getClient: getClient,
-      postClient: postClient,
-    ),
+  }) => _Bluesky.fromAtproto(
     atp.ATProto.anonymous(
       headers: headers,
       protocol: protocol,
@@ -218,7 +186,14 @@ sealed class Bluesky {
 }
 
 final class _Bluesky implements Bluesky {
-  _Bluesky(final core.ServiceContext ctx, this.atproto)
+  /// Drives every `app.bsky.*` service from [atproto]'s own context.
+  ///
+  /// A second context would carry a second copy of the session, and only one
+  /// of the two would ever be refreshed — see [atp.ATProto.ctx].
+  factory _Bluesky.fromAtproto(final atp.ATProto atproto) =>
+      _Bluesky._(atproto.ctx, atproto);
+
+  _Bluesky._(final core.ServiceContext ctx, this.atproto)
     : actor = ActorService(ctx),
       ageassurance = AgeassuranceService(ctx),
       feed = FeedService(ctx),

--- a/packages/bluesky/pubspec.yaml
+++ b/packages/bluesky/pubspec.yaml
@@ -1,7 +1,7 @@
 name: bluesky
 resolution: workspace
 description: The most famous and powerful Dart/Flutter library for Bluesky Social.
-version: 2.1.1
+version: 2.1.2
 homepage: https://atprotodart.com
 documentation: https://atprotodart.com/docs/packages/bluesky
 repository: https://github.com/myConsciousness/atproto.dart/tree/main/packages/bluesky
@@ -19,7 +19,7 @@ topics:
 
 dependencies:
   atproto_core: ^2.0.1
-  atproto: ^2.0.1
+  atproto: ^2.1.0
   freezed_annotation: ^3.1.0
   json_annotation: ^4.9.0
   characters: ^1.4.0

--- a/packages/bluesky/test/src/bluesky_test.dart
+++ b/packages/bluesky/test/src/bluesky_test.dart
@@ -1,6 +1,7 @@
 // Package imports:
 import 'package:atproto/atproto.dart';
 import 'package:atproto_core/atproto_core.dart' as core;
+import 'package:http/http.dart' as http;
 import 'package:test/test.dart';
 
 // Project imports:
@@ -8,6 +9,104 @@ import 'package:bluesky/app_bsky_services.dart';
 import 'package:bluesky/src/bluesky.dart';
 
 void main() {
+  group('.session (auto refresh)', () {
+    test('refreshes an expired access token on an app.bsky.* call', () async {
+      final refreshAuthHeaders = <String?>[];
+      final getAuthHeaders = <String?>[];
+
+      final bsky = Bluesky.fromSession(
+        core.Session(
+          did: 'did:plc:testaccount',
+          handle: 'test.dev',
+          //! Non-JWT token so the pre-flight refresh is skipped and the
+          //! reactive 401 path is exercised.
+          accessJwt: 'old-access',
+          refreshJwt: 'refresh-token',
+        ),
+        service: 'pds.test',
+        getClient: (url, {headers}) async {
+          getAuthHeaders.add(headers?['Authorization']);
+
+          if (headers?['Authorization'] == 'Bearer new-access') {
+            return http.Response(
+              '{"feed":[]}',
+              200,
+              headers: {'content-type': 'application/json'},
+              request: http.Request('GET', url),
+            );
+          }
+
+          return http.Response(
+            '{"error":"ExpiredToken"}',
+            401,
+            headers: {'content-type': 'application/json'},
+            request: http.Request('GET', url),
+          );
+        },
+        postClient: (url, {headers, body, encoding}) async {
+          //! The only POST expected here is the refreshSession call.
+          expect(url.path, contains('com.atproto.server.refreshSession'));
+          refreshAuthHeaders.add(headers?['Authorization']);
+
+          return http.Response(
+            '{"accessJwt":"new-access","refreshJwt":"new-refresh",'
+            '"handle":"test.dev","did":"did:plc:testaccount"}',
+            200,
+            headers: {'content-type': 'application/json'},
+            request: http.Request('POST', url),
+          );
+        },
+      );
+
+      final response = await bsky.feed.getTimeline();
+
+      expect(response.status.code, 200);
+      expect(refreshAuthHeaders, ['Bearer refresh-token']);
+      //! The `app.bsky.*` request failed with the old token, then succeeded
+      //! after the refresh with the new one.
+      expect(getAuthHeaders, ['Bearer old-access', 'Bearer new-access']);
+    });
+
+    test(
+      'exposes the refreshed session on both bsky and bsky.atproto',
+      () async {
+        final bsky = Bluesky.fromSession(
+          core.Session(
+            did: 'did:plc:testaccount',
+            handle: 'test.dev',
+            accessJwt: 'old-access',
+            refreshJwt: 'refresh-token',
+          ),
+          service: 'pds.test',
+          getClient: (url, {headers}) async => http.Response(
+            headers?['Authorization'] == 'Bearer new-access'
+                ? '{"feed":[]}'
+                : '{"error":"ExpiredToken"}',
+            headers?['Authorization'] == 'Bearer new-access' ? 200 : 401,
+            headers: {'content-type': 'application/json'},
+            request: http.Request('GET', url),
+          ),
+          postClient: (url, {headers, body, encoding}) async => http.Response(
+            '{"accessJwt":"new-access","refreshJwt":"new-refresh",'
+            '"handle":"test.dev","did":"did:plc:testaccount"}',
+            200,
+            headers: {'content-type': 'application/json'},
+            request: http.Request('POST', url),
+          ),
+        );
+
+        await bsky.feed.getTimeline();
+
+        //! Both views must agree: a caller persisting `bsky.session` would
+        //! otherwise store a refresh token that has already been spent.
+        expect(bsky.session?.accessJwt, 'new-access');
+        expect(bsky.session?.refreshJwt, 'new-refresh');
+        expect(bsky.atproto.session?.accessJwt, 'new-access');
+        expect(bsky.atproto.session?.refreshJwt, 'new-refresh');
+      },
+    );
+  });
+
   group('.session', () {
     test('fromSession', () {
       final session = core.Session(


### PR DESCRIPTION
## Problem

`Bluesky.fromSession` builds two `ServiceContext`s — one for the `app.bsky.*` / `chat.bsky.*` services, one inside the nested `ATProto` — and only the latter receives `onRefreshSession`. An expired access token therefore behaves differently depending on which client you reach through:

```dart
final bsky = Bluesky.fromSession(session);

await bsky.atproto.repo.createRecord(...); // refreshed and retried
await bsky.feed.getTimeline();             // throws UnauthorizedException
```

`ServiceContext._onUnauthorized` returns `false` when `onRefreshSession` is null, and `_maybeRefreshBeforeSend` returns early, so neither the reactive 401 path nor the pre-flight refresh runs for `app.bsky.*`.

There is a second, quieter consequence. `bsky.session` reads from the Bluesky context, so it keeps returning the original credentials even after `bsky.atproto` has refreshed. An app that persists `bsky.session` writes a refresh token that has already been spent, and signs the user out on next launch.

`git log -S onRefreshSession` points at `7ac54cf86`, which added the hook to `atproto` and did not carry it across to `bluesky`.

## Why not just pass the same callback to both

Refresh tokens are single-use. Two contexts each holding their own copy of the session would race — whichever refreshed second would present a token that had already been rotated away. The contexts have to be one.

## Fix

Every `Bluesky` factory now hands `_Bluesky` the context owned by the nested `ATProto`, instead of building a second one. The two were already constructed with identical arguments apart from the refresh hook, so this removes a duplicate rather than changing behaviour anywhere else. `ATProto` gains a `ctx` getter to make it reachable.

The OAuth factories were never affected: both contexts already shared one `OAuthSessionManager`, which owns refresh for that path. They are included in the change only because the duplicate context went away everywhere.

## Versioning

- `atproto` 2.0.1 → **2.1.0**. `ctx` is a new public member; adding one to a `sealed` class is not breaking for implementers, so this is a minor bump.
- `bluesky` 2.1.1 → **2.1.2**, with its `atproto` constraint moved to `^2.1.0`.

`dart run scripts/validate_dependencies.dart` passes.

## Tests

Two regression tests in `packages/bluesky/test/src/bluesky_test.dart`, both failing before the change and passing after:

- an `app.bsky.*` call that 401s refreshes and retries, asserted on the exact `Authorization` headers seen by the mocked transport
- `bsky.session` and `bsky.atproto.session` both report the rotated credentials

Full suites green: `atproto_core` 131, `atproto` 388, `bluesky` 871. `dart analyze` clean on both changed packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)