### PR TITLE
fix(bluesky_text): emit wire-complete facet maps

### DIFF
--- a/packages/bluesky/test/src/richtext_facet_wire_shape_test.dart
+++ b/packages/bluesky/test/src/richtext_facet_wire_shape_test.dart
@@ -1,0 +1,48 @@
+// Copyright (c) 2023-2026, Shinya Kato.
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// Package imports:
+import 'package:bluesky_text/bluesky_text.dart';
+import 'package:test/test.dart';
+
+// Project imports:
+import 'package:bluesky/src/services/codegen/app/bsky/richtext/facet/main.dart';
+
+void main() {
+  //* `bluesky_text` is dependency-free and cannot import `package:bluesky`, so
+  //* the cross-package guarantee is pinned here: the facet maps it emits are
+  //* already exactly what the lexicon converter serializes. Callers that build
+  //* a record map by hand (`com.atproto.repo.applyWrites`, local record CIDs)
+  //* therefore get the same bytes as `feed.post.create`.
+  group('bluesky_text facets are wire-complete for the lexicon models', () {
+    Future<List<Map<String, dynamic>>> facetsOf(final String value) async =>
+        BlueskyText(value).formatted.entities.toFacets(
+          resolver: (handle) async => 'did:plc:$handle',
+        );
+
+    test('a facet round-trips through RichtextFacet unchanged', () async {
+      final facets = await facetsOf(
+        'hi @alice.bsky.social see https://example.com #dart',
+      );
+
+      expect(facets, hasLength(3));
+
+      for (final facet in facets) {
+        expect(RichtextFacet.fromJson(facet).toJson(), facet);
+      }
+    });
+
+    test('every emitted facet passes RichtextFacet.validate', () async {
+      final facets = await facetsOf('hi @alice.bsky.social #dart');
+
+      expect(facets, isNotEmpty);
+
+      for (final facet in facets) {
+        //* `validate` returns false for a map without a `$type`, which is what
+        //* the previous, incomplete output produced.
+        expect(RichtextFacet.validate(facet), isTrue);
+      }
+    });
+  });
+}

