### PR TITLE
feat(atproto_core): add actorDid, an auth-kind-agnostic actor DID

### DIFF
--- a/packages/atproto/lib/src/atproto.dart
+++ b/packages/atproto/lib/src/atproto.dart
@@ -173,6 +173,15 @@ sealed class ATProto {
   /// [ATProto.fromOAuthSession], otherwise null.
   oauth.OAuthSessionManager? get oAuthSessionManager;
 
+  /// Returns the DID of the authenticated actor, regardless of how this
+  /// instance was authenticated. Null when this instance is anonymous.
+  ///
+  /// [session] is set only for [ATProto.fromSession] and [oAuthSessionManager]
+  /// only for [ATProto.fromOAuth] / [ATProto.fromOAuthSession], so answering
+  /// "which actor is this client authenticated as?" through them means
+  /// branching on the auth kind. This getter answers it for both.
+  String? get actorDid;
+
   /// Returns the current service.
   /// Defaults to `bsky.social`.
   String get service;
@@ -296,6 +305,9 @@ final class _ATProto implements ATProto {
   @override
   oauth.OAuthSessionManager? get oAuthSessionManager =>
       _ctx.oAuthSessionManager;
+
+  @override
+  String? get actorDid => _ctx.actorDid;
 
   @override
   String get service => _ctx.service;

--- a/packages/atproto/test/src/atproto_oauth_test.dart
+++ b/packages/atproto/test/src/atproto_oauth_test.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 // Package imports:
+import 'package:atproto_core/atproto_core.dart' as core;
 import 'package:test/test.dart';
 
 // Project imports:
@@ -24,5 +25,39 @@ void main() {
     final atproto = ATProto.fromOAuth(OAuthSessionManager.fromSession(session));
     expect(atproto.service, 'pds.example');
     expect(atproto.oAuthSessionManager, isNotNull);
+  });
+
+  test('ATProto.actorDid resolves both auth kinds', () {
+    final oauth = ATProto.fromOAuth(
+      OAuthSessionManager.fromSession(
+        OAuthSession(
+          accessToken: 'a',
+          scope: 'atproto',
+          sub: 'did:plc:oauth',
+          issuer: 'https://bsky.social',
+          pds: 'https://pds.example',
+          clientId: 'cid',
+          dpopPublicKey: 'PUB',
+          dpopPrivateKey: 'PRIV',
+        ),
+      ),
+    );
+
+    //! The legacy session is null here, so `actorDid` must be reaching the
+    //! OAuth subject rather than the session.
+    expect(oauth.session, isNull);
+    expect(oauth.actorDid, 'did:plc:oauth');
+
+    final legacy = ATProto.fromSession(
+      core.Session(
+        did: 'did:plc:legacy',
+        handle: 'test.dev',
+        accessJwt: 'access',
+        refreshJwt: 'refresh',
+      ),
+    );
+
+    expect(legacy.actorDid, 'did:plc:legacy');
+    expect(ATProto.anonymous().actorDid, isNull);
   });
 }

--- a/packages/atproto_core/lib/src/clients/service_context.dart
+++ b/packages/atproto_core/lib/src/clients/service_context.dart
@@ -166,7 +166,28 @@ base class ServiceContext {
 
   Map<String, String> get headers => _headers ?? const {};
 
-  String get repo => session?.did ?? oAuthSessionManager?.currentSub ?? '';
+  /// The DID of the authenticated actor, regardless of how this context was
+  /// authenticated. Null when this context is unauthenticated.
+  ///
+  /// Resolves the legacy (app-password) [session] first and falls back to the
+  /// OAuth subject held by [oAuthSessionManager]. Neither field alone answers
+  /// the question: on an OAuth-authenticated context [session] is permanently
+  /// null, and on a legacy one there is no manager. Without this getter every
+  /// caller that supports both kinds has to re-derive the composition and
+  /// therefore has to know which kind it is holding.
+  ///
+  /// No state is introduced. The value is computed on every read from the two
+  /// fields this context already owns, so it needs no invalidation: a legacy
+  /// session refresh replaces the session in place and is observed here on the
+  /// next read, and an OAuth rotation is applied by the manager to the session
+  /// it owns, which this getter reads through rather than copies.
+  ///
+  /// [repo] is this value with "unauthenticated" collapsed to the empty
+  /// string, because that is what the `repo` request parameter is filled with.
+  /// Prefer [actorDid] whenever that distinction matters.
+  String? get actorDid => session?.did ?? oAuthSessionManager?.currentSub;
+
+  String get repo => actorDid ?? '';
 
   Future<xrpc.XRPCResponse<T>> get<T>(
     final NSID methodId, {

--- a/packages/atproto_core/test/src/clients/service_context_oauth_test.dart
+++ b/packages/atproto_core/test/src/clients/service_context_oauth_test.dart
@@ -22,4 +22,16 @@ void main() {
     expect(ctx.service, 'pds.example');
     expect(ctx.repo, 'did:plc:abc');
   });
+
+  test('actorDid falls back to the OAuth subject', () {
+    final ctx = ServiceContext(
+      oAuthSessionManager: OAuthSessionManager.fromSession(_session()),
+    );
+
+    //! The legacy session is permanently null on an OAuth-authenticated
+    //! context, so `session?.did` cannot answer "which actor is this?" here.
+    //! `actorDid` reaches the manager's subject instead.
+    expect(ctx.session, isNull);
+    expect(ctx.actorDid, 'did:plc:abc');
+  });
 }

--- a/packages/atproto_core/test/src/clients/service_context_test.dart
+++ b/packages/atproto_core/test/src/clients/service_context_test.dart
@@ -197,6 +197,69 @@ void main() {
     });
   });
 
