### PR TITLE
fix(ci): repair the automated release chain from lexicon sync to pub.dev

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,6 +12,24 @@
 # pub.dev credential. No secrets or long-lived tokens are stored. Each package
 # must have "Automated publishing" enabled in its pub.dev Admin tab pointing at
 # this repo with a matching tag pattern.
+#
+# Two failure modes seen in production shaped the guards below:
+#
+#   1. Hanging on interactive auth. When pub cannot authenticate via OIDC (most
+#      often because "Automated publishing" was never enabled for that package)
+#      it falls back to the browser OAuth flow and waits on a localhost redirect
+#      that never arrives. The `bluesky_text_flutter-v0.1.1` / `v0.1.2` runs sat
+#      at "Waiting for your authorization..." for 6h and 2h50m before being
+#      cancelled. Guards: an OIDC preflight check, a `timeout` around the
+#      publish command, and `timeout-minutes` on the job as a backstop.
+#
+#   2. Re-publishing an existing version. Releasing locally with
+#      `melos publish_live` uploads to pub.dev *and* creates the tags; pushing
+#      those tags then asked this workflow to upload the same version again,
+#      which pub.dev rejects ("Version 2.1.0 of package bluesky already
+#      exists") — three red runs on 2026-07-18. Guard: `prepare` asks pub.dev
+#      whether the version is already there and skips the publish job if so, so
+#      the release is idempotent no matter which side did the upload.
 
 name: Publish
 
@@ -32,13 +50,16 @@ permissions:
 
 jobs:
   # Parse the pushed tag ref once and expose the package name + version to the
-  # publish jobs. `is_flutter` routes the flutter-only package to its own job.
+  # publish jobs. `is_flutter` routes the flutter-only package to its own job,
+  # and `already_published` short-circuits a re-run of a finished release.
   prepare:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     outputs:
       name: ${{ steps.parse.outputs.name }}
       version: ${{ steps.parse.outputs.version }}
       is_flutter: ${{ steps.parse.outputs.is_flutter }}
+      already_published: ${{ steps.published.outputs.already_published }}
     steps:
       - name: Parse tag into package name and version
         id: parse
@@ -62,12 +83,61 @@ jobs:
           fi
           echo "Parsed tag '$tag' -> package '$name' version '$version'."
 
+      # Idempotency gate. pub.dev is the authority on what has shipped, so ask
+      # it directly instead of assuming this workflow is the only publisher:
+      # `melos publish_live` uploads from a maintainer's machine before the tags
+      # are pushed, and a re-run/re-push of a tag is otherwise guaranteed to
+      # fail on "version already exists".
+      #
+      # 200 = this exact version exists, 404 = neither the version nor the
+      # package is on pub.dev yet (a first release hits 404 too). Anything else
+      # is inconclusive, so we fall through to publishing and let pub.dev
+      # decide — skipping a real release would be far worse than a duplicate
+      # upload attempt.
+      - name: Check whether the version is already on pub.dev
+        id: published
+        env:
+          NAME: ${{ steps.parse.outputs.name }}
+          VERSION: ${{ steps.parse.outputs.version }}
+        run: |
+          url="https://pub.dev/api/packages/$NAME/versions/$VERSION"
+          status=""
+          for attempt in 1 2 3; do
+            status=$(curl -sS -o /dev/null -w '%{http_code}' \
+              -H 'Accept: application/json' \
+              --max-time 30 "$url" || echo "000")
+            case "$status" in
+              200|404) break ;;
+              *) echo "pub.dev returned HTTP $status (attempt $attempt/3); retrying."; sleep 5 ;;
+            esac
+          done
+
+          case "$status" in
+            200)
+              echo "already_published=true" >> "$GITHUB_OUTPUT"
+              echo "::notice::$NAME $VERSION is already on pub.dev — skipping the publish job (nothing to do)."
+              echo "\`$NAME $VERSION\` was already on pub.dev; publish skipped." >> "$GITHUB_STEP_SUMMARY"
+              ;;
+            404)
+              echo "already_published=false" >> "$GITHUB_OUTPUT"
+              echo "$NAME $VERSION is not on pub.dev yet — publishing."
+              ;;
+            *)
+              echo "already_published=false" >> "$GITHUB_OUTPUT"
+              echo "::warning::Could not determine whether $NAME $VERSION exists (last HTTP status: $status). Attempting to publish; pub.dev will reject a duplicate."
+              ;;
+          esac
+
   # Publish a Dart-workspace package. Gated off for the flutter package, which
   # cannot resolve against the Dart-only pub workspace.
   publish-dart:
     needs: prepare
-    if: needs.prepare.outputs.is_flutter == 'false'
+    if: needs.prepare.outputs.is_flutter == 'false' && needs.prepare.outputs.already_published != 'true'
     runs-on: ubuntu-latest
+    # Backstop for anything that stalls outside the `timeout` below (SDK setup,
+    # `pub get`, a wedged runner). A healthy Dart publish finishes in under a
+    # minute, so this only ever fires on a hang.
+    timeout-minutes: 15
     defaults:
       run:
         working-directory: packages/${{ needs.prepare.outputs.name }}
@@ -77,6 +147,17 @@ jobs:
       - uses: dart-lang/setup-dart@v1
         with:
           sdk: stable