--- a/packages/bluesky_text/README.md
+++ b/packages/bluesky_text/README.md
@@ -75,7 +75,9 @@ Future<void> main() async {
 against `bsky.social` by default; pass a `service` to target another PDS, or a
 `resolver` to serve DIDs from your own cache instead of a per-handle network
 call. The returned `facets` map straight onto `RichtextFacet.fromJson` when
-posting with [bluesky](https://pub.dev/packages/bluesky).
+posting with [bluesky](https://pub.dev/packages/bluesky), and they are
+wire-complete — the facet, its `index` and every feature all carry their
+`$type` — so they can equally be embedded in a record map you assemble by hand.
 
 See **[example](https://github.com/myConsciousness/atproto.dart/blob/main/packages/bluesky_text/example/example.dart)** or **[official documents](https://atprotodart.com/docs/packages/bluesky_text)** from following links.
 

--- a/packages/bluesky_text/lib/src/bluesky_text.dart
+++ b/packages/bluesky_text/lib/src/bluesky_text.dart
@@ -202,6 +202,10 @@ sealed class BlueskyText {
   ///   facets: post.facets.map(RichtextFacet.fromJson).toList(),
   /// );
   /// ```
+  ///
+  /// `facets` is already wire-complete (see `Entity.toFacet`), so it can also
+  /// be dropped straight into a record map you assemble yourself — no
+  /// round-trip through a lexicon model needed to fill in the `$type`s.
   Future<
     ({
       String text,

--- a/packages/bluesky_text/lib/src/entities/entities.dart
+++ b/packages/bluesky_text/lib/src/entities/entities.dart
@@ -15,6 +15,9 @@ class Entities extends UnmodifiableListView<Entity> {
   /// Returns the facets for these entities, together with the handles that
   /// failed to resolve to a DID (and were therefore dropped from `facets`).
   ///
+  /// Each facet is wire-complete — see [Entity.toFacet] — so the maps can be
+  /// embedded directly in a hand-assembled record.
+  ///
   /// Pass a [resolver] to control mention resolution — e.g. to serve cached
   /// DIDs or batch lookups — instead of the built-in per-handle network call.
   /// `unresolvedHandles` lets the caller warn the user (or retry) rather than

--- a/packages/bluesky_text/lib/src/entities/entity.dart
+++ b/packages/bluesky_text/lib/src/entities/entity.dart
@@ -33,6 +33,14 @@ final class Entity implements Facetable {
 
   /// Returns the facet representation of this entity as JSON.
   ///
+  /// The map is wire-complete: the facet carries `$type`
+  /// `app.bsky.richtext.facet`, its `index` carries `$type`
+  /// `app.bsky.richtext.facet#byteSlice`, and every feature carries its own
+  /// `$type`. It is therefore byte-for-byte what a lexicon-generated facet
+  /// serializes to, so it can be embedded in a hand-assembled record (for
+  /// `com.atproto.repo.applyWrites`, or to compute a record CID locally)
+  /// without a round-trip through a lexicon model first.
+  ///
   /// For a handle, [resolver] (when given) is used to look up the DID instead of
   /// the built-in network call, so callers can inject a cache of known DIDs.
   /// When the handle does not resolve, an empty map is returned; use
@@ -43,7 +51,12 @@ final class Entity implements Facetable {
     HandleResolver? resolver,
   }) async {
     final facet = <String, dynamic>{
-      'index': {'byteStart': indices.start, 'byteEnd': indices.end},
+      '\$type': 'app.bsky.richtext.facet',
+      'index': {
+        '\$type': 'app.bsky.richtext.facet#byteSlice',
+        'byteStart': indices.start,
+        'byteEnd': indices.end,
+      },
       'features': [],
     };
 

--- a/packages/bluesky_text/test/src/entities/entities_test.dart
+++ b/packages/bluesky_text/test/src/entities/entities_test.dart
@@ -21,7 +21,12 @@ void main() {
 
       expect(facets, [
         {
-          'index': {'byteStart': 0, 'byteEnd': 0},
+          '\$type': 'app.bsky.richtext.facet',
+          'index': {
+            '\$type': 'app.bsky.richtext.facet#byteSlice',
+            'byteStart': 0,
+            'byteEnd': 0,
+          },
           'features': [
             {
               '\$type': 'app.bsky.richtext.facet#mention',

--- a/packages/bluesky_text/test/src/entities/entity_test.dart
+++ b/packages/bluesky_text/test/src/entities/entity_test.dart
@@ -17,7 +17,12 @@ void main() {
       final facet = await entity.toFacet();
 
       expect(facet, {
-        'index': {'byteStart': 0, 'byteEnd': 0},
+        '\$type': 'app.bsky.richtext.facet',
+        'index': {
+          '\$type': 'app.bsky.richtext.facet#byteSlice',
+          'byteStart': 0,
+          'byteEnd': 0,
+        },
         'features': [
           {
             '\$type': 'app.bsky.richtext.facet#mention',
@@ -61,7 +66,12 @@ void main() {
       final facet = await entity.toFacet();
 
       expect(facet, {
-        'index': {'byteStart': 0, 'byteEnd': 0},
+        '\$type': 'app.bsky.richtext.facet',
+        'index': {
+          '\$type': 'app.bsky.richtext.facet#byteSlice',
+          'byteStart': 0,
+          'byteEnd': 0,
+        },
         'features': [
           {
             '\$type': 'app.bsky.richtext.facet#link',
@@ -81,7 +91,12 @@ void main() {
       final facet = await entity.toFacet(service: 'bsky.social');
 
       expect(facet, {
-        'index': {'byteStart': 0, 'byteEnd': 0},
+        '\$type': 'app.bsky.richtext.facet',
+        'index': {
+          '\$type': 'app.bsky.richtext.facet#byteSlice',
+          'byteStart': 0,
+          'byteEnd': 0,
+        },
         'features': [
           {
             '\$type': 'app.bsky.richtext.facet#mention',
@@ -127,11 +142,244 @@ void main() {
       final facet = await entity.toFacet();
 
       expect(facet, {
-        'index': {'byteStart': 0, 'byteEnd': 5},
+        '\$type': 'app.bsky.richtext.facet',
+        'index': {
+          '\$type': 'app.bsky.richtext.facet#byteSlice',
+          'byteStart': 0,
+          'byteEnd': 5,
+        },
         'features': [
           {'\$type': 'app.bsky.richtext.facet#tag', 'tag': r'$AAPL'},
         ],
       });
+    });
+  });
+
+  group('wire-complete facet shape', () {
+    //* Every mention below resolves through an injected resolver so these
+    //* tests never touch the network.
+    Future<String?> resolve(String handle) async => 'did:plc:alice';
+
+    test('a mention facet is the exact wire map', () async {
+      final facet = await Entity(
+        type: EntityType.handle,
+        value: 'alice.bsky.social',
+        indices: ByteIndices(start: 6, end: 24),
+      ).toFacet(resolver: resolve);
+
+      expect(facet, {
+        '\$type': 'app.bsky.richtext.facet',
+        'index': {
+          '\$type': 'app.bsky.richtext.facet#byteSlice',
+          'byteStart': 6,
+          'byteEnd': 24,
+        },
+        'features': [
+          {'\$type': 'app.bsky.richtext.facet#mention', 'did': 'did:plc:alice'},
+        ],
+      });
+    });
+
+    test('a link facet is the exact wire map', () async {
+      final facet = await Entity(
+        type: EntityType.link,
+        value: 'https://example.com',
+        indices: ByteIndices(start: 3, end: 22),
+      ).toFacet();
+
+      expect(facet, {
+        '\$type': 'app.bsky.richtext.facet',
+        'index': {
+          '\$type': 'app.bsky.richtext.facet#byteSlice',
+          'byteStart': 3,
+          'byteEnd': 22,
+        },
+        'features': [
+          {
+            '\$type': 'app.bsky.richtext.facet#link',
+            'uri': 'https://example.com',
+          },
+        ],
+      });
+    });
+
+    test('a tag facet is the exact wire map', () async {
+      final facet = await Entity(
+        type: EntityType.tag,
+        value: 'dart',
+        indices: ByteIndices(start: 0, end: 5),
+      ).toFacet();
+
+      expect(facet, {
+        '\$type': 'app.bsky.richtext.facet',
+        'index': {
+          '\$type': 'app.bsky.richtext.facet#byteSlice',
+          'byteStart': 0,
+          'byteEnd': 5,
+        },
+        'features': [
+          {'\$type': 'app.bsky.richtext.facet#tag', 'tag': 'dart'},
+        ],
+      });
+    });
+
+    test('a cashtag facet is the exact wire map', () async {
+      final facet = await Entity(
+        type: EntityType.cashtag,
+        value: r'$TSLA',
+        indices: ByteIndices(start: 2, end: 7),
+      ).toFacet();
+
+      expect(facet, {
+        '\$type': 'app.bsky.richtext.facet',
+        'index': {
+          '\$type': 'app.bsky.richtext.facet#byteSlice',
+          'byteStart': 2,
+          'byteEnd': 7,
+        },
+        'features': [
+          {'\$type': 'app.bsky.richtext.facet#tag', 'tag': r'$TSLA'},
+        ],
+      });
+    });
+
+    test('every emitted facet carries a \$type at all three levels', () async {
+      final entities = [
+        Entity(
+          type: EntityType.handle,
+          value: 'alice.bsky.social',
+          indices: ByteIndices(start: 0, end: 18),
+        ),
+        Entity(
+          type: EntityType.link,
+          value: 'https://example.com',
+          indices: ByteIndices(start: 19, end: 38),
+        ),
+        Entity(
+          type: EntityType.tag,
+          value: 'dart',
+          indices: ByteIndices(start: 39, end: 44),
+        ),
+        Entity(
+          type: EntityType.cashtag,
+          value: r'$TSLA',
+          indices: ByteIndices(start: 45, end: 50),
+        ),
+      ];
+
+      for (final entity in entities) {
+        final facet = await entity.toFacet(resolver: resolve);
+
+        expect(
+          facet[r'$type'],
+          'app.bsky.richtext.facet',
+          reason: 'the facet itself must be typed (${entity.type.name})',
+        );
+        expect(
+          (facet['index'] as Map)[r'$type'],
+          'app.bsky.richtext.facet#byteSlice',
+          reason: 'the byte slice must be typed (${entity.type.name})',
+        );
+        for (final feature in facet['features'] as List) {
+          expect(
+            (feature as Map)[r'$type'],
+            isA<String>().having(
+              (t) => t.startsWith('app.bsky.richtext.facet#'),
+              'is a facet feature type',
+              isTrue,
+            ),
+          );
+        }
+      }
+    });
+
+    test('the emitted map is a fixed point of \$type defaulting', () async {
+      //* `bluesky_text` cannot import `package:bluesky`, so the property the
+      //* lexicon converter guarantees is asserted locally: re-serializing the
+      //* map through a converter that fills in the declared `$type` defaults
+      //* must leave it byte-for-byte unchanged. Before this shape was
+      //* wire-complete, the defaults were *added* here, which is exactly the
+      //* silent divergence a hand-assembled record suffered from.
+      Map<String, dynamic> defaultTypes(Map<String, dynamic> facet) => {
+        r'$type': facet[r'$type'] ?? 'app.bsky.richtext.facet',
+        'index': {
+          r'$type':
+              (facet['index'] as Map)[r'$type'] ??
+              'app.bsky.richtext.facet#byteSlice',
+          'byteStart': (facet['index'] as Map)['byteStart'],
+          'byteEnd': (facet['index'] as Map)['byteEnd'],
+        },
+        'features': facet['features'],
+      };
+
+      for (final entity in [
+        Entity(
+          type: EntityType.handle,
+          value: 'alice.bsky.social',
+          indices: ByteIndices(start: 0, end: 18),
+        ),
+        Entity(
+          type: EntityType.link,
+          value: 'https://example.com',
+          indices: ByteIndices(start: 19, end: 38),
+        ),
+        Entity(
+          type: EntityType.tag,
+          value: 'dart',
+          indices: ByteIndices(start: 39, end: 44),
+        ),
+      ]) {
+        final facet = await entity.toFacet(resolver: resolve);
+
+        expect(defaultTypes(facet), facet);
+      }
+    });
+
+    test('byte indices are untouched by the added keys', () async {
+      //* Guard: adding `$type` keys must not shift, rename or drop the byte
+      //* range, and `index` must carry nothing beyond those three keys.
+      for (final indices in [
+        ByteIndices(start: 0, end: 0),
+        ByteIndices(start: 0, end: 19),
+        ByteIndices(start: 137, end: 156),
+      ]) {
+        final facet = await Entity(
+          type: EntityType.link,
+          value: 'https://example.com',
+          indices: indices,
+        ).toFacet();
+
+        final index = facet['index'] as Map<String, dynamic>;
+
+        expect(index['byteStart'], indices.start);
+        expect(index['byteEnd'], indices.end);
+        expect(index.keys, containsAll([r'$type', 'byteStart', 'byteEnd']));
+        expect(index, hasLength(3));
+      }
+    });
+
+    test('an unresolvable handle still yields no facet at all', () async {
+      final facet = await Entity(
+        type: EntityType.handle,
+        value: 'ghost.bsky.social',
+        indices: ByteIndices(start: 0, end: 18),
+      ).toFacet(resolver: (_) async => null);
+
+      //* `Entities.toFacetsResult` filters on `isEmpty`, so this must stay a
+      //* truly empty map — never a `$type`-only facet with no features.
+      expect(facet, isEmpty);
+      expect(facet.containsKey(r'$type'), isFalse);
+    });
+
+    test('a raw markdown link still yields no facet at all', () async {
+      final facet = await Entity(
+        type: EntityType.markdownLink,
+        value: '[example](https://example.com)',
+        indices: ByteIndices(start: 0, end: 30),
+      ).toFacet();
+
+      expect(facet, isEmpty);
+      expect(facet.containsKey(r'$type'), isFalse);
     });
   });
 

--- a/website/docs/products/packages/bluesky_text.md
+++ b/website/docs/products/packages/bluesky_text.md
@@ -248,7 +248,12 @@ The generated facets are plain JSON matching the Bluesky API shape:
 ```json
 [
   {
-    "index": { "byteStart": 35, "byteEnd": 50 },
+    "$type": "app.bsky.richtext.facet",
+    "index": {
+      "$type": "app.bsky.richtext.facet#byteSlice",
+      "byteStart": 35,
+      "byteEnd": 50
+    },
     "features": [
       {
         "$type": "app.bsky.richtext.facet#mention",
@@ -257,7 +262,12 @@ The generated facets are plain JSON matching the Bluesky API shape:
     ]
   },
   {
-    "index": { "byteStart": 91, "byteEnd": 113 },
+    "$type": "app.bsky.richtext.facet",
+    "index": {
+      "$type": "app.bsky.richtext.facet#byteSlice",
+      "byteStart": 91,
+      "byteEnd": 113
+    },
     "features": [
       {
         "$type": "app.bsky.richtext.facet#link",
@@ -267,6 +277,12 @@ The generated facets are plain JSON matching the Bluesky API shape:
   }
 ]
 ```
+
+Every object carries its `$type`, so the maps are identical to what the lexicon
+models serialize to. That matters when you build a record yourself — for
+`com.atproto.repo.applyWrites`, or to compute a record CID locally — because the
+facets can be embedded as-is, without first round-tripping them through
+`RichtextFacet.fromJson(...).toJson()` to fill the `$type`s in.
 
 ## More Tips 🏄
 


### PR DESCRIPTION
## Problem

`Entity.toFacet` typed only the individual features. The facet object and its `index` carried no `$type`, so the returned map was not what the lexicon models serialize to:

- `RichtextFacet` declares `@Default('app.bsky.richtext.facet') String $type`
- `RichtextFacetByteSlice` declares `@Default('app.bsky.richtext.facet#byteSlice') String $type`
- `RichtextFacet.validate()` opens with `if (!object.containsKey('$type')) return false` — **so the map `toFacet()` returned failed this package family's own validator**

Callers going through `feed.post.create` never noticed, because the generated converter fills the `$type`s in on the way out. Callers that assemble a record map themselves — for `com.atproto.repo.applyWrites`, or to compute a record CID locally — silently produced a record that differed from the converter's output unless they knew to round-trip every facet through `RichtextFacet.fromJson(f).toJson()` first. That was an invisible trap, and the wrong bytes hash to the wrong CID.

## Change

`toFacet` now emits the `$type` on the facet and on its `index`. This flows through `Entities.toFacets`, `Entities.toFacetsResult` and `BlueskyText.toPostData`.

The "no facet" paths (unresolvable handle, raw markdown link) still return a truly empty map — that is what `Entities.toFacetsResult` filters on, so it is load-bearing and is now pinned by a test.

`lex_object_converter.dart`'s `translate()` special-cases `$type` and passes it through rather than folding it into `$unknown`, so feeding the now-typed map into `RichtextFacet.fromJson` is a no-op rather than a source of pollution.

## Tests

Existing exact-map expectations in `entity_test` / `entities_test` are updated to the wire shape. New tests pin the guarantees: the exact literal map per entity type, `$type` present at all three levels, the output being a fixed point of `$type` defaulting, byte indices undisturbed by the added keys, and both empty-map paths staying empty.

Since `bluesky_text` cannot import `package:bluesky`, the cross-package property is pinned in `packages/bluesky`: every emitted facet round-trips through `RichtextFacet.fromJson(...).toJson()` unchanged and passes `RichtextFacet.validate`. Both would have failed before this change.

Verified the tests bite by reverting `entity.dart` and confirming 11 failures, with the two empty-map tests correctly still passing.

## Verification

`bluesky_text` 407 passed (398 before), `bluesky` 877 passed, `dart analyze` clean, `dart format` no diff.

## Note on versioning

No `pubspec.yaml` is touched — the CHANGELOG entry sits under `## Unreleased`. Several branches are landing in the same window, so versions are left for a single release commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)