### PR TITLE
chore: release the generated sources that were never versioned

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -254,7 +254,7 @@ jobs:
           fi
 
           if grep -q 'Pub needs your authorization' "$log"; then
-            echo "::error::pub fell back to interactive OAuth, so OIDC publishing was rejected. Enable 'Automated publishing' for 'bluesky_text_flutter' on pub.dev (Admin tab -> repository myConsciousness/atproto.dart, tag pattern {{package}}-v{{version}})."
+            echo "::error::pub fell back to interactive OAuth, so OIDC publishing was rejected. Check 'Automated publishing' for 'bluesky_text_flutter' on pub.dev (Admin tab -> repository myConsciousness/atproto.dart, tag pattern bluesky_text_flutter-v{{version}})."
           elif [[ "$status" -eq 124 ]]; then
             echo "::error::'flutter pub publish' did not finish within 10 minutes and was killed."
           fi

--- a/packages/bluesky_cli/CHANGELOG.md
+++ b/packages/bluesky_cli/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Note
 
+## v0.6.5
+
+- chore: regenerated from synced lexicons
+
 ## v0.6.4
 
 - chore: widen `at_primitives` to `^1.2.0`, `xrpc` to `^1.1.3`, and `bluesky_text` to `^1.5.4`.

--- a/packages/bluesky_cli/pubspec.yaml
+++ b/packages/bluesky_cli/pubspec.yaml
@@ -1,7 +1,7 @@
 name: bluesky_cli
 resolution: workspace
 description: A powerful CLI tool that allows Bluesky Social's APIs to be executed from the command line powered by Dart language.
-version: 0.6.4
+version: 0.6.5
 homepage: https://atprotodart.com
 repository: https://github.com/myConsciousness/atproto.dart/tree/main/packages/bluesky_cli
 issue_tracker: https://github.com/myConsciousness/atproto.dart/issues

--- a/packages/lex_gen/CHANGELOG.md
+++ b/packages/lex_gen/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Note
 
+## v0.4.5
+
+- chore: bump `lexicon` to `^1.2.4`
+
 ## v0.4.4
 
 - chore: bump `lexicon` to `^1.2.3`.

--- a/packages/lex_gen/pubspec.yaml
+++ b/packages/lex_gen/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lex_gen
 resolution: workspace
 description: Provides a generator that automatically generates source code from the Lexicon in the AT Protocol.
-version: 0.4.4
+version: 0.4.5
 homepage: https://atprotodart.com
 repository: https://github.com/myConsciousness/atproto.dart/tree/main/packages/lex_gen
 issue_tracker: https://github.com/myConsciousness/atproto.dart/issues
@@ -12,7 +12,7 @@ environment:
   sdk: ">=3.8.0 <4.0.0"
 
 dependencies:
-  lexicon: ^1.2.3
+  lexicon: ^1.2.4
 
 dev_dependencies:
   lints: ^6.0.0

--- a/packages/lexicon/CHANGELOG.md
+++ b/packages/lexicon/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Note
 
+## v1.2.4
+
+- chore: regenerated from synced lexicons
+
 ## v1.2.3
 
 - chore: bump `at_primitives` to `^1.2.0`.

--- a/packages/lexicon/pubspec.yaml
+++ b/packages/lexicon/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lexicon
 resolution: workspace
 description: Core library for parsing Lexicon in the AT Protocol standard.
-version: 1.2.3
+version: 1.2.4
 homepage: https://atprotodart.com
 repository: https://github.com/myConsciousness/atproto.dart/packages/lexicon
 issue_tracker: https://github.com/myConsciousness/atproto.dart/issues


### PR DESCRIPTION
#2498 fixed the planner so packages that carry only generated output get bumped from now on. It could not fix the backlog it inherited: `lexicon` and `bluesky_cli` have content on `main` that was never given a version, so pub.dev serves stale generated code for both.

Measured against their release tags:

| Package | Unreleased content since its tag |
| --- | --- |
| `lexicon` | `lexicons.g.dart`, three syncs behind (#2494, #2495, #2496): `configRegion.platforms`, the `sort` parameters, `notification.starterPack` |
| `bluesky_cli` | `get_followers.dart` / `get_follows.dart` — the `sort` option from #2494 |

Every other package is byte-identical to its published tag (`git diff <tag>..main` is empty), so this is the whole backlog.

- `lexicon` 1.2.3 → 1.2.4
- `bluesky_cli` 0.6.4 → 0.6.5
- `lex_gen` 0.4.4 → 0.4.5, following the lockstep constraint on `lexicon`

The changelog entries are exactly what the fixed planner emits for these packages, verified by replaying the three syncs through it. `dart run scripts/validate_dependencies.dart` passes for all 12 packages.

Also points the flutter publish error at the tag pattern that package is actually configured with (`bluesky_text_flutter-v{{version}}`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)