+
+      # Fail before uploading anything if the OIDC token this job needs is not
+      # present: without it `pub publish` would silently switch to the browser
+      # OAuth flow and hang instead of erroring.
+      - name: Verify an OIDC token is available
+        run: |
+          if [[ -z "${ACTIONS_ID_TOKEN_REQUEST_URL:-}" || -z "${ACTIONS_ID_TOKEN_REQUEST_TOKEN:-}" ]]; then
+            echo "::error::No GitHub OIDC token in this job, so pub cannot authenticate to pub.dev. Check that this workflow still grants 'id-token: write'."
+            exit 1
+          fi
+          echo "OIDC token endpoint is available."
 
       # Guard: refuse to publish if the pubspec version disagrees with the tag,
       # so a stale/mismatched tag can never ship the wrong release.
@@ -97,14 +178,38 @@ jobs:
       # OIDC token is auto-exchanged because `id-token: write` is granted above.
       # `--force` skips the interactive confirmation (non-TTY in CI).
       - name: Publish to pub.dev
-        run: dart pub publish --force
+        env:
+          PACKAGE: ${{ needs.prepare.outputs.name }}
+        run: |
+          set -o pipefail
+          log="$RUNNER_TEMP/publish.log"
+          status=0
+          # `timeout` bounds the interactive-OAuth fallback, which waits on a
+          # localhost redirect that can never arrive on a runner. Capture the
+          # status with `||` rather than an `if`: a failing `if` condition with
+          # no `else` leaves `$?` at 0, which would report the failure as a
+          # successful publish.
+          timeout 10m dart pub publish --force 2>&1 | tee "$log" || status=$?
+          if [[ "$status" -eq 0 ]]; then
+            exit 0
+          fi
+
+          if grep -q 'Pub needs your authorization' "$log"; then
+            echo "::error::pub fell back to interactive OAuth, so OIDC publishing was rejected. Enable 'Automated publishing' for '$PACKAGE' on pub.dev (Admin tab -> repository myConsciousness/atproto.dart, tag pattern {{package}}-v{{version}})."
+          elif [[ "$status" -eq 124 ]]; then
+            echo "::error::'dart pub publish' did not finish within 10 minutes and was killed."
+          fi
+          exit "$status"
 
   # Publish the Flutter package. It lives outside the Dart pub workspace, so it
   # needs the Flutter SDK and `flutter pub`.
   publish-flutter:
     needs: prepare
-    if: needs.prepare.outputs.is_flutter == 'true'
+    if: needs.prepare.outputs.is_flutter == 'true' && needs.prepare.outputs.already_published != 'true'
     runs-on: ubuntu-latest
+    # Flutter SDK setup is slower than Dart's, hence the larger backstop. Both
+    # of this package's releases hung for hours before these guards existed.
+    timeout-minutes: 25
     defaults:
       run:
         working-directory: packages/bluesky_text_flutter
@@ -114,6 +219,14 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: stable
+
+      - name: Verify an OIDC token is available
+        run: |
+          if [[ -z "${ACTIONS_ID_TOKEN_REQUEST_URL:-}" || -z "${ACTIONS_ID_TOKEN_REQUEST_TOKEN:-}" ]]; then
+            echo "::error::No GitHub OIDC token in this job, so pub cannot authenticate to pub.dev. Check that this workflow still grants 'id-token: write'."
+            exit 1
+          fi
+          echo "OIDC token endpoint is available."
 
       - name: Verify pubspec version matches tag
         env:
@@ -131,4 +244,18 @@ jobs:
 
       # OIDC token is auto-exchanged because `id-token: write` is granted above.
       - name: Publish to pub.dev
-        run: flutter pub publish --force
+        run: |
+          set -o pipefail
+          log="$RUNNER_TEMP/publish.log"
+          status=0
+          timeout 10m flutter pub publish --force 2>&1 | tee "$log" || status=$?
+          if [[ "$status" -eq 0 ]]; then
+            exit 0
+          fi
+
+          if grep -q 'Pub needs your authorization' "$log"; then
+            echo "::error::pub fell back to interactive OAuth, so OIDC publishing was rejected. Enable 'Automated publishing' for 'bluesky_text_flutter' on pub.dev (Admin tab -> repository myConsciousness/atproto.dart, tag pattern {{package}}-v{{version}})."
+          elif [[ "$status" -eq 124 ]]; then
+            echo "::error::'flutter pub publish' did not finish within 10 minutes and was killed."
+          fi
+          exit "$status"

