### PR TITLE
feat(atproto_core): expose isAmbiguousFailure and let the retry layer own it

### DIFF
--- a/packages/atproto_core/lib/atproto_core.dart
+++ b/packages/atproto_core/lib/atproto_core.dart
@@ -23,6 +23,7 @@ export 'package:atproto_core/src/clients/retry_config.dart';
 export 'package:atproto_core/src/clients/retry_strategy.dart';
 export 'package:atproto_core/src/clients/retry_context.dart';
 export 'package:atproto_core/src/clients/retry_reason.dart';
+export 'package:atproto_core/src/clients/ambiguous_failure.dart';
 export 'package:atproto_core/src/utils/blob_converter.dart';
 export 'package:atproto_core/src/types/blob.dart';
 export 'package:atproto_core/src/types/blob_ref.dart';

--- a/packages/atproto_core/lib/src/clients/ambiguous_failure.dart
+++ b/packages/atproto_core/lib/src/clients/ambiguous_failure.dart
@@ -1,0 +1,103 @@
+// Copyright (c) 2023-2025, Shinya Kato.
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// Dart imports:
+import 'dart:async';
+
+// Package imports:
+import 'package:http/http.dart' as http;
+import 'package:xrpc/xrpc.dart' as xrpc;
+
+// Project imports:
+import 'network_error_detector_stub.dart'
+    if (dart.library.io) 'network_error_detector_io.dart';
+
+/// Whether [error] leaves it uncertain that the request reached the server.
+///
+/// A failed request falls into one of two groups. Either it *provably* never
+/// reached the server—a connection refused, a DNS lookup that never resolved,
+/// a `429` the server rejected before processing it—or it may have been
+/// received and applied even though the client never saw the response. The
+/// second group is *ambiguous*: a timeout is raised after the request was
+/// sent, a `5xx` may follow a partially applied side effect, and a connection
+/// reset while awaiting a response says nothing about what the server did.
+///
+/// The distinction only matters for a non-idempotent procedure (an XRPC
+/// `POST` such as `com.atproto.repo.createRecord` or
+/// `com.atproto.repo.applyWrites`). Retrying an ambiguous write may duplicate
+/// it; retrying an unambiguous one cannot, because the server never saw the
+/// first attempt.
+///
+/// This is the same classification the retry engine applies internally: it is
+/// surfaced to a `RetryStrategy` as `RetryContext.isAmbiguous`, and the
+/// default `RetryConfig` uses it to refuse to retry a procedure unless
+/// `RetryConfig.retryProcedureOnAmbiguousFailure` is set. Once the retries are
+/// exhausted the original error is rethrown unchanged—it may be a
+/// [TimeoutException] or an [http.ClientException], types this package does
+/// not own and therefore cannot annotate—so this predicate is how a caller
+/// recovers the classification from the error it caught.
+///
+/// A caller that writes records is expected to branch on the answer:
+///
+/// - `false` — the write never landed. Re-issuing it is safe.
+/// - `true` — the write may have landed. Do not blindly re-issue it; perform a
+///   recovery read first (for example list the collection, or fetch the record
+///   at the rkey the client chose) to discover whether it exists, and only
+///   re-issue when it does not.
+///
+/// ```dart
+/// try {
+///   await atproto.repo.createRecord(...);
+/// } catch (e) {
+///   if (isAmbiguousFailure(e)) {
+///     // The record may already exist: reconcile before writing again.
+///   } else {
+///     // Nothing reached the server: retrying cannot duplicate anything.
+///   }
+/// }
+/// ```
+///
+/// Any error this package does not classify as a transient failure—an
+/// [xrpc.InvalidRequestException], an [ArgumentError], anything else—returns
+/// `false`, because those never leave a write in doubt.
+bool isAmbiguousFailure(final Object error) {
+  // A timeout is raised after the request was sent, so the server may already
+  // have processed it.
+  if (error is TimeoutException) return true;
+
+  // The server received the request; a `5xx` may follow a partially applied
+  // side effect.
+  if (error is xrpc.InternalServerErrorException) return true;
+
+  // The request was rejected before it was processed, so retrying is safe
+  // even for a procedure.
+  if (error is xrpc.RateLimitExceededException) return false;
+
+  // Transient network failures, e.g. connection reset or refused. On the Dart
+  // VM, `SocketException`s thrown inside `package:http` are surfaced as
+  // `ClientException`s, but a raw `SocketException` can still escape a custom
+  // HTTP client that is not routed through `package:http`'s exception mapping.
+  if (error is http.ClientException || isSocketException(error)) {
+    // Unambiguous only when the request provably never reached the server.
+    return !_isUnreachedNetworkError(error);
+  }
+
+  return false;
+}
+
+/// Whether [error] indicates the request provably never reached the server
+/// (so retrying a non-idempotent request cannot duplicate a side effect).
+///
+/// Errors that leave the outcome uncertain (e.g. a connection reset while
+/// waiting for a response) are deliberately treated as ambiguous.
+bool _isUnreachedNetworkError(final Object error) {
+  final message = error.toString().toLowerCase();
+
+  return message.contains('connection refused') ||
+      message.contains('failed host lookup') ||
+      message.contains('no route to host') ||
+      message.contains('network is unreachable') ||
+      message.contains('nodename nor servname') ||
+      message.contains('name or service not known');
+}