+  group('.actorDid', () {
+    test('returns the legacy session DID', () {
+      final context = ServiceContext(
+        session: Session(
+          did: 'did:plc:iijrtk7ocored6zuziwmqq3c',
+          handle: 'shinyakato.dev',
+          accessJwt: '1234',
+          refreshJwt: '1234',
+        ),
+      );
+
+      expect(context.actorDid, 'did:plc:iijrtk7ocored6zuziwmqq3c');
+      expect(context.repo, 'did:plc:iijrtk7ocored6zuziwmqq3c');
+    });
+
+    test('is null when unauthenticated', () {
+      final context = ServiceContext();
+
+      expect(context.actorDid, isNull);
+      //! `repo` keeps collapsing "no actor" to the empty string, which is what
+      //! the `repo` request parameter has always been filled with. Redefining
+      //! it in terms of `actorDid` must not turn that into a null.
+      expect(context.repo, '');
+    });
+
+    test('follows the session adopted by a refresh', () async {
+      //! A real `refreshSession` never changes the DID; changing it here is
+      //! what makes it observable that `actorDid` reads the current session on
+      //! every access instead of snapshotting the one passed to the
+      //! constructor.
+      final context = ServiceContext(
+        session: Session(
+          did: 'did:plc:before',
+          handle: 'test.dev',
+          accessJwt: 'old-token',
+          refreshJwt: 'refresh-token',
+        ),
+        onRefreshSession: (current) async =>
+            current.copyWith(did: 'did:plc:after', accessJwt: 'new-token'),
+        getClient: (url, {headers}) async {
+          final refreshed = headers?['Authorization'] == 'Bearer new-token';
+
+          return http.Response(
+            refreshed ? '{}' : '{"error":"ExpiredToken"}',
+            refreshed ? 200 : 401,
+            headers: {'content-type': 'application/json'},
+            request: http.Request('GET', url),
+          );
+        },
+      );
+
+      expect(context.actorDid, 'did:plc:before');
+
+      await context.get<Map<String, Object?>>(
+        NSID.create('server.atproto.com', 'getSession'),
+        to: (json) => json,
+      );
+
+      expect(context.actorDid, 'did:plc:after');
+      expect(context.repo, 'did:plc:after');
+    });
+  });
+
   group('.get', () {
     test('generates JOSE-compatible DPoP proofs', () {
       final keyPair = getKeyPair();

--- a/packages/bluesky/lib/src/bluesky.dart
+++ b/packages/bluesky/lib/src/bluesky.dart
@@ -142,6 +142,16 @@ sealed class Bluesky {
   /// [Bluesky.fromOAuthSession], otherwise null.
   oauth.OAuthSessionManager? get oAuthSessionManager;
 
+  /// Returns the DID of the authenticated actor, regardless of how this
+  /// instance was authenticated. Null when this instance is anonymous.
+  ///
+  /// [session] is set only for [Bluesky.fromSession] and
+  /// [oAuthSessionManager] only for [Bluesky.fromOAuth] /
+  /// [Bluesky.fromOAuthSession], so answering "which actor is this client
+  /// authenticated as?" through them means branching on the auth kind. This
+  /// getter answers it for both.
+  String? get actorDid;
+
   /// Returns the current service.
   /// Defaults to `bsky.social`.
   String get service;
@@ -234,6 +244,9 @@ final class _Bluesky implements Bluesky {
   @override
   oauth.OAuthSessionManager? get oAuthSessionManager =>
       _ctx.oAuthSessionManager;
+
+  @override
+  String? get actorDid => _ctx.actorDid;
 
   @override
   String get service => _ctx.service;

--- a/packages/bluesky/lib/src/bluesky_chat.dart
+++ b/packages/bluesky/lib/src/bluesky_chat.dart
@@ -124,6 +124,16 @@ sealed class BlueskyChat {
   /// [BlueskyChat.fromOAuthSession], otherwise null.
   oauth.OAuthSessionManager? get oAuthSessionManager;
 
+  /// Returns the DID of the authenticated actor, regardless of how this
+  /// instance was authenticated. Null when this instance is anonymous.
+  ///
+  /// [session] is set only for [BlueskyChat.fromSession] and
+  /// [oAuthSessionManager] only for [BlueskyChat.fromOAuth] /
+  /// [BlueskyChat.fromOAuthSession], so answering "which actor is this client
+  /// authenticated as?" through them means branching on the auth kind. This
+  /// getter answers it for both.
+  String? get actorDid;
+
   /// Returns atproto features.
   atp.ATProto get atproto;
 
@@ -179,6 +189,9 @@ final class _BlueskyChat implements BlueskyChat {
   @override
   oauth.OAuthSessionManager? get oAuthSessionManager =>
       _ctx.oAuthSessionManager;
+
+  @override
+  String? get actorDid => _ctx.actorDid;
 
   @override
   String get service => _ctx.service;

--- a/packages/bluesky/lib/src/ozone_tool.dart
+++ b/packages/bluesky/lib/src/ozone_tool.dart
@@ -127,6 +127,16 @@ sealed class OzoneTool {
   /// [OzoneTool.fromOAuthSession], otherwise null.
   oauth.OAuthSessionManager? get oAuthSessionManager;
 
+  /// Returns the DID of the authenticated actor, regardless of how this
+  /// instance was authenticated. Null when this instance is anonymous.
+  ///
+  /// [session] is set only for [OzoneTool.fromSession] and
+  /// [oAuthSessionManager] only for [OzoneTool.fromOAuth] /
+  /// [OzoneTool.fromOAuthSession], so answering "which actor is this client
+  /// authenticated as?" through them means branching on the auth kind. This
+  /// getter answers it for both.
+  String? get actorDid;
+
   /// Returns the current service.
   /// Defaults to `bsky.social`.
   String get service;
@@ -216,6 +226,9 @@ final class _OzoneTool implements OzoneTool {
   @override
   oauth.OAuthSessionManager? get oAuthSessionManager =>
       _ctx.oAuthSessionManager;
+
+  @override
+  String? get actorDid => _ctx.actorDid;
 
   @override
   String get service => _ctx.service;

--- a/packages/bluesky/test/src/bluesky_oauth_test.dart
+++ b/packages/bluesky/test/src/bluesky_oauth_test.dart
@@ -3,25 +3,74 @@
 // BSD-style license that can be found in the LICENSE file.
 
 // Package imports:
+import 'package:atproto_core/atproto_core.dart' as core;
 import 'package:test/test.dart';
 
 // Project imports:
 import 'package:bluesky/atproto_oauth.dart';
 import 'package:bluesky/bluesky.dart';
+import 'package:bluesky/bluesky_chat.dart';
+import 'package:bluesky/ozone.dart';
+
+OAuthSession _oAuthSession({final String sub = 'did:plc:abc'}) => OAuthSession(
+  accessToken: 'a',
+  scope: 'atproto',
+  sub: sub,
+  issuer: 'https://bsky.social',
+  pds: 'https://pds.example',
+  clientId: 'cid',
+  dpopPublicKey: 'PUB',
+  dpopPrivateKey: 'PRIV',
+);
+
+core.Session _session() => core.Session(
+  did: 'did:plc:legacy',
+  handle: 'test.dev',
+  accessJwt: 'access',
+  refreshJwt: 'refresh',
+);
 
 void main() {
   test('Bluesky.fromOAuth exposes the manager', () {
-    final session = OAuthSession(
-      accessToken: 'a',
-      scope: 'atproto',
-      sub: 'did:plc:abc',
-      issuer: 'https://bsky.social',
-      pds: 'https://pds.example',
-      clientId: 'cid',
-      dpopPublicKey: 'PUB',
-      dpopPrivateKey: 'PRIV',
+    final bsky = Bluesky.fromOAuth(
+      OAuthSessionManager.fromSession(_oAuthSession()),
     );
-    final bsky = Bluesky.fromOAuth(OAuthSessionManager.fromSession(session));
     expect(bsky.oAuthSessionManager, isNotNull);
+  });
+
+  test('Bluesky.actorDid resolves both auth kinds', () {
+    final oauth = Bluesky.fromOAuth(
+      OAuthSessionManager.fromSession(_oAuthSession(sub: 'did:plc:oauth')),
+    );
+
+    //! The legacy session is null here, so `actorDid` must be reaching the
+    //! OAuth subject rather than the session.
+    expect(oauth.session, isNull);
+    expect(oauth.actorDid, 'did:plc:oauth');
+
+    expect(Bluesky.fromSession(_session()).actorDid, 'did:plc:legacy');
+    expect(Bluesky.anonymous().actorDid, isNull);
+  });
+
+  test('BlueskyChat.actorDid resolves both auth kinds', () {
+    final oauth = BlueskyChat.fromOAuth(
+      OAuthSessionManager.fromSession(_oAuthSession(sub: 'did:plc:oauth')),
+    );
+
+    expect(oauth.session, isNull);
+    expect(oauth.actorDid, 'did:plc:oauth');
+
+    expect(BlueskyChat.fromSession(_session()).actorDid, 'did:plc:legacy');
+  });
+
+  test('OzoneTool.actorDid resolves both auth kinds', () {
+    final oauth = OzoneTool.fromOAuth(
+      OAuthSessionManager.fromSession(_oAuthSession(sub: 'did:plc:oauth')),
+    );
+
+    expect(oauth.session, isNull);
+    expect(oauth.actorDid, 'did:plc:oauth');
+
+    expect(OzoneTool.fromSession(_session()).actorDid, 'did:plc:legacy');
   });
 }


### PR DESCRIPTION
## Problem

There is no public, auth-kind-agnostic way to ask a client "which actor am I authenticated as?".

`ServiceContext.session` is the legacy (app-password) session and is permanently null on an OAuth-authenticated context; OAuth callers must reach through `oAuthSessionManager.currentSub` instead. So every application supporting both auth kinds hand-writes `session?.did ?? oAuthSessionManager?.currentSub`.

## Change

```dart
// ServiceContext
String? get actorDid => session?.did ?? oAuthSessionManager?.currentSub;
String get repo => actorDid ?? '';   // unchanged behaviour, now defined in terms of it
```

The composition already existed inside `repo`, which fills the `repo` parameter of requests and therefore collapses "unauthenticated" to the empty string. `actorDid` is the nullable, properly-named form; redefining `repo` in terms of it keeps the two from drifting.

Delegated onto `ATProto`, `Bluesky`, `BlueskyChat` and `OzoneTool`, each in the same position as the existing `session` / `onSessionUpdated` / `oAuthSessionManager` delegations. `OzoneTool` is included so the four client surfaces stay consistent.

Named `actorDid` rather than `repo` because `ATProto.repo` is already the `com.atproto.repo.*` service.

## Tests

- All three context states: app-password (`actorDid` is the session DID), OAuth (`session` asserted null **and** `actorDid` is the manager's subject, so it can only be resolving through the manager), anonymous (`actorDid` null and `repo` still `''` — the regression guard for the `repo` redefinition).
- A real 401→refresh cycle whose `onRefreshSession` returns a session with a different DID, proving the value is read live rather than snapshotted. The test comment states plainly that a real `refreshSession` never changes the DID; the change is what makes live-reading observable.
- Client-level delegation tests for all four classes.

Mutation-checked: reducing `actorDid` to `session?.did` fails 3 tests in `atproto_core` plus tests in `bluesky`.

## Verification

`atproto_core` 142, `atproto` 389, `bluesky` 878 — all passed. `dart analyze` clean, `dart format` no diff.

## Note on versioning

No `pubspec.yaml` is touched — the CHANGELOG entries sit under `## Unreleased`. Several branches are landing in the same window, so versions are left for a single release commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)