### PR TITLE
feat(bluesky): share one ATProto context across clients

### DIFF
--- a/packages/bluesky/lib/src/bluesky.dart
+++ b/packages/bluesky/lib/src/bluesky.dart
@@ -13,7 +13,47 @@ import 'services/app/bsky/video_service.dart';
 
 /// Provides `app.bsky.*` services.
 sealed class Bluesky {
+  /// Returns a new [Bluesky] that drives every `app.bsky.*` service from the
+  /// context [atproto] already owns — see [atp.ATProto.ctx].
+  ///
+  /// Reach for this whenever one account needs more than one client. Every
+  /// other factory builds its own [atp.ATProto], and each of those owns a
+  /// separate [core.ServiceContext] holding a separate copy of the session.
+  /// Refresh tokens are single-use, so the moment the access token expires
+  /// those copies race: whichever context notices first spends the refresh
+  /// token, the other one's refresh is rejected by the server, and the losing
+  /// client fails with an `UnauthorizedException` the caller did nothing to
+  /// provoke.
+  ///
+  /// One shared context removes the race by construction:
+  ///
+  /// - **One session.** [session] reads the context's own field, so a refresh
+  ///   performed for one client is immediately visible to every other.
+  /// - **One refresh.** Concurrent expired requests join the single in-flight
+  ///   `refreshSession` call instead of each firing their own.
+  /// - **One [onSessionUpdated].** The stream belongs to the context, so a
+  ///   listener attached to any client observes every refresh — and what it
+  ///   emits is the only session worth persisting.
+  ///
+  /// ```dart
+  /// final atproto = atp.ATProto.fromSession(session);
+  /// final bluesky = Bluesky.fromAtproto(atproto);
+  ///
+  /// // `bluesky.session` and `atproto.session` are the same session.
+  /// ```
+  ///
+  /// Note that headers belong to the context too, so an [atproto] carrying a
+  /// service proxy header (`atproto-proxy`) sends every `app.bsky.*` call to
+  /// that service as well. Pass a client built for `app.bsky.*` traffic.
+  factory Bluesky.fromAtproto(final atp.ATProto atproto) = _Bluesky.fromAtproto;
+
   /// Returns the new instance of [Bluesky].
+  ///
+  /// This builds a fresh [atp.ATProto], and therefore a fresh
+  /// [core.ServiceContext] carrying its own copy of [session]. When the same
+  /// account also needs another client, build the [atp.ATProto] once and pass
+  /// it to [Bluesky.fromAtproto] instead — two contexts each holding a copy of
+  /// one session race to spend a single-use refresh token.
   factory Bluesky.fromSession(
     final core.Session session, {
     final Map<String, String>? headers,

--- a/packages/bluesky/lib/src/bluesky_chat.dart
+++ b/packages/bluesky/lib/src/bluesky_chat.dart
@@ -19,6 +19,25 @@ const _kBskyChatProxyHeaders = <String, String>{
 /// Provides `chat.bsky.*` services.
 sealed class BlueskyChat {
   /// Returns the new instance of [BlueskyChat].
+  ///
+  /// This builds a fresh [atp.ATProto], and therefore a fresh
+  /// [core.ServiceContext] carrying its own copy of [session].
+  ///
+  /// A `chat.bsky.*` client cannot share that context with another client, as
+  /// `Bluesky.fromAtproto` and `OzoneTool.fromAtproto` allow. Routing these
+  /// calls to the chat service takes an `atproto-proxy` header, headers belong
+  /// to the context rather than to the client reading from it, and a shared
+  /// context would therefore proxy the other client's `app.bsky.*` and
+  /// `com.atproto.*` calls to the chat service as well.
+  ///
+  /// That is worth knowing, because refresh tokens are single-use: a
+  /// [BlueskyChat] and any other client for the same account hold two copies
+  /// of one session, and whichever context first notices an expired access
+  /// token spends the refresh token the other one still holds. The other
+  /// client's own refresh is then rejected, and its next call fails with an
+  /// `UnauthorizedException`. Both directions are equally affected, so an app
+  /// that runs both keeps them in step by rebuilding one from the session the
+  /// other's [onSessionUpdated] emits.
   factory BlueskyChat.fromSession(
     final core.Session session, {
     final Map<String, String>? headers,

--- a/packages/bluesky/lib/src/ozone_tool.dart
+++ b/packages/bluesky/lib/src/ozone_tool.dart
@@ -21,7 +21,48 @@ import 'services/codegen/tools/ozone/verification_service.dart';
 
 /// Provides `tools.ozone.*` services.
 sealed class OzoneTool {
+  /// Returns a new [OzoneTool] that drives every `tools.ozone.*` service from
+  /// the context [atproto] already owns — see [atp.ATProto.ctx].
+  ///
+  /// Reach for this whenever one account needs more than one client. Every
+  /// other factory builds its own [atp.ATProto], and each of those owns a
+  /// separate [core.ServiceContext] holding a separate copy of the session.
+  /// Refresh tokens are single-use, so the moment the access token expires
+  /// those copies race: whichever context notices first spends the refresh
+  /// token, the other one's refresh is rejected by the server, and the losing
+  /// client fails with an `UnauthorizedException` the caller did nothing to
+  /// provoke.
+  ///
+  /// One shared context removes the race by construction:
+  ///
+  /// - **One session.** [session] reads the context's own field, so a refresh
+  ///   performed for one client is immediately visible to every other.
+  /// - **One refresh.** Concurrent expired requests join the single in-flight
+  ///   `refreshSession` call instead of each firing their own.
+  /// - **One [onSessionUpdated].** The stream belongs to the context, so a
+  ///   listener attached to any client observes every refresh — and what it
+  ///   emits is the only session worth persisting.
+  ///
+  /// ```dart
+  /// final atproto = atp.ATProto.fromSession(session);
+  /// final ozone = OzoneTool.fromAtproto(atproto);
+  ///
+  /// // `ozone.session` and `atproto.session` are the same session.
+  /// ```
+  ///
+  /// Note that headers belong to the context too, so an [atproto] carrying a
+  /// service proxy header (`atproto-proxy`) sends every `tools.ozone.*` call
+  /// to that service as well. Pass a client built for `tools.ozone.*` traffic.
+  factory OzoneTool.fromAtproto(final atp.ATProto atproto) =
+      _OzoneTool.fromAtproto;
+
   /// Returns the new instance of [OzoneTool].
+  ///
+  /// This builds a fresh [atp.ATProto], and therefore a fresh
+  /// [core.ServiceContext] carrying its own copy of [session]. When the same
+  /// account also needs another client, build the [atp.ATProto] once and pass
+  /// it to [OzoneTool.fromAtproto] instead — two contexts each holding a copy
+  /// of one session race to spend a single-use refresh token.
   factory OzoneTool.fromSession(
     final core.Session session, {
     final Map<String, String>? headers,

--- a/packages/bluesky/test/src/from_atproto_test.dart
+++ b/packages/bluesky/test/src/from_atproto_test.dart
@@ -1,0 +1,260 @@
+// Package imports:
+import 'package:atproto/atproto.dart' as atp;
+import 'package:atproto_core/atproto_core.dart' as core;
+import 'package:http/http.dart' as http;
+import 'package:test/test.dart';
+
+// Project imports:
+import 'package:bluesky/src/bluesky.dart';
+import 'package:bluesky/src/bluesky_chat.dart';
+import 'package:bluesky/src/ozone_tool.dart';
+
+/// A fake PDS that enforces the one rule these tests are about: a refresh
+/// token is single-use.
+///
+/// Every authenticated `GET` fails with `401` unless it carries the current
+/// access token, and `com.atproto.server.refreshSession` fails unless it
+/// carries the current refresh token — so a client working from a stale copy
+/// of the session cannot recover, exactly as the real server behaves.
+final class _FakePds {
+  /// The only access token this PDS accepts.
+  ///
+  /// Starts as a value no client was ever handed, so the access token in
+  /// [initialSession] is already expired — the situation these tests are
+  /// about.
+  String _access = '<expired>';
+  String _refresh = 'refresh-0';
+  int _rotations = 0;
+
+  /// How many times `com.atproto.server.refreshSession` was called.
+  int refreshCalls = 0;
+
+  /// The session handed to the client, holding the tokens this PDS starts
+  /// with.
+  ///
+  /// The tokens are deliberately not JWTs, so the pre-flight expiry check is
+  /// skipped and the reactive `401` path is what gets exercised.
+  core.Session get initialSession => core.Session(
+    did: 'did:plc:testaccount',
+    handle: 'test.dev',
+    accessJwt: 'access-0',
+    refreshJwt: 'refresh-0',
+  );
+
+  Future<http.Response> get(
+    final Uri url, {
+    final Map<String, String>? headers,
+  }) async {
+    if (headers?['Authorization'] != 'Bearer $_access') {
+      return _response(url, 'GET', 401, '{"error":"ExpiredToken"}');
+    }
+
+    return _response(
+      url,
+      'GET',
+      200,
+      url.path.contains('tools.ozone.server.getConfig') ? '{}' : '{"feed":[]}',
+    );
+  }
+
+  Future<http.Response> post(
+    final Uri url, {
+    final Map<String, String>? headers,
+    final Object? body,
+    final Object? encoding,
+  }) async {
+    expect(url.path, contains('com.atproto.server.refreshSession'));
+    refreshCalls++;
+
+    if (headers?['Authorization'] != 'Bearer $_refresh') {
+      //! The refresh token was already spent by someone else.
+      return _response(url, 'POST', 400, '{"error":"ExpiredToken"}');
+    }
+
+    _rotations++;
+    _access = 'access-$_rotations';
+    _refresh = 'refresh-$_rotations';
+
+    return _response(
+      url,
+      'POST',
+      200,
+      '{"accessJwt":"$_access","refreshJwt":"$_refresh",'
+          '"handle":"test.dev","did":"did:plc:testaccount"}',
+    );
+  }
+
+  static http.Response _response(
+    final Uri url,
+    final String method,
+    final int status,
+    final String body,
+  ) => http.Response(
+    body,
+    status,
+    headers: {'content-type': 'application/json'},
+    request: http.Request(method, url),
+  );
+}
+
+void main() {
+  group('.fromAtproto', () {
+    test('drives every client from the caller-owned context', () {
+      final pds = _FakePds();
+      final atproto = atp.ATProto.fromSession(
+        pds.initialSession,
+        service: 'pds.test',
+        getClient: pds.get,
+        postClient: pds.post,
+      );
+
+      final bsky = Bluesky.fromAtproto(atproto);
+      final ozone = OzoneTool.fromAtproto(atproto);
+
+      //! Not merely equal: the very same context, so there is only one place
+      //! the session can live.
+      expect(identical(bsky.atproto, atproto), isTrue);
+      expect(identical(ozone.atproto, atproto), isTrue);
+      expect(identical(bsky.atproto.ctx, ozone.atproto.ctx), isTrue);
+      expect(identical(bsky.session, ozone.session), isTrue);
+      expect(identical(bsky.session, atproto.session), isTrue);
+    });
+
+    test('a refresh driven by one client is adopted by the other', () async {
+      final pds = _FakePds();
+      final atproto = atp.ATProto.fromSession(
+        pds.initialSession,
+        service: 'pds.test',
+        getClient: pds.get,
+        postClient: pds.post,
+      );
+
+      final bsky = Bluesky.fromAtproto(atproto);
+      final ozone = OzoneTool.fromAtproto(atproto);
+
+      final fromBsky = <core.Session>[];
+      final fromOzone = <core.Session>[];
+      bsky.onSessionUpdated.listen(fromBsky.add);
+      ozone.onSessionUpdated.listen(fromOzone.add);
+
+      //! Only the `app.bsky.*` client makes a call, and only it hits the
+      //! expired access token.
+      await bsky.feed.getTimeline();
+      await Future<void>.delayed(Duration.zero);
+
+      expect(pds.refreshCalls, 1);
+      expect(bsky.session?.accessJwt, 'access-1');
+      expect(ozone.session?.accessJwt, 'access-1');
+      expect(atproto.session?.accessJwt, 'access-1');
+
+      //! One stream source: the refresh nobody asked the ozone client about is
+      //! still announced to a listener attached to it.
+      expect(fromBsky.single.refreshJwt, 'refresh-1');
+      expect(fromOzone.single.refreshJwt, 'refresh-1');
+      expect(identical(fromBsky.single, fromOzone.single), isTrue);
+    });
+
+    test('the second client never spends the used refresh token', () async {
+      final pds = _FakePds();
+      final atproto = atp.ATProto.fromSession(
+        pds.initialSession,
+        service: 'pds.test',
+        getClient: pds.get,
+        postClient: pds.post,
+      );
+
+      final bsky = Bluesky.fromAtproto(atproto);
+      final ozone = OzoneTool.fromAtproto(atproto);
+
+      await bsky.feed.getTimeline();
+      final response = await ozone.server.getConfig();
+
+      //! The ozone call succeeded on its first attempt with the token the
+      //! timeline call had already obtained: one refresh in total, and the
+      //! single-use token was never presented twice.
+      expect(response.status.code, 200);
+      expect(pds.refreshCalls, 1);
+    });
+
+    test('two independent contexts race for the single-use token', () async {
+      final pds = _FakePds();
+      final session = pds.initialSession;
+
+      //! What a caller writes without `fromAtproto`: each factory builds its
+      //! own `ATProto`, and each of those owns a context with its own copy of
+      //! `session`.
+      final bsky = Bluesky.fromSession(
+        session,
+        service: 'pds.test',
+        getClient: pds.get,
+        postClient: pds.post,
+      );
+      final ozone = OzoneTool.fromSession(
+        session,
+        service: 'pds.test',
+        getClient: pds.get,
+        postClient: pds.post,
+      );
+
+      expect(identical(bsky.atproto.ctx, ozone.atproto.ctx), isFalse);
+
+      await bsky.feed.getTimeline();
+
+      //! The ozone context never saw the refresh, so it retries with the token
+      //! the timeline call already spent and the server rejects it.
+      expect(ozone.session?.refreshJwt, 'refresh-0');
+      await expectLater(
+        ozone.server.getConfig(),
+        throwsA(isA<core.UnauthorizedException>()),
+      );
+    });
+  });
+
+  group('existing factories', () {
+    core.Session session() => core.Session(
+      did: 'did:plc:testaccount',
+      handle: 'test.dev',
+      accessJwt: 'access',
+      refreshJwt: 'refresh',
+    );
+
+    test('Bluesky.fromSession still owns the session it was given', () {
+      final bsky = Bluesky.fromSession(session());
+
+      expect(bsky.session, session());
+      expect(bsky.headers, isEmpty);
+    });
+
+    test('OzoneTool.fromSession still owns the session it was given', () {
+      final ozone = OzoneTool.fromSession(
+        session(),
+        headers: const {'x-test': 'value'},
+      );
+
+      expect(ozone.session, session());
+      //! Ozone adds no headers of its own; the caller's pass straight through.
+      expect(ozone.headers, {'x-test': 'value'});
+    });
+
+    test('BlueskyChat.fromSession still adds the proxy header', () {
+      final chat = BlueskyChat.fromSession(session());
+
+      expect(chat.headers['atproto-proxy'], 'did:web:api.bsky.chat#bsky_chat');
+      expect(chat.session, session());
+    });
+
+    test('BlueskyChat.fromSession still merges caller headers', () {
+      final chat = BlueskyChat.fromSession(
+        session(),
+        headers: const {'x-test': 'value'},
+      );
+
+      expect(chat.headers['x-test'], 'value');
+      expect(chat.headers['atproto-proxy'], 'did:web:api.bsky.chat#bsky_chat');
+    });
+
+    test('Bluesky.anonymous still has no session', () {
+      expect(Bluesky.anonymous().session, isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Problem

Refresh tokens are single-use. Every factory built its own `ATProto`, and each of those owned a `ServiceContext` holding its own copy of the session — so an app needing more than one client for the same account ended up with two copies of one session. The moment the access token expires they race: the context that notices first spends the refresh token, and the other one's refresh is rejected, surfacing as an `UnauthorizedException` the caller did nothing to provoke.

The correct structure already existed privately — `_Bluesky.fromAtproto` and its doc comment already name this hazard — but every public factory built a fresh `ATProto`, so there was no way to say "share this one".

## Change

```dart
factory Bluesky.fromAtproto(final atp.ATProto atproto);
factory OzoneTool.fromAtproto(final atp.ATProto atproto);
```

One `ATProto` passed to both gives them one session, one deduplicated refresh, and one `onSessionUpdated` stream. Strictly additive; no existing factory changed. `fromSession`'s doc comments now point at `fromAtproto` for the multi-client case, since that is where callers currently fall into the trap.

## `BlueskyChat` is deliberately excluded

The obvious third factory does not work, and shipping it with a caveat would be worse than not shipping it.

`_kBskyChatProxyHeaders` (`atproto-proxy: did:web:api.bsky.chat#bsky_chat`) is merged into the **context's** headers by the chat factories, and `ServiceContext._headers` is context-wide — merged into every request. So a shared context carrying the header would proxy the other client's `app.bsky.*` and `com.atproto.*` calls to the chat service, and one without it would send `chat.bsky.*` to the PDS.

`BlueskyChat.fromSession`'s doc now records this and what it costs: a chat client always holds its own copy of the session and races any other client for the same account's refresh token. The honest mitigation — rebuilding one client from the session the other's `onSessionUpdated` emits — is documented; no future work is promised. `Bluesky` and `OzoneTool` inject no headers of their own, which is why they are unconditionally safe.

## Tests

A `_FakePds` helper enforces genuine single-use refresh semantics: a `GET` 401s unless it carries the current access token, and `refreshSession` returns 400 unless it carries the current refresh token, so refreshes are real rather than simulated.

- One context, one session object, shared across both clients (`identical` on contexts and sessions).
- A refresh driven by one client is adopted by the other, with exactly one refresh call, and listeners on both `onSessionUpdated` streams receive the same event.
- **The contrast case reproduces the actual bug**: two clients built from separate `fromSession` calls, and the second genuinely throws `UnauthorizedException` because the server rejects the spent refresh token.
- Regression guards on every pre-existing factory, including that `OzoneTool.fromSession` passes caller headers through untouched — which is what the header-neutrality argument rests on.

## Verification

`bluesky` 884 passed, `dart analyze` clean across `bluesky` / `atproto` / `atproto_core`, `dart format` no diff.

## Note on versioning

No `pubspec.yaml` is touched — the CHANGELOG entry sits under `## Unreleased`. Several branches are landing in the same window, so versions are left for a single release commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)