--- a/packages/atproto_core/lib/src/clients/challenge.dart
+++ b/packages/atproto_core/lib/src/clients/challenge.dart
@@ -11,6 +11,7 @@ import 'package:http_parser/http_parser.dart';
 import 'package:xrpc/xrpc.dart' as xrpc;
 
 // Project imports:
+import 'ambiguous_failure.dart';
 import 'retry_context.dart';
 import 'retry_reason.dart';
 import 'retry_strategy.dart';
@@ -63,10 +64,8 @@ final class Challenge {
         action,
         e,
         stackTrace,
-        // A timeout is raised after the request was sent, so the server may
-        // already have processed it.
         reason: RetryReason.timeout,
-        isAmbiguous: true,
+        isAmbiguous: isAmbiguousFailure(e),
         isProcedure: isProcedure,
         nsid: nsid,
         attempt: attempt,
@@ -80,10 +79,8 @@ final class Challenge {
         action,
         e,
         stackTrace,
-        // The server received the request; a `5xx` may follow a partially
-        // applied side effect.
         reason: RetryReason.serverError,
-        isAmbiguous: true,
+        isAmbiguous: isAmbiguousFailure(e),
         statusCode: 500,
         isProcedure: isProcedure,
         nsid: nsid,
@@ -98,10 +95,8 @@ final class Challenge {
         action,
         e,
         stackTrace,
-        // The request was rejected before it was processed, so retrying is
-        // safe even for a procedure.
         reason: RetryReason.rateLimited,
-        isAmbiguous: false,
+        isAmbiguous: isAmbiguousFailure(e),
         statusCode: 429,
         isProcedure: isProcedure,
         nsid: nsid,
@@ -122,8 +117,7 @@ final class Challenge {
         e,
         stackTrace,
         reason: RetryReason.network,
-        // Safe only when the request provably never reached the server.
-        isAmbiguous: !_isUnreachedNetworkError(e),
+        isAmbiguous: isAmbiguousFailure(e),
         isProcedure: isProcedure,
         nsid: nsid,
         attempt: attempt,
@@ -193,7 +187,7 @@ final class Challenge {
           e,
           stackTrace,
           reason: RetryReason.network,
-          isAmbiguous: !_isUnreachedNetworkError(e),
+          isAmbiguous: isAmbiguousFailure(e),
           isProcedure: isProcedure,
           nsid: nsid,
           attempt: attempt,
@@ -268,22 +262,6 @@ final class Challenge {
     }
 
     Error.throwWithStackTrace(error, stackTrace);
-  }
-
-  /// Whether [error] indicates the request provably never reached the server
-  /// (so retrying a non-idempotent request cannot duplicate a side effect).
-  ///
-  /// Errors that leave the outcome uncertain (e.g. a connection reset while
-  /// waiting for a response) are deliberately treated as ambiguous.
-  bool _isUnreachedNetworkError(final Object error) {
-    final message = error.toString().toLowerCase();
-
-    return message.contains('connection refused') ||
-        message.contains('failed host lookup') ||
-        message.contains('no route to host') ||
-        message.contains('network is unreachable') ||
-        message.contains('nodename nor servname') ||
-        message.contains('name or service not known');
   }
 
   /// Returns how long the server asks us to wait before retrying a

--- a/packages/atproto_core/test/src/clients/ambiguous_failure_test.dart
+++ b/packages/atproto_core/test/src/clients/ambiguous_failure_test.dart
@@ -1,0 +1,259 @@
+// Copyright (c) 2023-2025, Shinya Kato.
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// Dart imports:
+import 'dart:async';
+import 'dart:io';
+
+// Package imports:
+import 'package:http/http.dart' as http;
+import 'package:test/test.dart';
+import 'package:xrpc/xrpc.dart' as xrpc;
+
+// Project imports:
+import 'package:atproto_core/src/clients/ambiguous_failure.dart';
+import 'package:atproto_core/src/clients/challenge.dart';
+import 'package:atproto_core/src/clients/retry_context.dart';
+import 'package:atproto_core/src/clients/retry_strategy.dart';
+
+xrpc.XRPCResponse<xrpc.XRPCError> _errorResponse({
+  required int statusCode,
+  String error = 'Error',
+}) => xrpc.XRPCResponse(
+  headers: const {},
+  status: xrpc.HttpStatus.valueOf(statusCode),
+  request: xrpc.XRPCRequest(
+    method: xrpc.HttpMethod.get,
+    url: Uri.https('bsky.social', '/xrpc/com.example.test'),
+  ),
+  rateLimit: xrpc.RateLimit.unlimited(),
+  data: xrpc.XRPCError(error: error),
+);
+
+/// A [RetryStrategy] that never retries and records every context it is
+/// handed, so a test can observe what the retry layer actually classified.
+final class _RecordingStrategy implements RetryStrategy {
+  final contexts = <RetryContext>[];
+
+  @override
+  FutureOr<Duration?> nextDelay(final RetryContext context) {
+    contexts.add(context);
+
+    return null;
+  }
+}
+
+/// Runs [error] through the real retry path and returns the `isAmbiguous`
+/// value the retry layer produced, or null when the error never reached the
+/// retry layer at all (i.e. it is not treated as a transient failure).
+Future<bool?> _isAmbiguousFromRetryLayer(final Object error) async {
+  final strategy = _RecordingStrategy();
+  final challenge = Challenge(strategy);
+
+  await expectLater(
+    challenge.execute<String>(
+      () async => throw error,
+      isProcedure: true,
+      nsid: 'com.example.doThing',
+    ),
+    throwsA(same(error)),
+  );
+
+  return strategy.contexts.isEmpty
+      ? null
+      : strategy.contexts.single.isAmbiguous;
+}
+
+void main() {
+  group('isAmbiguousFailure', () {
+    test('a timeout is ambiguous: the request was already sent', () {
+      expect(isAmbiguousFailure(TimeoutException('timeout')), isTrue);
+    });
+
+    test('a 500 is ambiguous: a side effect may be partially applied', () {
+      expect(
+        isAmbiguousFailure(
+          xrpc.InternalServerErrorException(
+            _errorResponse(statusCode: 500, error: 'InternalServerError'),
+          ),
+        ),
+        isTrue,
+      );
+    });
+
+    test('a 429 is not ambiguous: rejected before it was processed', () {
+      expect(
+        isAmbiguousFailure(
+          xrpc.RateLimitExceededException(
+            _errorResponse(statusCode: 429, error: 'RateLimitExceeded'),
+          ),
+        ),
+        isFalse,
+      );
+    });
+
+    group('http.ClientException', () {
+      test('is not ambiguous when the connection was never established', () {
+        expect(
+          isAmbiguousFailure(http.ClientException('Connection refused')),
+          isFalse,
+        );
+        expect(
+          isAmbiguousFailure(
+            http.ClientException('Failed host lookup: \'bsky.social\''),
+          ),
+          isFalse,
+        );
+        expect(
+          isAmbiguousFailure(http.ClientException('No route to host')),
+          isFalse,
+        );
+        expect(
+          isAmbiguousFailure(http.ClientException('Network is unreachable')),
+          isFalse,
+        );
+        expect(
+          isAmbiguousFailure(
+            http.ClientException('nodename nor servname provided'),
+          ),
+          isFalse,
+        );
+        expect(
+          isAmbiguousFailure(http.ClientException('Name or service not known')),
+          isFalse,
+        );
+      });
+
+      test('is ambiguous when the failure happened mid-exchange', () {
+        expect(
+          isAmbiguousFailure(http.ClientException('Connection reset by peer')),
+          isTrue,
+        );
+        expect(
+          isAmbiguousFailure(
+            http.ClientException('Connection closed while receiving data'),
+          ),
+          isTrue,
+        );
+      });
+
+      test('the match is case insensitive', () {
+        expect(
+          isAmbiguousFailure(http.ClientException('CONNECTION REFUSED')),
+          isFalse,
+        );
+      });
+    });
+
+    group('SocketException', () {
+      // A raw `SocketException` can escape a custom HTTP client that does not
+      // route through `package:http`'s exception mapping, and the retry layer
+      // classifies it with the same rule as `ClientException`.
+      test('is not ambiguous when the connection was never established', () {
+        expect(
+          isAmbiguousFailure(const SocketException('Connection refused')),
+          isFalse,
+        );
+      });
+
+      test('is ambiguous when the failure happened mid-exchange', () {
+        expect(
+          isAmbiguousFailure(const SocketException('Connection reset by peer')),
+          isTrue,
+        );
+      });
+    });
+
+    group('unclassified errors', () {
+      test('a 400 is not ambiguous', () {
+        expect(
+          isAmbiguousFailure(
+            xrpc.InvalidRequestException(
+              _errorResponse(statusCode: 400, error: 'InvalidRequest'),
+            ),
+          ),
+          isFalse,
+        );
+      });
+
+      test('an arbitrary error type is not ambiguous', () {
+        expect(isAmbiguousFailure(ArgumentError('broken')), isFalse);
+        expect(isAmbiguousFailure(StateError('broken')), isFalse);
+        expect(isAmbiguousFailure(Exception('broken')), isFalse);
+        expect(isAmbiguousFailure('a bare string'), isFalse);
+      });
+    });
+  });
+
+  group('isAmbiguousFailure agrees with the retry layer', () {
+    // The predicate exists so a caller can recover the classification the
+    // retry layer applied. If the two ever disagree the predicate lies, so
+    // every classified error type is driven through `Challenge` and the
+    // `RetryContext.isAmbiguous` it really produced is checked. Both the
+    // retry layer and the predicate are pinned to the same literal, so this
+    // stays a real assertion rather than a comparison of one against the
+    // other.
+    final classifiedErrors = <String, (Object, bool)>{
+      'TimeoutException': (TimeoutException('timeout'), true),
+      'InternalServerErrorException': (
+        xrpc.InternalServerErrorException(
+          _errorResponse(statusCode: 500, error: 'InternalServerError'),
+        ),
+        true,
+      ),
+      'RateLimitExceededException': (
+        xrpc.RateLimitExceededException(
+          _errorResponse(statusCode: 429, error: 'RateLimitExceeded'),
+        ),
+        false,
+      ),
+      'ClientException (unreached)': (
+        http.ClientException('Connection refused'),
+        false,
+      ),
+      'ClientException (ambiguous)': (
+        http.ClientException('Connection reset by peer'),
+        true,
+      ),
+      'SocketException (unreached)': (
+        const SocketException('Connection refused'),
+        false,
+      ),
+      'SocketException (ambiguous)': (
+        const SocketException('Connection reset by peer'),
+        true,
+      ),
+    };
+
+    for (final entry in classifiedErrors.entries) {
+      test(entry.key, () async {
+        final (error, expected) = entry.value;
+        final fromRetryLayer = await _isAmbiguousFromRetryLayer(error);
+
+        // Guards the guard: a classified error must actually reach the retry
+        // layer, otherwise the assertions below would pass vacuously.
+        expect(
+          fromRetryLayer,
+          isNotNull,
+          reason: '${entry.key} never reached the retry layer',
+        );
+        expect(fromRetryLayer, expected);
+        expect(isAmbiguousFailure(error), expected);
+      });
+    }
+
+    test(
+      'an unclassified error never reaches the retry layer at all',
+      () async {
+        // Nothing to compare for these: the retry layer rethrows without ever
+        // building a `RetryContext`, and the predicate reports `false` because
+        // such a failure never leaves a write in doubt.
+        final error = ArgumentError('broken');
+
+        expect(await _isAmbiguousFromRetryLayer(error), isNull);
+        expect(isAmbiguousFailure(error), isFalse);
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Problem

The retry layer already classifies whether a failed request **may have reached the server** — the distinction that decides whether retrying a non-idempotent procedure risks duplicating its side effect. But that classification was only visible to a `RetryStrategy`, via `RetryContext.isAmbiguous`.

Once the retries are exhausted, `challenge.dart` rethrows the **original** error through `Error.throwWithStackTrace`. Those errors include `TimeoutException` (dart:async) and `http.ClientException` (package:http) — types this package does not own. So the classification could not be attached to the exception, and a caller that writes records had no way to tell a safe retry from one that risks a duplicate write.

## Change

Adds a public pure predicate:

```dart
bool isAmbiguousFailure(final Object error);
```

Given the answer, a caller re-issues an unambiguous failure directly and reconciles an ambiguous one with a recovery read first.

**No new rules were invented.** The classification is moved verbatim out of `challenge.dart`, which now calls the predicate at every classification site. That is the point of the change: a predicate that could drift from the retry layer's real behaviour would eventually lie to callers.

## One more classification site than expected

Besides the four obvious sites, the catch-all clause also classified raw `SocketException`s that escape a custom HTTP client not routed through `package:http`'s exception mapping. Treating "anything else" as unambiguous would have made the predicate answer `false` for `SocketException('Connection reset by peer')` while the retry layer answers `true` — precisely the drift this change exists to prevent. The predicate therefore classifies `SocketException` with the same rule as `ClientException`, reusing the existing conditional-import `isSocketException` helper so the file stays web-safe.

## Tests

- One case per classified error type, including six unreached-network messages and two mid-exchange ones, plus case-insensitivity and unclassified types.
- A consistency guard that drives each error through the real retry path and asserts both the produced `RetryContext.isAmbiguous` **and** `isAmbiguousFailure(error)` equal a pinned literal — compared against literals rather than against each other, so a coordinated drift still fails.
- The `ArgumentError` case documents its own limitation in the test body: it never reaches the retry layer, so there is no `RetryContext` to compare, and the test asserts exactly that rather than pretending to.

Refactor safety was verified by reverting `challenge.dart` to its pre-refactor state and running the new tests against it — all 18 passed, so the retry behaviour is unchanged. A mutation check (hard-coding `isAmbiguous: true` back into the rate-limit branch) confirmed the guard is not vacuous.

## Verification

`atproto_core` 156 passed, `dart analyze` clean across `atproto_core` / `atproto` / `bluesky` / `xrpc`, `dart format` no diff.

## Note on versioning

No `pubspec.yaml` is touched — the CHANGELOG entry sits under `## Unreleased`. Several branches are landing in the same window, so versions are left for a single release commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)