--- a/.github/workflows/release_tags.yml
+++ b/.github/workflows/release_tags.yml
@@ -1,0 +1,130 @@
+# The missing link between the automated version bumps and pub.dev.
+#
+# `sync_and_generate.yml` syncs lexicons, regenerates sources, and runs
+# `scripts/gen_changelog.dart`, which appends CHANGELOG entries and bumps the
+# affected packages (patch/minor, propagated to dependents). That PR auto-merges
+# into `main` -- and then nothing happened: `publish.yml` is tag-driven, and no
+# job ever created the tags. Releases therefore stalled on `main` until someone
+# ran `melos publish_live` by hand. `bluesky` sat at 2.2.4 on `main` while
+# pub.dev still served 2.2.2 (two unreleased bumps).
+#
+# This workflow closes that gap: on every push to `main` that touches a package
+# pubspec, it compares each package's `version:` against the existing tags and
+# pushes `<package>-v<x.y.z>` for whatever is missing. Those tag pushes fire
+# `publish.yml`, which publishes to pub.dev via OIDC.
+#
+# Two things make this safe to run on every push:
+#   * It only ever *adds* tags that do not exist yet, so re-runs are no-ops.
+#   * `publish.yml` asks pub.dev whether the version is already there and skips
+#     the upload if so, so a tag for an already-published version is harmless.
+#
+# The push MUST use `secrets.PAT`: tags pushed with the default `GITHUB_TOKEN`
+# do not trigger workflows, which would leave `publish.yml` just as dormant as
+# it was before.
+
+name: Release Tags
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "packages/*/pubspec.yaml"
+  # Manual safety valve: run against `main` to tag any release that was missed
+  # (for example a bump merged while this workflow was failing).
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+# Serialise runs so two pushes in quick succession cannot race on tag creation.
+# Never cancel: a cancelled run would silently drop a release.
+concurrency:
+  group: release-tags
+  cancel-in-progress: false
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # A PAT is required so the tag push triggers `publish.yml`; pushes made
+          # with the default GITHUB_TOKEN do not start workflows.
+          token: ${{ secrets.PAT }}
+          # Tags are needed to tell a new version from an already-tagged one.
+          fetch-depth: 0
+
+      - name: Create and push missing release tags
+        env:
+          GIT_AUTHOR_NAME: github-actions[bot]
+          GIT_AUTHOR_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+          GIT_COMMITTER_NAME: github-actions[bot]
+          GIT_COMMITTER_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+        run: |
+          set -o pipefail
+
+          # Tags already on the remote. `git tag` alone would miss a tag pushed
+          # by a maintainer after this checkout started.
+          remote_tags="$(git ls-remote --tags origin | sed 's#.*refs/tags/##' | sed 's#\^{}$##' | sort -u)"
+
+          tags=()
+          skipped=()
+
+          for pubspec in packages/*/pubspec.yaml; do
+            dir="$(dirname "$pubspec")"
+            name="$(grep -m1 '^name:' "$pubspec" | awk '{print $2}')"
+            version="$(grep -m1 '^version:' "$pubspec" | awk '{print $2}')"
+
+            # `publish_to: none` packages (atproto_test) are never released.
+            if grep -qE '^publish_to:[[:space:]]*none' "$pubspec"; then
+              skipped+=("$name (publish_to: none)")
+              continue
+            fi
+
+            if [[ -z "$name" || -z "$version" ]]; then
+              echo "::warning::Could not read name/version from $pubspec; skipping."
+              skipped+=("$dir (unreadable pubspec)")
+              continue
+            fi
+
+            # Only plain `x.y.z` versions match `publish.yml`'s tag filter. A
+            # pre-release version would produce a tag that never publishes, so
+            # flag it instead of creating a dead tag.
+            if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "::warning::$name version '$version' is not a plain x.y.z release; not tagging."
+              skipped+=("$name $version (not a plain release version)")
+              continue
+            fi
+
+            tag="$name-v$version"
+            if grep -qxF "$tag" <<<"$remote_tags"; then
+              echo "$tag already exists; nothing to release for $name."
+              continue
+            fi
+
+            echo "$name $version has no tag yet; creating $tag."
+            git tag "$tag"
+            tags+=("$tag")
+          done
+
+          if [[ ${#skipped[@]} -gt 0 ]]; then
+            printf 'Skipped: %s\n' "${skipped[@]}"
+          fi
+
+          if [[ ${#tags[@]} -eq 0 ]]; then
+            echo "No new release tags. (Every package pubspec version is already tagged.)"
+            echo 'No new release tags — every package version is already tagged.' >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          # One atomic push: either every tag lands or none does, so a partial
+          # release cannot leave half the workspace published.
+          git push --atomic origin "${tags[@]}"
+
+          echo "::notice::Pushed ${#tags[@]} release tag(s): ${tags[*]}"
+          {
+            echo "Pushed release tags (each one triggers **Publish**):"
+            printf -- '- `%s`\n' "${tags[@]}"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/packages/bluesky/CHANGELOG.md
+++ b/packages/bluesky/CHANGELOG.md
@@ -1,13 +1,9 @@
 # Release Note
 
-## v2.2.4
-
-- feat: added `app.bsky.notification.listNotifications#notification.starterPack`
-- chore: regenerated from synced lexicons
-
 ## v2.2.3
 
 - feat: added `app.bsky.ageassurance.defs#configRegion.platforms`
+- feat: added `app.bsky.notification.listNotifications#notification.starterPack`
 - chore: regenerated from synced lexicons
 
 ## v2.2.2

--- a/packages/bluesky/pubspec.yaml
+++ b/packages/bluesky/pubspec.yaml
@@ -1,7 +1,7 @@
 name: bluesky
 resolution: workspace
 description: The most famous and powerful Dart/Flutter library for Bluesky Social.
-version: 2.2.4
+version: 2.2.3
 homepage: https://atprotodart.com
 documentation: https://atprotodart.com/docs/packages/bluesky
 repository: https://github.com/myConsciousness/atproto.dart/tree/main/packages/bluesky

--- a/scripts/gen_changelog.dart
+++ b/scripts/gen_changelog.dart
@@ -25,15 +25,27 @@ Map<String, PackagePlan> run({
   required Map<String, List<String>> dependents,
 }) {
   final changesByPackage = <String, List<ClassifiedChange>>{};
+  var hasAnyChange = false;
   for (final change in diffSnapshots(oldSnap, newSnap)) {
+    hasAnyChange = true;
     final pkg = packageForNsid(change.nsid);
     if (pkg == null) continue; // unmapped namespace (e.g. site.standard.*)
     changesByPackage.putIfAbsent(pkg, () => []).add(classify(change));
   }
+
+  // Packages that only carry generated output. `lexicon` embeds every lexicon
+  // document, so any change reaches it; `bluesky_cli` generates commands from
+  // the owned namespaces, so it follows the owner packages.
+  final regenerated = <String>{
+    if (hasAnyChange) ...allLexiconConsumers,
+    if (changesByPackage.isNotEmpty) ...mappedLexiconConsumers,
+  };
+
   return planVersions(
     changesByPackage: changesByPackage,
     currentVersions: currentVersions,
     dependents: dependents,
+    regeneratedPackages: regenerated,
   );
 }
 

--- a/scripts/gen_changelog/lexicon_diff.dart
+++ b/scripts/gen_changelog/lexicon_diff.dart
@@ -8,6 +8,23 @@ import 'dart:convert';
 // Project imports:
 import 'models.dart';
 
+/// Label of the def's own schema, as opposed to a nested one (`parameters`,
+/// `input`, ...). Empty so it never collides with a real lexicon key.
+const _ownSchema = '';
+
+/// Def keys that a dedicated diff already covers. They are excluded from the
+/// signature comparison so a nested change is never reported twice.
+const _structuralKeys = {
+  'properties',
+  'required',
+  'record',
+  'parameters',
+  'input',
+  'output',
+  'message',
+  'errors',
+};
+
 /// Computes the semantic difference between two lexicon snapshots.
 List<LexChange> diffSnapshots(Snapshot old, Snapshot updated) {
   final changes = <LexChange>[];
@@ -75,6 +92,60 @@ Map<String, dynamic> _schemaOf(Map<String, dynamic> def) {
   return def;
 }
 
+/// Every schema of [def] that carries public API surface, keyed by label.
+///
+/// `object` and `record` defs hold their fields directly, but `query`,
+/// `procedure` and `subscription` defs nest theirs under `parameters` and the
+/// `input` / `output` / `message` bodies. Walking only the def's own
+/// `properties` — as this differ originally did — therefore made every change
+/// to an endpoint invisible: the `sort` parameter added to
+/// `app.bsky.graph.getFollowers` and `getFollows` regenerated both `bluesky`
+/// and `bluesky_cli` sources yet produced no changelog entry and no version
+/// bump.
+Map<String, Map<String, dynamic>> _schemasOf(Map<String, dynamic> def) {
+  final schemas = <String, Map<String, dynamic>>{_ownSchema: _schemaOf(def)};
+
+  // `parameters` is a `params` object holding the query string fields.
+  final parameters = def['parameters'];
+  if (parameters is Map<String, dynamic>) {
+    schemas['parameters'] = parameters;
+  }
+
+  // Request/response bodies wrap their schema in an encoding envelope.
+  for (final body in const ['input', 'output', 'message']) {
+    final envelope = def[body];
+    if (envelope is! Map<String, dynamic>) continue;
+    final schema = envelope['schema'];
+    if (schema is Map<String, dynamic>) schemas[body] = schema;
+  }
+
+  return schemas;
+}
+
+/// Compares everything but the fields, so a `knownValues`, `description` or
+/// `type` edit on the schema itself is still reported. Generated sources embed
+/// all three, so a release is warranted.
+String _signatureOf(Map<String, dynamic> schema) => jsonEncode(
+  Map<String, dynamic>.of(schema)
+    ..removeWhere((key, _) => _structuralKeys.contains(key)),
+);
+
+/// `errors` entries keyed by name, for the error list of a query/procedure.
+Map<String, dynamic> _errorsOf(Map<String, dynamic> def) {
+  final errors = def['errors'];
+  if (errors is! List) return const {};
+  return {
+    for (final error in errors)
+      if (error is Map<String, dynamic> && error['name'] is String)
+        error['name'] as String: error,
+  };
+}
+
+/// Qualifies [field] with its schema [label] so `parameters.sort` cannot be
+/// confused with a body field of the same name.
+String _qualify(String label, String field) =>
+    label == _ownSchema ? field : '$label.$field';
+
 List<LexChange> _diffDef(
   String nsid,
   String def,
@@ -82,8 +153,88 @@ List<LexChange> _diffDef(
   Map<String, dynamic> newDef,
 ) {
   final changes = <LexChange>[];
-  final oldSchema = _schemaOf(oldDef);
-  final newSchema = _schemaOf(newDef);
+  final oldSchemas = _schemasOf(oldDef);
+  final newSchemas = _schemasOf(newDef);
+
+  for (final label in {...oldSchemas.keys, ...newSchemas.keys}) {
+    final oldSchema = oldSchemas[label];
+    final newSchema = newSchemas[label];
+
+    // A whole body appearing or disappearing (e.g. a query that gained an
+    // `output` schema) is reported against the label itself.
+    if (oldSchema == null || newSchema == null) {
+      changes.add(
+        LexChange(
+          nsid: nsid,
+          defName: def,
+          field: label,
+          kind: oldSchema == null
+              ? LexChangeKind.propertyAdded
+              : LexChangeKind.propertyRemoved,
+        ),
+      );
+      continue;
+    }
+
+    changes.addAll(_diffSchema(nsid, def, label, oldSchema, newSchema));
+  }
+
+  // The def's own non-field keys. For a record these live outside the schema
+  // walked above (`key`, `description`), so compare them separately.
+  if (!identical(oldSchemas[_ownSchema], oldDef) &&
+      _signatureOf(oldDef) != _signatureOf(newDef)) {
+    changes.add(
+      LexChange(nsid: nsid, defName: def, kind: LexChangeKind.metadataChanged),
+    );
+  }
+
+  final oldErrors = _errorsOf(oldDef);
+  final newErrors = _errorsOf(newDef);
+  for (final name in {...oldErrors.keys, ...newErrors.keys}) {
+    final oldError = oldErrors[name];
+    final newError = newErrors[name];
+    final field = _qualify('errors', name);
+    if (oldError == null) {
+      changes.add(
+        LexChange(
+          nsid: nsid,
+          defName: def,
+          field: field,
+          kind: LexChangeKind.propertyAdded,
+        ),
+      );
+    } else if (newError == null) {
+      changes.add(
+        LexChange(
+          nsid: nsid,
+          defName: def,
+          field: field,
+          kind: LexChangeKind.propertyRemoved,
+        ),
+      );
+    } else if (jsonEncode(oldError) != jsonEncode(newError)) {
+      changes.add(
+        LexChange(
+          nsid: nsid,
+          defName: def,
+          field: field,
+          kind: LexChangeKind.metadataChanged,
+        ),
+      );
+    }
+  }
+
+  return changes;
+}
+
+List<LexChange> _diffSchema(
+  String nsid,
+  String def,
+  String label,
+  Map<String, dynamic> oldSchema,
+  Map<String, dynamic> newSchema,
+) {
+  final changes = <LexChange>[];
 
   final oldProps =
       (oldSchema['properties'] as Map<String, dynamic>?) ?? const {};
@@ -99,13 +250,14 @@ List<LexChange> _diffDef(
   for (final prop in {...oldProps.keys, ...newProps.keys}) {
     final oldProp = oldProps[prop];
     final newProp = newProps[prop];
+    final field = _qualify(label, prop);
 
     if (oldProp == null) {
       changes.add(
         LexChange(
           nsid: nsid,
           defName: def,
-          field: prop,
+          field: field,
           kind: LexChangeKind.propertyAdded,
         ),
       );
@@ -116,7 +268,7 @@ List<LexChange> _diffDef(
         LexChange(
           nsid: nsid,
           defName: def,
-          field: prop,
+          field: field,
           kind: LexChangeKind.propertyRemoved,
         ),
       );
@@ -130,7 +282,7 @@ List<LexChange> _diffDef(
         LexChange(
           nsid: nsid,
           defName: def,
-          field: prop,
+          field: field,
           kind: LexChangeKind.propertyTypeChanged,
           detail: '$oldType -> $newType',
         ),
@@ -145,7 +297,7 @@ List<LexChange> _diffDef(
         LexChange(
           nsid: nsid,
           defName: def,
-          field: prop,
+          field: field,
           kind: LexChangeKind.propertyBecameRequired,
         ),
       );
@@ -154,7 +306,7 @@ List<LexChange> _diffDef(
         LexChange(
           nsid: nsid,
           defName: def,
-          field: prop,
+          field: field,
           kind: LexChangeKind.propertyBecameOptional,
         ),
       );
@@ -163,12 +315,26 @@ List<LexChange> _diffDef(
         LexChange(
           nsid: nsid,
           defName: def,
-          field: prop,
+          field: field,
           kind: LexChangeKind.metadataChanged,
         ),
       );
     }
   }
+
+  // Schema-level edits that no field covers: `knownValues` on a string def, a
+  // union's `refs`, a changed `type`, a reworded `description`.
+  if (_signatureOf(oldSchema) != _signatureOf(newSchema)) {
+    changes.add(
+      LexChange(
+        nsid: nsid,
+        defName: def,
+        field: label == _ownSchema ? null : label,
+        kind: LexChangeKind.metadataChanged,
+      ),
+    );
+  }
+
   return changes;
 }
 

--- a/scripts/gen_changelog/lexicon_diff_test.dart
+++ b/scripts/gen_changelog/lexicon_diff_test.dart
@@ -100,6 +100,117 @@ void main() {
     );
   });
 
+  test('detects an added query parameter', () {
+    // The real regression: `sort` was added to app.bsky.graph.getFollowers and
+    // getFollows, regenerating bluesky and bluesky_cli sources, yet the differ
+    // reported nothing because it only walked the def's own `properties`.
+    final old = _snap({
+      'app.bsky.graph.getFollowers':
+          '{"main":{"type":"query","parameters":{"type":"params","required":["actor"],"properties":{"actor":{"type":"string"},"cursor":{"type":"string"}}}}}',
+    });
+    final updated = _snap({
+      'app.bsky.graph.getFollowers':
+          '{"main":{"type":"query","parameters":{"type":"params","required":["actor"],"properties":{"actor":{"type":"string"},"cursor":{"type":"string"},"sort":{"type":"string","knownValues":["latest","top"]}}}}}',
+    });
+    expect(diffSnapshots(old, updated), [
+      const LexChange(
+        nsid: 'app.bsky.graph.getFollowers',
+        defName: 'main',
+        field: 'parameters.sort',
+        kind: LexChangeKind.propertyAdded,
+      ),
+    ]);
+  });
+
+  test('detects changes in input and output bodies', () {
+    final old = _snap({
+      'com.atproto.repo.createRecord':
+          '{"main":{"type":"procedure","input":{"encoding":"application/json","schema":{"type":"object","properties":{"repo":{"type":"string"}}}},"output":{"encoding":"application/json","schema":{"type":"object","properties":{"uri":{"type":"string"}}}}}}',
+    });
+    final updated = _snap({
+      'com.atproto.repo.createRecord':
+          '{"main":{"type":"procedure","input":{"encoding":"application/json","schema":{"type":"object","properties":{"repo":{"type":"string"},"swapCommit":{"type":"string"}}}},"output":{"encoding":"application/json","schema":{"type":"object","properties":{"uri":{"type":"integer"}}}}}}',
+    });
+    expect(
+      diffSnapshots(old, updated),
+      containsAll([
+        const LexChange(
+          nsid: 'com.atproto.repo.createRecord',
+          defName: 'main',
+          field: 'input.swapCommit',
+          kind: LexChangeKind.propertyAdded,
+        ),
+        const LexChange(
+          nsid: 'com.atproto.repo.createRecord',
+          defName: 'main',
+          field: 'output.uri',
+          kind: LexChangeKind.propertyTypeChanged,
+          detail: 'string -> integer',
+        ),
+      ]),
+    );
+  });
+
+  test('detects a whole body being added', () {
+    final old = _snap({'x.y.z': '{"main":{"type":"query"}}'});
+    final updated = _snap({
+      'x.y.z':
+          '{"main":{"type":"query","output":{"encoding":"application/json","schema":{"type":"object","properties":{"a":{"type":"string"}}}}}}',
+    });
+    expect(
+      diffSnapshots(old, updated),
+      contains(
+        const LexChange(
+          nsid: 'x.y.z',
+          defName: 'main',
+          field: 'output',
+          kind: LexChangeKind.propertyAdded,
+        ),
+      ),
+    );
+  });
+
+  test('detects an added error', () {
+    final old = _snap({
+      'x.y.z': '{"main":{"type":"query","errors":[{"name":"NotFound"}]}}',
+    });
+    final updated = _snap({
+      'x.y.z':
+          '{"main":{"type":"query","errors":[{"name":"NotFound"},{"name":"BlockedActor"}]}}',
+    });
+    expect(diffSnapshots(old, updated), [
+      const LexChange(
+        nsid: 'x.y.z',
+        defName: 'main',
+        field: 'errors.BlockedActor',
+        kind: LexChangeKind.propertyAdded,
+      ),
+    ]);
+  });
+
+  test('detects knownValues added to a string def', () {
+    final old = _snap({'x.y.z': '{"kind":{"type":"string"}}'});
+    final updated = _snap({
+      'x.y.z': '{"kind":{"type":"string","knownValues":["a","b"]}}',
+    });
+    expect(diffSnapshots(old, updated), [
+      const LexChange(
+        nsid: 'x.y.z',
+        defName: 'kind',
+        kind: LexChangeKind.metadataChanged,
+      ),
+    ]);
+  });
+
+  test('an unchanged query yields empty list', () {
+    const query =
+        '{"main":{"type":"query","description":"d","parameters":{"type":"params","properties":{"actor":{"type":"string"}}},"output":{"encoding":"application/json","schema":{"type":"object","properties":{"a":{"type":"string"}}}},"errors":[{"name":"NotFound"}]}}';
+    expect(
+      diffSnapshots(_snap({'x.y.z': query}), _snap({'x.y.z': query})),
+      isEmpty,
+    );
+  });
+
   test('no change yields empty list', () {
     final s = _snap({
       'x.y.z':

--- a/scripts/gen_changelog/package_mapper.dart
+++ b/scripts/gen_changelog/package_mapper.dart
@@ -9,6 +9,23 @@ const Map<String, List<String>> packageNamespaces = {
   'bluesky': ['app.bsky', 'chat.bsky', 'tools.ozone'],
 };
 
+/// Packages regenerated from *every* lexicon document, whatever its namespace.
+///
+/// `lexicon` embeds all of `lexicons/` in `lexicons.g.dart`, including the
+/// namespaces no package owns (`site.standard`), so its published content goes
+/// stale on any sync it is not released for.
+const allLexiconConsumers = ['lexicon'];
+
+/// Packages regenerated from the owned namespaces in [packageNamespaces].
+///
+/// `bluesky_cli` generates one command per endpoint across every mapped
+/// namespace (`lib/src/commands/codegen/{app,chat,com,tools}/...`). It owns no
+/// namespace of its own and depends on neither `atproto` nor `bluesky`, so
+/// neither the namespace mapping nor dependency propagation ever bumped it —
+/// its generated commands changed on `main` while pub.dev kept serving the old
+/// ones.
+const mappedLexiconConsumers = ['bluesky_cli'];
+
 /// Returns the owning package for [nsid], or null if no package generates it.
 String? packageForNsid(String nsid) {
   for (final entry in packageNamespaces.entries) {

--- a/scripts/gen_changelog/version_planner.dart
+++ b/scripts/gen_changelog/version_planner.dart
@@ -16,13 +16,29 @@ class _Draft {
   final Set<String> _bumpedDeps = {};
 
   Version get newVersion => oldVersion.bump(level);
+
+  /// Adds [line] unless it is already recorded.
+  void addLine(String line) {
+    if (!lines.contains(line)) lines.add(line);
+  }
 }
 
+/// The entry every regenerated package gets, on its own for packages that only
+/// carry generated output.
+const _regeneratedLine = 'chore: regenerated from synced lexicons';
+
 /// Plans per-package version bumps and changelog lines from classified changes.
+///
+/// [regeneratedPackages] are packages whose sources are regenerated from the
+/// lexicons without owning any namespace (see `package_mapper.dart`). They get
+/// a patch bump and the generic regenerated line, because the diff that
+/// justifies their release is in generated code rather than in a lexicon they
+/// own.
 Map<String, PackagePlan> planVersions({
   required Map<String, List<ClassifiedChange>> changesByPackage,
   required Map<String, Version> currentVersions,
   required Map<String, List<String>> dependents,
+  Set<String> regeneratedPackages = const {},
 }) {
   final drafts = <String, _Draft>{};
 
@@ -41,11 +57,20 @@ Map<String, PackagePlan> planVersions({
     for (final c in entry.value) {
       if (seen.add(c.changelogLine)) draft.lines.add(c.changelogLine);
     }
-    draft.lines.add('chore: regenerated from synced lexicons');
+    draft.addLine(_regeneratedLine);
     drafts[pkg] = draft;
   }
 
-  // 2. Propagate to dependents until fixed point.
+  // 2. Regenerated-only packages. Skipped when the package already has a draft
+  // (it owns changed lexicons too) or has no known version.
+  for (final pkg in regeneratedPackages) {
+    final current = currentVersions[pkg];
+    if (current == null || drafts.containsKey(pkg)) continue;
+    drafts[pkg] = _Draft(pkg, current, BumpLevel.patch)
+      ..addLine(_regeneratedLine);
+  }
+
+  // 3. Propagate to dependents until fixed point.
   var changed = true;
   while (changed) {
     changed = false;
@@ -54,7 +79,13 @@ Map<String, PackagePlan> planVersions({
       for (final dep in dependents[pkg] ?? const <String>[]) {
         var draft = drafts[dep];
         if (draft == null) {
-          draft = _Draft(dep, currentVersions[dep]!, BumpLevel.patch);
+          // A dependent whose version could not be read (non-semver, or the
+          // pubspec is gone) cannot be planned. Skip it rather than throwing:
+          // one unreadable package used to abort the whole run, leaving every
+          // other package without its bump and changelog entry.
+          final current = currentVersions[dep];
+          if (current == null) continue;
+          draft = _Draft(dep, current, BumpLevel.patch);
           drafts[dep] = draft;
           changed = true;
         }

--- a/scripts/gen_changelog/version_planner_test.dart
+++ b/scripts/gen_changelog/version_planner_test.dart
@@ -88,6 +88,56 @@ void main() {
     );
   });
 
+  test('regenerated-only packages get a patch bump and the generic line', () {
+    final plans = planVersions(
+      changesByPackage: {
+        'bluesky': [_c(BumpLevel.patch, 'feat: added `app.bsky.a`')],
+      },
+      currentVersions: {
+        'bluesky': Version.parse('2.2.2'),
+        'bluesky_cli': Version.parse('0.6.4'),
+        'lexicon': Version.parse('1.2.3'),
+      },
+      dependents: {},
+      regeneratedPackages: {'bluesky_cli', 'lexicon'},
+    );
+    expect(plans['bluesky_cli']!.newVersion.toString(), '0.6.5');
+    expect(plans['bluesky_cli']!.changelogLines, [
+      'chore: regenerated from synced lexicons',
+    ]);
+    expect(plans['lexicon']!.newVersion.toString(), '1.2.4');
+  });
+
+  test('a regenerated package that owns changes keeps its own entries', () {
+    final plans = planVersions(
+      changesByPackage: {
+        'lexicon': [_c(BumpLevel.minor, 'fix!: removed `x.y.z` (BREAKING)')],
+      },
+      currentVersions: {'lexicon': Version.parse('1.2.3')},
+      dependents: {},
+      regeneratedPackages: {'lexicon'},
+    );
+    // The minor bump wins over the regenerated patch, and the generic line is
+    // recorded once.
+    expect(plans['lexicon']!.newVersion.toString(), '1.3.0');
+    expect(
+      plans['lexicon']!.changelogLines
+          .where((l) => l == 'chore: regenerated from synced lexicons')
+          .length,
+      1,
+    );
+  });
+
+  test('regenerated packages with no known version are skipped', () {
+    final plans = planVersions(
+      changesByPackage: {},
+      currentVersions: {'lexicon': Version.parse('1.2.3')},
+      dependents: {},
+      regeneratedPackages: {'lexicon', 'not_a_package'},
+    );
+    expect(plans.keys, ['lexicon']);
+  });
+
   test('deduplicates identical changelog lines', () {
     final plans = planVersions(
       changesByPackage: {

--- a/scripts/gen_changelog_test.dart
+++ b/scripts/gen_changelog_test.dart
@@ -39,11 +39,58 @@ void main() {
     expect(plans['bluesky_cli']!.newVersion.toString(), '0.6.1');
   });
 
-  test('run drops changes for unmapped namespaces', () {
+  test('run bumps the generated-code consumers alongside the owner', () {
+    // bluesky_cli depends on neither atproto nor bluesky, so only the
+    // regenerated-consumer path can release its regenerated commands.
+    final plans = run(
+      oldSnap: _snap({
+        'app.bsky.graph.getFollows':
+            '{"main":{"type":"query","parameters":{"type":"params","properties":{"actor":{"type":"string"}}}}}',
+      }),
+      newSnap: _snap({
+        'app.bsky.graph.getFollows':
+            '{"main":{"type":"query","parameters":{"type":"params","properties":{"actor":{"type":"string"},"sort":{"type":"string"}}}}}',
+      }),
+      currentVersions: {
+        'bluesky': Version.parse('2.2.2'),
+        'bluesky_cli': Version.parse('0.6.4'),
+        'lexicon': Version.parse('1.2.3'),
+      },
+      dependents: {},
+    );
+    expect(plans['bluesky']!.newVersion.toString(), '2.2.3');
+    expect(
+      plans['bluesky']!.changelogLines,
+      contains('feat: added `app.bsky.graph.getFollows.parameters.sort`'),
+    );
+    expect(plans['bluesky_cli']!.newVersion.toString(), '0.6.5');
+    expect(plans['lexicon']!.newVersion.toString(), '1.2.4');
+  });
+
+  test('run bumps only lexicon for an unmapped namespace', () {
+    // `site.standard.*` belongs to no package, but `lexicons.g.dart` embeds it.
     final plans = run(
       oldSnap: {},
       newSnap: _snap({'site.standard.document': '{"main":{"type":"record"}}'}),
-      currentVersions: {'atproto': Version.parse('1.7.0')},
+      currentVersions: {
+        'atproto': Version.parse('1.7.0'),
+        'bluesky_cli': Version.parse('0.6.4'),
+        'lexicon': Version.parse('1.2.3'),
+      },
+      dependents: {},
+    );
+    expect(plans.keys, ['lexicon']);
+    expect(plans['lexicon']!.newVersion.toString(), '1.2.4');
+  });
+
+  test('run yields no plans when nothing changed', () {
+    final snap = _snap({
+      'site.standard.document': '{"main":{"type":"record"}}',
+    });
+    final plans = run(
+      oldSnap: snap,
+      newSnap: snap,
+      currentVersions: {'lexicon': Version.parse('1.2.3')},
       dependents: {},
     );
     expect(plans, isEmpty);


### PR DESCRIPTION
Releases have not been reaching pub.dev on their own. `bluesky` sat at 2.2.4 on `main` while pub.dev still served 2.2.2, and some synced lexicon changes never produced a changelog entry or a version bump at all. This fixes every link in that chain, plus the versions it burned.

## Why the chain was broken

**Nothing created the tags.** `sync_and_generate.yml` bumps versions, appends CHANGELOG entries and auto-merges its PR; `publish.yml` triggers on `<package>-v<x.y.z>` tags. No job in between ever created one, so every bump merged into `main` and stopped there until a maintainer ran `melos publish_live` by hand. Tags stop at `bluesky-v2.2.2`, two bumps behind `main`.

**Endpoint changes were invisible to `gen_changelog`.** The differ walked only a def's own `properties`, which only `object` and `record` defs have. `query`, `procedure` and `subscription` defs keep their surface under `parameters` and the `input` / `output` / `message` bodies, so every change to an endpoint went unreported. #2494 is the clean example: `sort` was added to `app.bsky.graph.getFollowers` and `getFollows`, 11 generated files changed across `bluesky` and `bluesky_cli`, and the run produced no changelog entry and no bump.

**Generated-code-only packages were never bumped.** `lexicon` embeds every lexicon document in `lexicons.g.dart` (including `site.standard`, which no package owns) and `bluesky_cli` generates one command per endpoint. Neither owns a namespace, and neither depends on `atproto` or `bluesky`, so neither the namespace mapping nor dependency propagation ever reached them — pub.dev keeps serving their stale generated code.

**Publishing could hang for hours.** `bluesky_text_flutter-v0.1.1` and `v0.1.2` ran for 6h and 2h50m before being cancelled. `flutter pub publish` could not authenticate via OIDC, fell back to browser OAuth and waited on a localhost redirect that never arrives.

**Publishing was not idempotent.** `melos publish_live` uploads and tags together, so pushing those tags asked CI to upload versions that already existed: three red runs on 2026-07-18 (`Version 2.1.0 of package bluesky already exists`).

## What this changes

- **New `release_tags.yml`** — on every push to `main` touching a package pubspec, compares each version against the remote tags and pushes what is missing, which fires Publish. Only ever adds tags, so re-runs are no-ops. Uses `secrets.PAT`, because tags pushed with `GITHUB_TOKEN` do not start workflows. Skips `publish_to: none` and non-`x.y.z` versions.
- **`publish.yml` hardened** — `prepare` asks pub.dev whether the version exists and skips the publish job if so; publishing runs under `timeout 10m` with `timeout-minutes` as a backstop; an up-front OIDC check plus detection of the OAuth fallback turns the old hang into an error naming the pub.dev setting to enable. The publish status is captured with `||` instead of an `if`, whose exit status is 0 on a failing condition — that form would have reported a failed publish as a success.
- **`gen_changelog` differ** — walks `parameters`, `input`, `output` and `message` schemas, the `errors` list, and the def's own non-field keys. Fields are qualified (`parameters.sort`) so a body field of the same name cannot be confused with a query parameter.
- **`lexicon` and `bluesky_cli`** are planned as regenerated packages: a patch bump and the generic regenerated line whenever the lexicons they carry change.
- **Propagation no longer crashes** on a dependent whose version cannot be read; it used to abort the whole run, leaving every other package without its bump.
- **`bluesky` 2.2.4 → 2.2.3** — both bumps were never tagged or published, so the two changelog sections become one 2.2.3 release instead of spending a version for nothing.

## Verification

- `dart test scripts/` — 42 tests pass, including new cases for the added query parameter, input/output bodies, a whole body appearing, added errors, `knownValues` on a string def, and the regenerated-package plans.
- Replayed the three most recent syncs through the fixed pipeline. #2494 (which shipped nothing) now yields `feat: added \`app.bsky.graph.getFollowers.parameters.sort\`` and the `getFollows` equivalent, plus `bluesky` / `lexicon` / `bluesky_cli` bumps. A synthetic `com.atproto` change bumps `atproto` and propagates to `bluesky`.
- Dry-ran the tagging step against `main`'s real tree with `git tag` / `git push` stubbed: it produces exactly `bluesky-v2.2.3`, skips `atproto_test` (`publish_to: none`) and refuses a `1.0.0-dev.1` version.
- Exercised the publish wrapper against fake success / OAuth-fallback / duplicate-version outcomes: exits 0, 124 with the actionable error, and 1 respectively.
- `dart run scripts/validate_dependencies.dart` — all 12 packages pass.

## After merging

Release Tags will push `bluesky-v2.2.3` and Publish will ship it — the catch-up release for what has been sitting on `main`.

One manual step remains and is not automatable from here: **`bluesky_text_flutter` needs "Automated publishing" enabled on pub.dev** (Admin tab → repository `myConsciousness/atproto.dart`, tag pattern `{{package}}-v{{version}}`). Until then its releases fail fast within 10 minutes with a pointer to that setting, instead of hanging for hours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)