### PR TITLE
feat: announce refreshed sessions; refresh on chat.bsky.* and tools.ozone.*

### DIFF
--- a/packages/atproto/CHANGELOG.md
+++ b/packages/atproto/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release Note
 
+## v2.2.0
+
+- feat: added `ATProto.onSessionUpdated`, surfacing `ServiceContext.onSessionUpdated` so callers can re-persist credentials rotated by an automatic refresh. Without it an app that persists the session it constructed the client with ends up storing a spent refresh token, since refresh tokens are single-use.
+- chore: bump `atproto_core` to `^2.1.0`.
+
 ## v2.1.0
 
 - feat: added `ATProto.ctx`, exposing the `ServiceContext` that backs every service. A wrapping client can now drive its own services from the same context instead of constructing a second one, which is required for correct session refresh because refresh tokens are single-use.

--- a/packages/atproto/lib/src/atproto.dart
+++ b/packages/atproto/lib/src/atproto.dart
@@ -150,6 +150,23 @@ sealed class ATProto {
   /// [ATProto.fromSession], otherwise null.
   core.Session? get session;
 
+  /// Emits the refreshed session every time an expired access token is
+  /// renewed, so the owner of the credentials can re-persist them.
+  ///
+  /// [ATProto.fromSession] refreshes automatically, and [session] then holds
+  /// the new credentials — but nothing otherwise tells the caller to read it
+  /// back. Because refresh tokens are single-use, persisting the session
+  /// originally passed in would store a spent refresh token, and the next run
+  /// would restore a session that can no longer be refreshed.
+  ///
+  /// ```dart
+  /// atproto.onSessionUpdated.listen(store.save);
+  /// ```
+  ///
+  /// Silent on OAuth-backed instances; use
+  /// `oAuthSessionManager.onSessionUpdated` for those.
+  Stream<core.Session> get onSessionUpdated;
+
   /// Returns the current OAuth session manager.
   ///
   /// Set only when this instance was created via [ATProto.fromOAuth] or
@@ -272,6 +289,9 @@ final class _ATProto implements ATProto {
 
   @override
   core.Session? get session => _ctx.session;
+
+  @override
+  Stream<core.Session> get onSessionUpdated => _ctx.onSessionUpdated;
 
   @override
   oauth.OAuthSessionManager? get oAuthSessionManager =>

--- a/packages/atproto/pubspec.yaml
+++ b/packages/atproto/pubspec.yaml
@@ -1,7 +1,7 @@
 name: atproto
 resolution: workspace
 description: The most famous and powerful Dart/Flutter library for AT Protocol.
-version: 2.1.0
+version: 2.2.0
 homepage: https://atprotodart.com
 documentation: https://atprotodart.com/docs/packages/atproto
 repository: https://github.com/myConsciousness/atproto.dart/tree/main/packages/atproto
@@ -18,7 +18,7 @@ topics:
   - api
 
 dependencies:
-  atproto_core: ^2.0.1
+  atproto_core: ^2.1.0
   xrpc: ^1.1.2
   freezed_annotation: ^3.1.0
   json_annotation: ^4.9.0

--- a/packages/atproto_core/CHANGELOG.md
+++ b/packages/atproto_core/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Note
 
+## v2.1.0
+
+- feat: added `ServiceContext.onSessionUpdated`, a broadcast stream that emits the refreshed `Session` each time an expired access token is renewed. `session` already reflected the new credentials, but nothing told the caller to read it back — and because refresh tokens are single-use, a caller that kept persisting the session it originally passed in stored a spent refresh token, so the next run restored a session that could no longer be refreshed. Mirrors `OAuthSessionManager.onSessionUpdated` for the legacy (app-password) path; it stays silent on OAuth-backed contexts. Concurrent requests that share one deduplicated refresh emit exactly one event.
+
 ## v2.0.1
 
 - docs: rewrite the README to document the actual public API — `Session`/`OAuthSession`, JWT decoding (`decodeJwt`/`Jwt`), the pluggable retry engine (`RetryStrategy`, `RetryConfig`, `RetryContext`, `RetryReason`, `RetryEvent`, `Jitter`), `BaseHttpService`/`ServiceContext`, `Blob`/`BlobRef`, `decodeCar`, `isValidAppPassword`, and the `xrpc`/`multiformats`/`cbor` re-exports — and frame the package as the shared core layer `atproto`/`bluesky` build on.

--- a/packages/atproto_core/lib/src/clients/service_context.dart
+++ b/packages/atproto_core/lib/src/clients/service_context.dart
@@ -69,6 +69,22 @@ base class ServiceContext {
   /// `OAuthSessionManager._inflightRefresh` for the OAuth path.
   Future<Session>? _inflightRefresh;
 
+  final StreamController<Session> _sessionUpdates =
+      StreamController<Session>.broadcast();
+
+  /// Emits the refreshed [Session] every time an expired access token is
+  /// renewed, so the owner of the credentials can re-persist them.
+  ///
+  /// Without this, an automatic refresh is invisible outside the client:
+  /// [session] holds the new credentials, but nothing tells the caller to read
+  /// it. Because refresh tokens are single-use, a caller that keeps persisting
+  /// the session it originally passed in ends up storing a spent refresh
+  /// token, and the next run restores a session that can no longer be
+  /// refreshed. Mirrors `OAuthSessionManager.onSessionUpdated`, which covers
+  /// the same need for the OAuth path — this stream is the legacy
+  /// (app-password) counterpart and stays silent on OAuth-backed contexts.
+  Stream<Session> get onSessionUpdated => _sessionUpdates.stream;
+
   /// Caches the decoded access-token expiry so the pre-flight refresh check
   /// does not re-run `decodeJwt` on every authenticated request. Keyed by the
   /// access JWT string, so it is implicitly invalidated whenever the session
@@ -410,6 +426,11 @@ base class ServiceContext {
     final future = refresh(current)
         .then((refreshed) {
           _currentSession = refreshed;
+          //! Broadcast after adopting it, so a listener that reads `session`
+          //! sees the credentials it was just handed. Never awaited: a slow or
+          //! throwing listener must not delay or fail the request that
+          //! triggered the refresh.
+          _sessionUpdates.add(refreshed);
 
           return refreshed;
         })

--- a/packages/atproto_core/pubspec.yaml
+++ b/packages/atproto_core/pubspec.yaml
@@ -1,7 +1,7 @@
 name: atproto_core
 resolution: workspace
 description: Core library for clients and tools. This package is mainly used by https://atprotodart.com packages.
-version: 2.0.1
+version: 2.1.0
 homepage: https://atprotodart.com
 documentation: https://atprotodart.com/docs/intro
 repository: https://github.com/myConsciousness/atproto.dart/tree/main/packages/atproto_core

--- a/packages/atproto_core/test/src/clients/service_context_test.dart
+++ b/packages/atproto_core/test/src/clients/service_context_test.dart
@@ -351,6 +351,65 @@ void main() {
       },
     );
 
+    test('emits the refreshed session on onSessionUpdated', () async {
+      final context = ServiceContext(
+        session: session(),
+        onRefreshSession: (current) async =>
+            current.copyWith(accessJwt: 'new-token', refreshJwt: 'new-refresh'),
+        getClient: (url, {headers}) async =>
+            headers?['Authorization'] == 'Bearer new-token'
+            ? json(url, 200, '{}')
+            : json(url, 401, '{"error":"ExpiredToken"}'),
+      );
+
+      final updates = <Session>[];
+      context.onSessionUpdated.listen(updates.add);
+
+      await context.get<Map<String, Object?>>(
+        NSID.create('server.atproto.com', 'getSession'),
+        to: (json) => json,
+      );
+      //! The stream is async; give the broadcast a turn to be delivered.
+      await Future<void>.delayed(Duration.zero);
+
+      //! Without this a caller cannot know the rotation happened, and would go
+      //! on persisting a refresh token the server has already spent.
+      expect(updates, hasLength(1));
+      expect(updates.single.accessJwt, 'new-token');
+      expect(updates.single.refreshJwt, 'new-refresh');
+    });
+
+    test('emits once when concurrent requests share one refresh', () async {
+      final context = ServiceContext(
+        session: session(),
+        onRefreshSession: (current) async {
+          await Future<void>.delayed(const Duration(milliseconds: 10));
+
+          return current.copyWith(accessJwt: 'new-token');
+        },
+        getClient: (url, {headers}) async =>
+            headers?['Authorization'] == 'Bearer new-token'
+            ? json(url, 200, '{}')
+            : json(url, 401, '{"error":"ExpiredToken"}'),
+      );
+
+      final updates = <Session>[];
+      context.onSessionUpdated.listen(updates.add);
+
+      await Future.wait([
+        for (var i = 0; i < 3; i++)
+          context.get<Map<String, Object?>>(
+            NSID.create('server.atproto.com', 'getSession'),
+            to: (json) => json,
+          ),
+      ]);
+      await Future<void>.delayed(Duration.zero);
+
+      //! One refresh (deduplicated by `_inflightRefresh`) means exactly one
+      //! notification — a listener that persists must not be handed three.
+      expect(updates, hasLength(1));
+    });
+
     test('rethrows and refreshes only once when still unauthorized', () async {
       int refreshCalls = 0;
       int calls = 0;

--- a/packages/bluesky/CHANGELOG.md
+++ b/packages/bluesky/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release Note
 
+## v2.2.0
+
+- fix: `chat.bsky.*` and `tools.ozone.*` calls now refresh an expired access token instead of throwing `UnauthorizedException`. v2.1.2 described this as covering `chat.bsky.*`, but only `Bluesky` was changed: `BlueskyChat.fromSession` and `OzoneTool.fromSession` each still built a standalone `ServiceContext` with no refresh hook, so every call through `chat.convo` / `chat.actor` / the ozone services surfaced an expired token as an error. Both now drive their services from the context owned by their nested `ATProto`, as `Bluesky` already did — the proxy headers that route those calls are preserved, since the nested client is built with them.
+- feat: added `onSessionUpdated` to `Bluesky`, `BlueskyChat` and `OzoneTool`, surfacing the refreshed session so callers can re-persist it. Refresh tokens are single-use, so an app that keeps persisting the session it built the client with stores a spent token and is signed out on next launch.
+- chore: bump `atproto` to `^2.2.0` and `atproto_core` to `^2.1.0`.
+
 ## v2.1.2
 
 - fix: `app.bsky.*` and `chat.bsky.*` calls now refresh an expired access token instead of throwing `UnauthorizedException`. `Bluesky.fromSession` built a second `ServiceContext` for those services and never gave it the refresh hook, so only calls made through `bsky.atproto` recovered from an expired token. Every factory now shares the context owned by the nested `ATProto`, which also makes `bsky.session` reflect a refresh — previously it kept returning the spent credentials, so persisting it signed the user out on next launch. The OAuth factories were unaffected, since both contexts already shared one `OAuthSessionManager`.

--- a/packages/bluesky/lib/src/bluesky.dart
+++ b/packages/bluesky/lib/src/bluesky.dart
@@ -123,6 +123,19 @@ sealed class Bluesky {
   /// [Bluesky.fromSession], otherwise null.
   core.Session? get session;
 
+  /// Emits the refreshed session every time an expired access token is
+  /// renewed, so the owner of the credentials can re-persist them.
+  ///
+  /// A `fromSession` instance refreshes automatically, and [session] then
+  /// holds the new credentials — but nothing otherwise tells the caller to
+  /// read it back. Because refresh tokens are single-use, persisting the
+  /// session originally passed in would store a spent refresh token, and the
+  /// next run would restore a session that can no longer be refreshed.
+  ///
+  /// Silent on OAuth-backed instances; use
+  /// `oAuthSessionManager.onSessionUpdated` for those.
+  Stream<core.Session> get onSessionUpdated;
+
   /// Returns the current OAuth session manager.
   ///
   /// Set only when this instance was created via [Bluesky.fromOAuth] or
@@ -214,6 +227,9 @@ final class _Bluesky implements Bluesky {
 
   @override
   core.Session? get session => _ctx.session;
+
+  @override
+  Stream<core.Session> get onSessionUpdated => _ctx.onSessionUpdated;
 
   @override
   oauth.OAuthSessionManager? get oAuthSessionManager =>

--- a/packages/bluesky/lib/src/bluesky_chat.dart
+++ b/packages/bluesky/lib/src/bluesky_chat.dart
@@ -29,18 +29,7 @@ sealed class BlueskyChat {
     final core.RetryStrategy? retryConfig,
     final core.GetClient? getClient,
     final core.PostClient? postClient,
-  }) => _BlueskyChat(
-    core.ServiceContext(
-      headers: {...?headers, ..._kBskyChatProxyHeaders},
-      protocol: protocol,
-      service: service,
-      relayService: relayService,
-      session: session,
-      timeout: timeout,
-      retryConfig: retryConfig,
-      getClient: getClient,
-      postClient: postClient,
-    ),
+  }) => _BlueskyChat.fromAtproto(
     atp.ATProto.fromSession(
       headers: {...?headers, ..._kBskyChatProxyHeaders},
       session,
@@ -66,18 +55,7 @@ sealed class BlueskyChat {
     final core.RetryStrategy? retryConfig,
     final core.GetClient? getClient,
     final core.PostClient? postClient,
-  }) => _BlueskyChat(
-    core.ServiceContext(
-      headers: {...?headers, ..._kBskyChatProxyHeaders},
-      protocol: protocol,
-      service: service,
-      relayService: relayService,
-      oAuthSessionManager: manager,
-      timeout: timeout,
-      retryConfig: retryConfig,
-      getClient: getClient,
-      postClient: postClient,
-    ),
+  }) => _BlueskyChat.fromAtproto(
     atp.ATProto.fromOAuth(
       manager,
       headers: {...?headers, ..._kBskyChatProxyHeaders},
@@ -127,6 +105,19 @@ sealed class BlueskyChat {
   /// [BlueskyChat.fromSession], otherwise null.
   core.Session? get session;
 
+  /// Emits the refreshed session every time an expired access token is
+  /// renewed, so the owner of the credentials can re-persist them.
+  ///
+  /// A `fromSession` instance refreshes automatically, and [session] then
+  /// holds the new credentials — but nothing otherwise tells the caller to
+  /// read it back. Because refresh tokens are single-use, persisting the
+  /// session originally passed in would store a spent refresh token, and the
+  /// next run would restore a session that can no longer be refreshed.
+  ///
+  /// Silent on OAuth-backed instances; use
+  /// `oAuthSessionManager.onSessionUpdated` for those.
+  Stream<core.Session> get onSessionUpdated;
+
   /// Returns the current OAuth session manager.
   ///
   /// Set only when this instance was created via [BlueskyChat.fromOAuth] or
@@ -158,7 +149,17 @@ sealed class BlueskyChat {
 }
 
 final class _BlueskyChat implements BlueskyChat {
-  _BlueskyChat(final core.ServiceContext ctx, this.atproto)
+  /// Drives every `chat.bsky.*` service from [atproto]'s own context.
+  ///
+  /// A second context would carry a second copy of the session, and only one
+  /// of the two would ever be refreshed — see [atp.ATProto.ctx]. It is safe to
+  /// adopt this one wholesale: every factory above builds [atproto] with the
+  /// same arguments the discarded context received, `_kBskyChatProxyHeaders`
+  /// included.
+  factory _BlueskyChat.fromAtproto(final atp.ATProto atproto) =>
+      _BlueskyChat._(atproto.ctx, atproto);
+
+  _BlueskyChat._(final core.ServiceContext ctx, this.atproto)
     : actor = ActorService(ctx),
       convo = ConvoService(ctx),
       moderation = ModerationService(ctx),
@@ -171,6 +172,9 @@ final class _BlueskyChat implements BlueskyChat {
 
   @override
   core.Session? get session => _ctx.session;
+
+  @override
+  Stream<core.Session> get onSessionUpdated => _ctx.onSessionUpdated;
 
   @override
   oauth.OAuthSessionManager? get oAuthSessionManager =>

--- a/packages/bluesky/lib/src/ozone_tool.dart
+++ b/packages/bluesky/lib/src/ozone_tool.dart
@@ -32,18 +32,7 @@ sealed class OzoneTool {
     final core.RetryStrategy? retryConfig,
     final core.GetClient? getClient,
     final core.PostClient? postClient,
-  }) => _OzoneTool(
-    core.ServiceContext(
-      headers: headers,
-      protocol: protocol,
-      service: service,
-      relayService: relayService,
-      session: session,
-      timeout: timeout,
-      retryConfig: retryConfig,
-      getClient: getClient,
-      postClient: postClient,
-    ),
+  }) => _OzoneTool.fromAtproto(
     atp.ATProto.fromSession(
       session,
       headers: headers,
@@ -69,18 +58,7 @@ sealed class OzoneTool {
     final core.RetryStrategy? retryConfig,
     final core.GetClient? getClient,
     final core.PostClient? postClient,
-  }) => _OzoneTool(
-    core.ServiceContext(
-      headers: headers,
-      protocol: protocol,
-      service: service,
-      relayService: relayService,
-      oAuthSessionManager: manager,
-      timeout: timeout,
-      retryConfig: retryConfig,
-      getClient: getClient,
-      postClient: postClient,
-    ),
+  }) => _OzoneTool.fromAtproto(
     atp.ATProto.fromOAuth(
       manager,
       headers: headers,
@@ -129,6 +107,19 @@ sealed class OzoneTool {
   /// Set only if an instance of this object was created in
   /// [OzoneTool.fromSession], otherwise null.
   core.Session? get session;
+
+  /// Emits the refreshed session every time an expired access token is
+  /// renewed, so the owner of the credentials can re-persist them.
+  ///
+  /// A `fromSession` instance refreshes automatically, and [session] then
+  /// holds the new credentials — but nothing otherwise tells the caller to
+  /// read it back. Because refresh tokens are single-use, persisting the
+  /// session originally passed in would store a spent refresh token, and the
+  /// next run would restore a session that can no longer be refreshed.
+  ///
+  /// Silent on OAuth-backed instances; use
+  /// `oAuthSessionManager.onSessionUpdated` for those.
+  Stream<core.Session> get onSessionUpdated;
 
   /// Returns the current OAuth session manager.
   ///
@@ -189,7 +180,16 @@ sealed class OzoneTool {
 }
 
 final class _OzoneTool implements OzoneTool {
-  _OzoneTool(final core.ServiceContext ctx, this.atproto)
+  /// Drives every `tools.ozone.*` service from [atproto]'s own context.
+  ///
+  /// A second context would carry a second copy of the session, and only one
+  /// of the two would ever be refreshed — see [atp.ATProto.ctx]. It is safe to
+  /// adopt this one wholesale: every factory above builds [atproto] with the
+  /// same arguments the discarded context received.
+  factory _OzoneTool.fromAtproto(final atp.ATProto atproto) =>
+      _OzoneTool._(atproto.ctx, atproto);
+
+  _OzoneTool._(final core.ServiceContext ctx, this.atproto)
     : communication = CommunicationService(ctx),
       hosting = HostingService(ctx),
       moderation = ModerationService(ctx),
@@ -209,6 +209,9 @@ final class _OzoneTool implements OzoneTool {
 
   @override
   core.Session? get session => _ctx.session;
+
+  @override
+  Stream<core.Session> get onSessionUpdated => _ctx.onSessionUpdated;
 
   @override
   oauth.OAuthSessionManager? get oAuthSessionManager =>

--- a/packages/bluesky/pubspec.yaml
+++ b/packages/bluesky/pubspec.yaml
@@ -1,7 +1,7 @@
 name: bluesky
 resolution: workspace
 description: The most famous and powerful Dart/Flutter library for Bluesky Social.
-version: 2.1.2
+version: 2.2.0
 homepage: https://atprotodart.com
 documentation: https://atprotodart.com/docs/packages/bluesky
 repository: https://github.com/myConsciousness/atproto.dart/tree/main/packages/bluesky
@@ -18,8 +18,8 @@ topics:
   - api
 
 dependencies:
-  atproto_core: ^2.0.1
-  atproto: ^2.1.0
+  atproto_core: ^2.1.0
+  atproto: ^2.2.0
   freezed_annotation: ^3.1.0
   json_annotation: ^4.9.0
   characters: ^1.4.0

--- a/packages/bluesky/test/src/bluesky_chat_test.dart
+++ b/packages/bluesky/test/src/bluesky_chat_test.dart
@@ -1,0 +1,143 @@
+// Package imports:
+import 'package:atproto_core/atproto_core.dart' as core;
+import 'package:http/http.dart' as http;
+import 'package:test/test.dart';
+
+// Project imports:
+import 'package:bluesky/src/bluesky_chat.dart';
+
+void main() {
+  group('.session (auto refresh)', () {
+    core.Session session() => core.Session(
+      did: 'did:plc:testaccount',
+      handle: 'test.dev',
+      //! Non-JWT token so the pre-flight refresh is skipped and the reactive
+      //! 401 path is exercised.
+      accessJwt: 'old-access',
+      refreshJwt: 'refresh-token',
+    );
+
+    test('refreshes an expired access token on a chat.bsky.* call', () async {
+      final refreshAuthHeaders = <String?>[];
+      final getAuthHeaders = <String?>[];
+
+      final chat = BlueskyChat.fromSession(
+        session(),
+        service: 'pds.test',
+        getClient: (url, {headers}) async {
+          getAuthHeaders.add(headers?['Authorization']);
+
+          if (headers?['Authorization'] == 'Bearer new-access') {
+            return http.Response(
+              '{"convos":[]}',
+              200,
+              headers: {'content-type': 'application/json'},
+              request: http.Request('GET', url),
+            );
+          }
+
+          return http.Response(
+            '{"error":"ExpiredToken"}',
+            401,
+            headers: {'content-type': 'application/json'},
+            request: http.Request('GET', url),
+          );
+        },
+        postClient: (url, {headers, body, encoding}) async {
+          //! The only POST expected here is the refreshSession call.
+          expect(url.path, contains('com.atproto.server.refreshSession'));
+          refreshAuthHeaders.add(headers?['Authorization']);
+
+          return http.Response(
+            '{"accessJwt":"new-access","refreshJwt":"new-refresh",'
+            '"handle":"test.dev","did":"did:plc:testaccount"}',
+            200,
+            headers: {'content-type': 'application/json'},
+            request: http.Request('POST', url),
+          );
+        },
+      );
+
+      final response = await chat.convo.listConvos();
+
+      expect(response.status.code, 200);
+      //! `chat.bsky.*` used to run on a context built without
+      //! `onRefreshSession`, so an expired token surfaced as
+      //! `UnauthorizedException` instead of being refreshed — unlike
+      //! `app.bsky.*`, which was fixed for `Bluesky` alone.
+      expect(refreshAuthHeaders, ['Bearer refresh-token']);
+      expect(getAuthHeaders, ['Bearer old-access', 'Bearer new-access']);
+    });
+
+    test('keeps the chat proxy header across the refresh', () async {
+      final proxyHeaders = <String?>[];
+
+      final chat = BlueskyChat.fromSession(
+        session(),
+        service: 'pds.test',
+        getClient: (url, {headers}) async {
+          proxyHeaders.add(headers?['atproto-proxy']);
+
+          return http.Response(
+            headers?['Authorization'] == 'Bearer new-access'
+                ? '{"convos":[]}'
+                : '{"error":"ExpiredToken"}',
+            headers?['Authorization'] == 'Bearer new-access' ? 200 : 401,
+            headers: {'content-type': 'application/json'},
+            request: http.Request('GET', url),
+          );
+        },
+        postClient: (url, {headers, body, encoding}) async => http.Response(
+          '{"accessJwt":"new-access","refreshJwt":"new-refresh",'
+          '"handle":"test.dev","did":"did:plc:testaccount"}',
+          200,
+          headers: {'content-type': 'application/json'},
+          request: http.Request('POST', url),
+        ),
+      );
+
+      await chat.convo.listConvos();
+
+      //! Adopting the nested ATProto's context must not drop the proxy header
+      //! that routes these calls to the chat service.
+      expect(proxyHeaders, [
+        'did:web:api.bsky.chat#bsky_chat',
+        'did:web:api.bsky.chat#bsky_chat',
+      ]);
+    });
+
+    test('exposes the refreshed session and announces it', () async {
+      final chat = BlueskyChat.fromSession(
+        session(),
+        service: 'pds.test',
+        getClient: (url, {headers}) async => http.Response(
+          headers?['Authorization'] == 'Bearer new-access'
+              ? '{"convos":[]}'
+              : '{"error":"ExpiredToken"}',
+          headers?['Authorization'] == 'Bearer new-access' ? 200 : 401,
+          headers: {'content-type': 'application/json'},
+          request: http.Request('GET', url),
+        ),
+        postClient: (url, {headers, body, encoding}) async => http.Response(
+          '{"accessJwt":"new-access","refreshJwt":"new-refresh",'
+          '"handle":"test.dev","did":"did:plc:testaccount"}',
+          200,
+          headers: {'content-type': 'application/json'},
+          request: http.Request('POST', url),
+        ),
+      );
+
+      final updates = <core.Session>[];
+      chat.onSessionUpdated.listen(updates.add);
+
+      await chat.convo.listConvos();
+      await Future<void>.delayed(Duration.zero);
+
+      //! Both views must agree: a caller persisting `chat.session` would
+      //! otherwise store a refresh token that has already been spent.
+      expect(chat.session?.refreshJwt, 'new-refresh');
+      expect(chat.atproto.session?.refreshJwt, 'new-refresh');
+      expect(updates.single.refreshJwt, 'new-refresh');
+    });
+  });
+}

--- a/packages/bluesky/test/src/bluesky_test.dart
+++ b/packages/bluesky/test/src/bluesky_test.dart
@@ -105,6 +105,44 @@ void main() {
         expect(bsky.atproto.session?.refreshJwt, 'new-refresh');
       },
     );
+
+    test('announces the refreshed session on onSessionUpdated', () async {
+      final bsky = Bluesky.fromSession(
+        core.Session(
+          did: 'did:plc:testaccount',
+          handle: 'test.dev',
+          accessJwt: 'old-access',
+          refreshJwt: 'refresh-token',
+        ),
+        service: 'pds.test',
+        getClient: (url, {headers}) async => http.Response(
+          headers?['Authorization'] == 'Bearer new-access'
+              ? '{"feed":[]}'
+              : '{"error":"ExpiredToken"}',
+          headers?['Authorization'] == 'Bearer new-access' ? 200 : 401,
+          headers: {'content-type': 'application/json'},
+          request: http.Request('GET', url),
+        ),
+        postClient: (url, {headers, body, encoding}) async => http.Response(
+          '{"accessJwt":"new-access","refreshJwt":"new-refresh",'
+          '"handle":"test.dev","did":"did:plc:testaccount"}',
+          200,
+          headers: {'content-type': 'application/json'},
+          request: http.Request('POST', url),
+        ),
+      );
+
+      final updates = <core.Session>[];
+      bsky.onSessionUpdated.listen(updates.add);
+
+      await bsky.feed.getTimeline();
+      await Future<void>.delayed(Duration.zero);
+
+      //! Reading `bsky.session` back requires knowing a refresh happened;
+      //! this is how a caller learns to re-persist before the stored refresh
+      //! token goes stale.
+      expect(updates.single.refreshJwt, 'new-refresh');
+    });
   });
 
   group('.session', () {


### PR DESCRIPTION
## Summary

An automatic session refresh is currently invisible from outside the client. `session` holds the new credentials, but nothing tells the caller to read it back — and refresh tokens are single-use, so an app that keeps persisting the session it constructed the client with stores a **spent** refresh token and is signed out on its next launch.

This adds a way to be told, and fixes a second case of the bug v2.1.2 set out to solve.

### 1. `onSessionUpdated`

`ServiceContext.onSessionUpdated` is a broadcast stream carrying the refreshed `Session`, surfaced as `ATProto.onSessionUpdated` and on `Bluesky` / `BlueskyChat` / `OzoneTool`:

```dart
atproto.onSessionUpdated.listen(store.save);
```

It mirrors `OAuthSessionManager.onSessionUpdated`, which already covers this for the OAuth path, and stays silent on OAuth-backed instances. A stream rather than a constructor callback for exactly that symmetry — `ServiceContext` already mirrors `OAuthSessionManager._inflightRefresh` — and because it avoids threading a new parameter through every `from*` factory.

Concurrent requests that share one deduplicated refresh emit exactly one event; no change was needed there, since `_inflightRefresh` already collapses the stampede.

### 2. `chat.bsky.*` and `tools.ozone.*` still did not refresh

v2.1.2's note says it covered `app.bsky.*` **and `chat.bsky.*`**, but only `Bluesky` was changed. `BlueskyChat.fromSession` and `OzoneTool.fromSession` each still built a standalone `ServiceContext` with no `onRefreshSession`, so every call through `chat.convo` / `chat.actor` / the ozone services surfaced an expired token as `UnauthorizedException`.

Both now drive their services from the context owned by their nested `ATProto`, exactly as `_Bluesky.fromAtproto` does. Adopting it wholesale is safe: every factory already builds that nested client with the same arguments the discarded context received, `_kBskyChatProxyHeaders` included. A test pins the proxy header across the refresh so that cannot silently regress.

## Test plan

Five new tests:

- `ServiceContext` emits the refreshed session, and emits **once** when three concurrent requests share one refresh.
- `chat.bsky.*` refreshes an expired token and retries; the chat proxy header survives; `chat.session`, `chat.atproto.session` and the stream all agree.
- `Bluesky.onSessionUpdated` announces the refresh.

The three chat tests were verified to **fail** against the previous separate-context construction, so they are not vacuous.

`atproto_core` 133, `atproto` 388, `bluesky` 875 — all green; `dart analyze` clean across the three packages.

## Versions

`atproto_core` 2.1.0, `atproto` 2.2.0, `bluesky` 2.2.0, with CHANGELOG entries. The `bluesky` entry notes that v2.1.2's description was inaccurate for `chat.bsky.*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)