### PR TITLE
feat(atproto_core,bluesky): share one session across clients that need different headers

### DIFF
--- a/packages/atproto/lib/src/atproto.dart
+++ b/packages/atproto/lib/src/atproto.dart
@@ -67,6 +67,14 @@ sealed class ATProto {
 
   /// Returns a new [ATProto] backed by an OAuth [manager], which owns DPoP
   /// header building and transparent token refresh.
+  ///
+  /// The [oauth.OAuthSessionManager] is what gets shared on this path: it
+  /// holds the session, the single in-flight refresh, and its own
+  /// `onSessionUpdated`, none of which live on the context. So passing one
+  /// manager to several clients gives them one session and one refresh even
+  /// though each keeps a context of its own. Build the manager once and pass
+  /// it around; [ATProto.fromOAuthSession] builds a new one on every call and
+  /// does not share.
   factory ATProto.fromOAuth(
     final oauth.OAuthSessionManager manager, {
     final Map<String, String>? headers,
@@ -95,6 +103,16 @@ sealed class ATProto {
   ///
   /// Pass [oauthClient] to enable transparent token refresh; without it the
   /// session is used as-is and cannot be refreshed.
+  ///
+  /// This builds a fresh [oauth.OAuthSessionManager] on every call, so calling
+  /// it twice for one account does not give you two views of a shared session
+  /// — and what it gives you instead is worse than two independent clients.
+  /// Each manager holds its own copy of [session], and a rotating refresh
+  /// token is only honoured once: whichever manager refreshes first spends it,
+  /// and the other's refresh comes back as an `OAuthSessionRevokedException`
+  /// — the signal to send the user back through authorization — for a session
+  /// that was working moments earlier. Build the manager yourself and pass it
+  /// to [ATProto.fromOAuth] when more than one client shares an account.
   factory ATProto.fromOAuthSession(
     final oauth.OAuthSession session, {
     final oauth.OAuthClient? oauthClient,

--- a/packages/atproto_core/lib/src/clients/service_context.dart
+++ b/packages/atproto_core/lib/src/clients/service_context.dart
@@ -17,44 +17,34 @@ import '../types/session.dart';
 import 'challenge.dart';
 import 'retry_strategy.dart';
 
-base class ServiceContext {
-  ServiceContext({
-    Map<String, String>? headers,
-    xrpc.Protocol? protocol,
-    String? service,
-    String? relayService,
-    Session? session,
-    this.oAuthSessionManager,
-    Duration? timeout,
-    RetryStrategy? retryConfig,
-    final xrpc.GetClient? getClient,
-    final xrpc.PostClient? postClient,
-    this.onRefreshSession,
-  }) : _headers = headers,
-       _protocol = protocol ?? defaultProtocol,
-       _currentSession = session,
-       _explicitService = service,
-       relayService = relayService ?? defaultRelayService,
-       _challenge = Challenge(retryConfig),
-       _timeout = timeout ?? defaultTimeout,
-       _getClient = getClient,
-       _postClient = postClient;
-
-  /// The global headers without auth header.
-  final Map<String, String>? _headers;
+/// Owns everything about one account's legacy (app-password) session that
+/// changes over time: the current credentials, the single in-flight refresh,
+/// the stream announcing rotations, and the caches derived from the access
+/// token.
+///
+/// This is deliberately separate from [ServiceContext] so that contexts
+/// differing only in the headers they send can share one of these instead of
+/// each holding a copy. Headers belong to the client that sends them; the
+/// session belongs to the account, and refresh tokens are single-use, so a
+/// second copy of the session is a race waiting for the access token to
+/// expire.
+///
+/// Kept private: unlike [OAuthSessionManager], which the caller builds and
+/// hands over along with its DPoP signer, nonce cache, and OAuth client, there
+/// is nothing here for a caller to choose. Both fields are assembled by the
+/// factory that builds the context.
+///
+/// Left empty and unused on OAuth-backed contexts, where [OAuthSessionManager]
+/// plays exactly this role.
+final class _SessionState {
+  _SessionState(this.session, this.onRefreshSession);
 
   /// The current session.
   ///
   /// This is mutable internally so that an expired access token can be
   /// transparently refreshed via [onRefreshSession] without recreating the
   /// context.
-  Session? _currentSession;
-
-  /// Returns the current session.
-  ///
-  /// After an automatic refresh this reflects the latest credentials, so
-  /// callers can persist the up-to-date session.
-  Session? get session => _currentSession;
+  Session? session;
 
   /// Optional callback used to refresh an expired [session].
   ///
@@ -69,8 +59,200 @@ base class ServiceContext {
   /// `OAuthSessionManager._inflightRefresh` for the OAuth path.
   Future<Session>? _inflightRefresh;
 
-  final StreamController<Session> _sessionUpdates =
+  final StreamController<Session> _updates =
       StreamController<Session>.broadcast();
+
+  Stream<Session> get updates => _updates.stream;
+
+  /// Caches the decoded access-token expiry so the pre-flight refresh check
+  /// does not re-run `decodeJwt` on every authenticated request. Keyed by the
+  /// access JWT string, so it is implicitly invalidated whenever the session
+  /// (and therefore the access token) changes on refresh.
+  String? _cachedAccessJwt;
+  DateTime? _cachedAccessExp;
+
+  /// Caches the resolved PDS endpoint so the `service` getter does not
+  /// re-run the JWT base64/JSON decode (via `atprotoPdsEndpoint`) on every
+  /// authenticated request when the `didDoc` lacks a `#atproto_pds` service.
+  /// Keyed by the access JWT string, so it is implicitly invalidated whenever
+  /// the session (and therefore the access token) changes on refresh.
+  /// Mirrors [_cachedAccessExp].
+  String? _cachedPdsJwt;
+  String? _cachedPdsEndpoint;
+
+  /// The clock skew margin used to refresh an access token slightly before it
+  /// actually expires.
+  static const Duration _refreshSkew = Duration(seconds: 30);
+
+  /// Returns the cached PDS endpoint for [current], recomputing (and thus
+  /// re-decoding the access JWT) only when the access token has changed since
+  /// the last call. Returns null when the session yields no PDS endpoint.
+  String? pdsEndpoint(final Session current) {
+    if (_cachedPdsJwt == current.accessJwt) return _cachedPdsEndpoint;
+
+    _cachedPdsJwt = current.accessJwt;
+
+    return _cachedPdsEndpoint = current.atprotoPdsEndpoint;
+  }
+
+  /// Refreshes the legacy [current] session, deduplicating concurrent
+  /// refreshes.
+  ///
+  /// The first caller starts the single `onRefreshSession` call and stores it
+  /// in [_inflightRefresh]; concurrent callers await that same future instead
+  /// of each firing their own `refreshSession` POST (a refresh stampede). The
+  /// in-flight future is cleared once it settles so a later expiry can refresh
+  /// again.
+  Future<Session> refresh(final Session current) {
+    final existing = _inflightRefresh;
+    if (existing != null) return existing;
+
+    final refresh = onRefreshSession!;
+    final future = refresh(current)
+        .then((refreshed) {
+          session = refreshed;
+          //! Broadcast after adopting it, so a listener that reads `session`
+          //! sees the credentials it was just handed. Never awaited: a slow or
+          //! throwing listener must not delay or fail the request that
+          //! triggered the refresh.
+          _updates.add(refreshed);
+
+          return refreshed;
+        })
+        .whenComplete(() => _inflightRefresh = null);
+
+    return _inflightRefresh = future;
+  }
+
+  /// Attempts to refresh an expired access token in response to a genuine
+  /// `401 Unauthorized`.
+  ///
+  /// Returns true when the session was refreshed and the request should be
+  /// retried, or false when no refresh is possible (no session, no callback)
+  /// or the refresh itself failed. On failure the original `401` is surfaced
+  /// by the caller.
+  Future<bool> refreshOnUnauthorized() async {
+    final current = session;
+    if (current == null || onRefreshSession == null) return false;
+
+    try {
+      await refresh(current);
+
+      return true;
+    } catch (_) {
+      //! Swallow refresh errors so the original unauthorized error surfaces.
+      return false;
+    }
+  }
+
+  /// Proactively refreshes the session when the current access token is
+  /// expired or about to expire within [_refreshSkew].
+  ///
+  /// This is best-effort: if the access token cannot be decoded, or the
+  /// refresh fails, the request proceeds unchanged and the reactive
+  /// [refreshOnUnauthorized] path handles any resulting `401`.
+  Future<void> refreshIfExpiring() async {
+    final current = session;
+    if (current == null || onRefreshSession == null) return;
+
+    final exp = _accessTokenExp(current);
+    if (exp == null) {
+      //! Cannot determine expiry, e.g. a non-JWT access token. Send as-is.
+      return;
+    }
+
+    final threshold = DateTime.now().toUtc().add(_refreshSkew);
+    if (threshold.isBefore(exp)) return;
+
+    try {
+      await refresh(current);
+    } catch (_) {
+      //! Ignore; the reactive 401 handler will retry if needed.
+    }
+  }
+
+  /// Returns the cached access-token expiry for [current], decoding the JWT
+  /// only when the access token has changed since the last call. Returns null
+  /// when the access token is not a decodable JWT.
+  DateTime? _accessTokenExp(final Session current) {
+    if (_cachedAccessJwt == current.accessJwt) return _cachedAccessExp;
+
+    _cachedAccessJwt = current.accessJwt;
+    try {
+      return _cachedAccessExp = current.accessTokenJwt.exp;
+    } on FormatException {
+      return _cachedAccessExp = null;
+    }
+  }
+}
+
+base class ServiceContext {
+  ServiceContext({
+    Map<String, String>? headers,
+    xrpc.Protocol? protocol,
+    String? service,
+    String? relayService,
+    Session? session,
+    this.oAuthSessionManager,
+    Duration? timeout,
+    RetryStrategy? retryConfig,
+    final xrpc.GetClient? getClient,
+    final xrpc.PostClient? postClient,
+    final Future<Session> Function(Session current)? onRefreshSession,
+  }) : _headers = headers,
+       _protocol = protocol ?? defaultProtocol,
+       _state = _SessionState(session, onRefreshSession),
+       _explicitService = service,
+       relayService = relayService ?? defaultRelayService,
+       _challenge = Challenge(retryConfig),
+       _timeout = timeout ?? defaultTimeout,
+       _getClient = getClient,
+       _postClient = postClient;
+
+  /// Builds a context around session state that already belongs to another
+  /// context, carrying every immutable setting across unchanged and replacing
+  /// only the headers. See [withHeaders], the only caller.
+  ServiceContext._shared(
+    this._state, {
+    required final Map<String, String>? headers,
+    required final xrpc.Protocol protocol,
+    required final String? explicitService,
+    required this.relayService,
+    required this.oAuthSessionManager,
+    required final Challenge challenge,
+    required final Duration timeout,
+    required final xrpc.GetClient? getClient,
+    required final xrpc.PostClient? postClient,
+  }) : _headers = headers,
+       _protocol = protocol,
+       _explicitService = explicitService,
+       _challenge = challenge,
+       _timeout = timeout,
+       _getClient = getClient,
+       _postClient = postClient;
+
+  /// The global headers without auth header.
+  final Map<String, String>? _headers;
+
+  /// Everything about the current account's session that changes over time.
+  ///
+  /// Held by reference rather than by value: [withHeaders] hands the same
+  /// instance to the context it derives, so both send different headers over
+  /// one session.
+  final _SessionState _state;
+
+  /// Returns the current session.
+  ///
+  /// After an automatic refresh this reflects the latest credentials, so
+  /// callers can persist the up-to-date session.
+  Session? get session => _state.session;
+
+  /// Optional callback used to refresh an expired [session].
+  ///
+  /// Given the current session it must return a new session with fresh
+  /// tokens. When null, expired access tokens are not refreshed automatically.
+  Future<Session> Function(Session current)? get onRefreshSession =>
+      _state.onRefreshSession;
 
   /// Emits the refreshed [Session] every time an expired access token is
   /// renewed, so the owner of the credentials can re-persist them.
@@ -83,27 +265,54 @@ base class ServiceContext {
   /// refreshed. Mirrors `OAuthSessionManager.onSessionUpdated`, which covers
   /// the same need for the OAuth path — this stream is the legacy
   /// (app-password) counterpart and stays silent on OAuth-backed contexts.
-  Stream<Session> get onSessionUpdated => _sessionUpdates.stream;
+  ///
+  /// Contexts derived through [withHeaders] share one stream, so a refresh
+  /// driven by any of them reaches a listener attached to any other.
+  Stream<Session> get onSessionUpdated => _state.updates;
 
-  /// Caches the decoded access-token expiry so the pre-flight refresh check
-  /// does not re-run `decodeJwt` on every authenticated request. Keyed by the
-  /// access JWT string, so it is implicitly invalidated whenever the session
-  /// (and therefore the access token) changes on refresh.
-  String? _cachedAccessJwt;
-  DateTime? _cachedAccessExp;
-
-  /// Caches the resolved PDS endpoint so the [service] getter does not
-  /// re-run the JWT base64/JSON decode (via `atprotoPdsEndpoint`) on every
-  /// authenticated request when the `didDoc` lacks a `#atproto_pds` service.
-  /// Keyed by the access JWT string, so it is implicitly invalidated whenever
-  /// the session (and therefore the access token) changes on refresh.
-  /// Mirrors [_cachedAccessExp].
-  String? _cachedPdsJwt;
-  String? _cachedPdsEndpoint;
-
-  /// The clock skew margin used to refresh an access token slightly before it
-  /// actually expires.
-  static const Duration _refreshSkew = Duration(seconds: 30);
+  /// Returns a context that shares this one's session state but sends
+  /// [headers] in place of this context's own.
+  ///
+  /// The current session, the single in-flight refresh, and
+  /// [onSessionUpdated] are one thing shared by both contexts: a refresh
+  /// started through either is seen by both, and the refresh token — which is
+  /// single-use — is spent exactly once. Everything else is carried over
+  /// unchanged: protocol, service, relay service, timeout, retry strategy,
+  /// HTTP clients, and the OAuth session manager when there is one.
+  ///
+  /// This exists because request headers belong to the client that sends
+  /// them, while the session belongs to the account. A client that must send
+  /// a header the others must not — an `atproto-proxy` routing its calls to a
+  /// different service, say — would otherwise need a context of its own, and
+  /// a second context used to mean a second copy of the session. Two copies
+  /// race the moment the access token expires: whichever refreshes first
+  /// spends the token, and the other's refresh is rejected by the server as
+  /// an `UnauthorizedException` the caller did nothing to provoke.
+  ///
+  /// ```dart
+  /// final proxied = ctx.withHeaders({
+  ///   ...ctx.headers,
+  ///   'atproto-proxy': 'did:web:example.com#service',
+  /// });
+  /// ```
+  ///
+  /// [headers] replaces this context's headers rather than extending them;
+  /// spread [headers] of the origin context, as above, to keep them.
+  ServiceContext withHeaders(final Map<String, String> headers) =>
+      ServiceContext._shared(
+        _state,
+        headers: headers,
+        protocol: _protocol,
+        explicitService: _explicitService,
+        relayService: relayService,
+        oAuthSessionManager: oAuthSessionManager,
+        //! Stateless and immutable, so sharing the instance is equivalent to
+        //! rebuilding one from the same retry strategy.
+        challenge: _challenge,
+        timeout: _timeout,
+        getClient: _getClient,
+        postClient: _postClient,
+      );
 
   /// The current OAuth session manager.
   ///
@@ -132,20 +341,9 @@ base class ServiceContext {
     final current = session;
 
     return _explicitService ??
-        (current != null ? _sessionPdsEndpoint(current) : null) ??
+        (current != null ? _state.pdsEndpoint(current) : null) ??
         oAuthSessionManager?.currentPdsHost ??
         defaultService;
-  }
-
-  /// Returns the cached PDS endpoint for [current], recomputing (and thus
-  /// re-decoding the access JWT) only when the access token has changed since
-  /// the last call. Returns null when the session yields no PDS endpoint.
-  String? _sessionPdsEndpoint(final Session current) {
-    if (_cachedPdsJwt == current.accessJwt) return _cachedPdsEndpoint;
-
-    _cachedPdsJwt = current.accessJwt;
-
-    return _cachedPdsEndpoint = current.atprotoPdsEndpoint;
   }
 
   /// The current relay service.
@@ -198,7 +396,7 @@ base class ServiceContext {
     final xrpc.ResponseDataAdaptor? adaptor,
     final xrpc.GetClient? client,
   }) async {
-    await _maybeRefreshBeforeSend();
+    await _state.refreshIfExpiring();
     await _ensureOAuthSessionResolved();
     final resolvedService = service ?? this.service;
     final endpoint = _endpointFor(resolvedService, methodId);
@@ -247,7 +445,7 @@ base class ServiceContext {
     final xrpc.ResponseDataBuilder<T>? to,
     final xrpc.PostClient? client,
   }) async {
-    await _maybeRefreshBeforeSend();
+    await _state.refreshIfExpiring();
     await _ensureOAuthSessionResolved();
     final resolvedService = service ?? this.service;
     final endpoint = _endpointFor(resolvedService, methodId);
@@ -317,7 +515,7 @@ base class ServiceContext {
     // token) must survive; never overwrite it with the session token.
     if (_hasAuthorization(header)) return header;
 
-    final currentSession = _currentSession;
+    final currentSession = _state.session;
     if (currentSession != null) {
       return _mergeAuthHeaders(header, {
         'Authorization': 'Bearer ${currentSession.accessJwt}',
@@ -418,85 +616,6 @@ base class ServiceContext {
       return await manager.refreshOnUnauthorized();
     }
 
-    final current = _currentSession;
-    if (current == null || onRefreshSession == null) return false;
-
-    try {
-      await _refreshSession(current);
-
-      return true;
-    } catch (_) {
-      //! Swallow refresh errors so the original unauthorized error surfaces.
-      return false;
-    }
-  }
-
-  /// Refreshes the legacy [current] session, deduplicating concurrent
-  /// refreshes.
-  ///
-  /// The first caller starts the single `onRefreshSession` call and stores it
-  /// in [_inflightRefresh]; concurrent callers await that same future instead
-  /// of each firing their own `refreshSession` POST (a refresh stampede). The
-  /// in-flight future is cleared once it settles so a later expiry can refresh
-  /// again.
-  Future<Session> _refreshSession(final Session current) {
-    final existing = _inflightRefresh;
-    if (existing != null) return existing;
-
-    final refresh = onRefreshSession!;
-    final future = refresh(current)
-        .then((refreshed) {
-          _currentSession = refreshed;
-          //! Broadcast after adopting it, so a listener that reads `session`
-          //! sees the credentials it was just handed. Never awaited: a slow or
-          //! throwing listener must not delay or fail the request that
-          //! triggered the refresh.
-          _sessionUpdates.add(refreshed);
-
-          return refreshed;
-        })
-        .whenComplete(() => _inflightRefresh = null);
-
-    return _inflightRefresh = future;
-  }
-
-  /// Proactively refreshes the session when the current access token is
-  /// expired or about to expire within [_refreshSkew].
-  ///
-  /// This is best-effort: if the access token cannot be decoded, or the
-  /// refresh fails, the request proceeds unchanged and the reactive
-  /// [_onUnauthorized] path handles any resulting `401`.
-  Future<void> _maybeRefreshBeforeSend() async {
-    final current = _currentSession;
-    if (current == null || onRefreshSession == null) return;
-
-    final exp = _accessTokenExp(current);
-    if (exp == null) {
-      //! Cannot determine expiry, e.g. a non-JWT access token. Send as-is.
-      return;
-    }
-
-    final threshold = DateTime.now().toUtc().add(_refreshSkew);
-    if (threshold.isBefore(exp)) return;
-
-    try {
-      await _refreshSession(current);
-    } catch (_) {
-      //! Ignore; the reactive 401 handler will retry if needed.
-    }
-  }
-
-  /// Returns the cached access-token expiry for [current], decoding the JWT
-  /// only when the access token has changed since the last call. Returns null
-  /// when the access token is not a decodable JWT.
-  DateTime? _accessTokenExp(final Session current) {
-    if (_cachedAccessJwt == current.accessJwt) return _cachedAccessExp;
-
-    _cachedAccessJwt = current.accessJwt;
-    try {
-      return _cachedAccessExp = current.accessTokenJwt.exp;
-    } on FormatException {
-      return _cachedAccessExp = null;
-    }
+    return await _state.refreshOnUnauthorized();
   }
 }

--- a/packages/atproto_core/test/src/clients/service_context_test.dart
+++ b/packages/atproto_core/test/src/clients/service_context_test.dart
@@ -15,6 +15,8 @@ import 'package:test/test.dart';
 import 'package:xrpc/xrpc.dart' as xrpc;
 
 // Project imports:
+import 'package:atproto_core/src/clients/retry_context.dart';
+import 'package:atproto_core/src/clients/retry_strategy.dart';
 import 'package:atproto_core/src/clients/service_context.dart';
 import 'package:atproto_core/src/types/session.dart';
 
@@ -915,12 +917,382 @@ void main() {
       expect(dialed.single.path, '/xrpc/com.atproto.sync.subscribeRepos');
     });
   });
+
+  group('.withHeaders', () {
+    Session session({
+      String accessJwt = 'old-token',
+      String refreshJwt = 'refresh-token',
+    }) => Session(
+      did: 'did:plc:testaccount',
+      handle: 'test.dev',
+      accessJwt: accessJwt,
+      refreshJwt: refreshJwt,
+    );
+
+    http.Response json(Uri url, int status, String body) => http.Response(
+      body,
+      status,
+      headers: {'content-type': 'application/json'},
+      request: http.Request('GET', url),
+    );
+
+    test('sends its own headers and leaves the origin context alone', () async {
+      final sent = <Map<String, String>?>[];
+
+      final origin = ServiceContext(
+        headers: const {'x-origin': 'yes'},
+        getClient: (url, {headers}) async {
+          sent.add(headers);
+
+          return json(url, 200, '{}');
+        },
+      );
+      final derived = origin.withHeaders({
+        ...origin.headers,
+        'atproto-proxy': 'did:web:example.com#service',
+      });
+
+      await derived.get(NSID.create('server.atproto.com', 'describeServer'));
+      await origin.get(NSID.create('server.atproto.com', 'describeServer'));
+
+      //! The whole point: one session below, two different sets of headers
+      //! above it.
+      expect(derived.headers, {
+        'x-origin': 'yes',
+        'atproto-proxy': 'did:web:example.com#service',
+      });
+      expect(origin.headers, const {'x-origin': 'yes'});
+      expect(sent.first?['atproto-proxy'], 'did:web:example.com#service');
+      expect(sent.last?.containsKey('atproto-proxy'), isFalse);
+    });
+
+    test('replaces the origin headers rather than extending them', () {
+      final origin = ServiceContext(headers: const {'x-origin': 'yes'});
+
+      //! Documented semantics: callers who want the origin's headers spread
+      //! them in themselves.
+      expect(origin.withHeaders(const {'x-only': 'mine'}).headers, const {
+        'x-only': 'mine',
+      });
+    });
+
+    test(
+      'a refresh driven by the derived context reaches the origin',
+      () async {
+        int refreshCalls = 0;
+
+        final origin = ServiceContext(
+          session: session(),
+          onRefreshSession: (current) async {
+            refreshCalls++;
+
+            return current.copyWith(
+              accessJwt: 'new-token',
+              refreshJwt: 'new-refresh',
+            );
+          },
+          getClient: (url, {headers}) async =>
+              headers?['Authorization'] == 'Bearer new-token'
+              ? json(url, 200, '{}')
+              : json(url, 401, '{"error":"ExpiredToken"}'),
+        );
+        final derived = origin.withHeaders(const {'x-derived': 'yes'});
+
+        final fromOrigin = <Session>[];
+        final fromDerived = <Session>[];
+        origin.onSessionUpdated.listen(fromOrigin.add);
+        derived.onSessionUpdated.listen(fromDerived.add);
+
+        await derived.get(NSID.create('server.atproto.com', 'getSession'));
+        await Future<void>.delayed(Duration.zero);
+
+        expect(refreshCalls, 1);
+        //! One session: the context that never made the call still reads the
+        //! credentials the call obtained.
+        expect(origin.session?.refreshJwt, 'new-refresh');
+        expect(derived.session?.refreshJwt, 'new-refresh');
+        expect(identical(origin.session, derived.session), isTrue);
+        //! One stream: a listener attached to either sees every rotation.
+        expect(fromOrigin.single.refreshJwt, 'new-refresh');
+        expect(fromDerived.single.refreshJwt, 'new-refresh');
+        expect(identical(fromOrigin.single, fromDerived.single), isTrue);
+      },
+    );
+
+    test(
+      'a refresh driven by the origin reaches the derived context',
+      () async {
+        final origin = ServiceContext(
+          session: session(),
+          onRefreshSession: (current) async => current.copyWith(
+            accessJwt: 'new-token',
+            refreshJwt: 'new-refresh',
+          ),
+          getClient: (url, {headers}) async =>
+              headers?['Authorization'] == 'Bearer new-token'
+              ? json(url, 200, '{}')
+              : json(url, 401, '{"error":"ExpiredToken"}'),
+        );
+        final derived = origin.withHeaders(const {'x-derived': 'yes'});
+
+        final fromDerived = <Session>[];
+        derived.onSessionUpdated.listen(fromDerived.add);
+
+        await origin.get(NSID.create('server.atproto.com', 'getSession'));
+        await Future<void>.delayed(Duration.zero);
+
+        //! Sharing is symmetric; neither context is the owner.
+        expect(derived.session?.refreshJwt, 'new-refresh');
+        expect(fromDerived.single.refreshJwt, 'new-refresh');
+      },
+    );
+
+    test('the derived context sends the refreshed access token', () async {
+      final authHeaders = <String?>[];
+
+      final origin = ServiceContext(
+        session: session(),
+        onRefreshSession: (current) async =>
+            current.copyWith(accessJwt: 'new-token'),
+        getClient: (url, {headers}) async {
+          authHeaders.add(headers?['Authorization']);
+
+          return headers?['Authorization'] == 'Bearer new-token'
+              ? json(url, 200, '{}')
+              : json(url, 401, '{"error":"ExpiredToken"}');
+        },
+      );
+      final derived = origin.withHeaders(const {'x-derived': 'yes'});
+
+      await origin.get(NSID.create('server.atproto.com', 'getSession'));
+      await derived.get(NSID.create('server.atproto.com', 'getSession'));
+
+      //! The auth header is built from the shared session, so the derived
+      //! context never presents the token the origin's refresh replaced.
+      expect(authHeaders, [
+        'Bearer old-token',
+        'Bearer new-token',
+        'Bearer new-token',
+      ]);
+    });
+
+    test(
+      'concurrent expiries across both contexts issue exactly one refresh',
+      () async {
+        int refreshCalls = 0;
+        final gate = Completer<void>();
+
+        final origin = ServiceContext(
+          session: session(),
+          onRefreshSession: (current) async {
+            refreshCalls++;
+            //! Hold the refresh open so both contexts attach to the same
+            //! in-flight future before it completes.
+            await gate.future;
+
+            return current.copyWith(accessJwt: 'new-token');
+          },
+          getClient: (url, {headers}) async =>
+              headers?['Authorization'] == 'Bearer new-token'
+              ? json(url, 200, '{}')
+              : json(url, 401, '{"error":"ExpiredToken"}'),
+        );
+        final derived = origin.withHeaders(const {'x-derived': 'yes'});
+
+        final responses = Future.wait([
+          origin.get(NSID.create('server.atproto.com', 'getSession')),
+          derived.get(NSID.create('server.atproto.com', 'getSession')),
+        ]);
+
+        await Future<void>.delayed(const Duration(milliseconds: 20));
+        gate.complete();
+
+        expect((await responses).every((r) => r.status.code == 200), isTrue);
+        //! The in-flight refresh is shared, not merely the session: a single
+        //! `refreshSession` POST covers both contexts, so the single-use
+        //! refresh token is spent exactly once.
+        expect(refreshCalls, 1);
+      },
+    );
+
+    test('the pre-flight expiry refresh is shared as well', () async {
+      int refreshCalls = 0;
+      final authHeaders = <String?>[];
+
+      final expiredAt = DateTime.now().toUtc().subtract(
+        const Duration(seconds: 5),
+      );
+      final expSeconds = expiredAt.millisecondsSinceEpoch ~/ 1000;
+
+      final origin = ServiceContext(
+        session: session(
+          accessJwt: _jwt({
+            'sub': 'did:plc:testaccount',
+            'exp': expSeconds,
+            'iat': expSeconds - 100,
+          }),
+        ),
+        onRefreshSession: (current) async {
+          refreshCalls++;
+
+          return current.copyWith(accessJwt: 'new-token');
+        },
+        getClient: (url, {headers}) async {
+          authHeaders.add(headers?['Authorization']);
+
+          return json(url, 200, '{}');
+        },
+      );
+      final derived = origin.withHeaders(const {'x-derived': 'yes'});
+
+      await derived.get(NSID.create('server.atproto.com', 'getSession'));
+      await origin.get(NSID.create('server.atproto.com', 'getSession'));
+
+      //! The derived context ran the pre-flight refresh; the origin then found
+      //! a token that is no longer expiring and sent it without refreshing
+      //! again. Nothing 401s here, so this is the pre-flight path alone.
+      expect(refreshCalls, 1);
+      expect(authHeaders, ['Bearer new-token', 'Bearer new-token']);
+    });
+
+    test('carries the OAuth session manager across', () {
+      final manager = OAuthSessionManager.fromSession(
+        OAuthSession(
+          accessToken: 'access-1',
+          scope: 'atproto',
+          sub: 'did:plc:abc',
+          issuer: 'https://bsky.social',
+          pds: 'https://pds.example',
+          clientId: 'cid',
+          dpopPublicKey: 'PUB',
+          dpopPrivateKey: 'PRIV',
+        ),
+      );
+
+      final derived = ServiceContext(
+        oAuthSessionManager: manager,
+      ).withHeaders(const {'x-derived': 'yes'});
+
+      //! On the OAuth path the manager already owns the session, so carrying
+      //! the reference over is all sharing takes.
+      expect(identical(derived.oAuthSessionManager, manager), isTrue);
+      expect(derived.service, 'pds.example');
+      expect(derived.repo, 'did:plc:abc');
+    });
+
+    test(
+      'carries protocol, service, relay service and clients across',
+      () async {
+        final gotUrls = <Uri>[];
+        final postedUrls = <Uri>[];
+
+        final origin = ServiceContext(
+          protocol: xrpc.Protocol.http,
+          service: 'pds.test',
+          relayService: 'relay.test',
+          getClient: (url, {headers}) async {
+            gotUrls.add(url);
+
+            return http.Response(
+              '{}',
+              200,
+              headers: {'content-type': 'application/json'},
+              request: http.Request('GET', url),
+            );
+          },
+          postClient: (url, {headers, body, encoding}) async {
+            postedUrls.add(url);
+
+            return http.Response(
+              '{}',
+              200,
+              headers: {'content-type': 'application/json'},
+              request: http.Request('POST', url),
+            );
+          },
+        );
+        final derived = origin.withHeaders(const {'x-derived': 'yes'});
+
+        await derived.get(NSID.create('server.atproto.com', 'describeServer'));
+        await derived.post(NSID.create('server.atproto.com', 'createSession'));
+
+        expect(derived.service, 'pds.test');
+        expect(derived.relayService, 'relay.test');
+        //! `http` rather than `https` proves the protocol came across, the host
+        //! proves the service did, and reaching these recorders at all proves
+        //! both HTTP clients did.
+        expect(gotUrls.single.scheme, 'http');
+        expect(gotUrls.single.host, 'pds.test');
+        expect(postedUrls.single.scheme, 'http');
+        expect(postedUrls.single.host, 'pds.test');
+      },
+    );
+
+    test('carries the timeout across', () async {
+      final derived = ServiceContext(
+        timeout: const Duration(milliseconds: 1),
+        getClient: (url, {headers}) async {
+          await Future<void>.delayed(const Duration(milliseconds: 200));
+
+          return http.Response(
+            '{}',
+            200,
+            headers: {'content-type': 'application/json'},
+            request: http.Request('GET', url),
+          );
+        },
+      ).withHeaders(const {'x-derived': 'yes'});
+
+      await expectLater(
+        derived.get(NSID.create('server.atproto.com', 'describeServer')),
+        throwsA(isA<TimeoutException>()),
+      );
+    });
+
+    test('carries the retry strategy across', () async {
+      int calls = 0;
+
+      final derived = ServiceContext(
+        retryConfig: const _RetryOnce(),
+        getClient: (url, {headers}) async {
+          calls++;
+
+          return http.Response(
+            '{}',
+            500,
+            headers: {'content-type': 'application/json'},
+            request: http.Request('GET', url),
+          );
+        },
+      ).withHeaders(const {'x-derived': 'yes'});
+
+      await expectLater(
+        derived.get(NSID.create('server.atproto.com', 'describeServer')),
+        throwsA(isA<xrpc.InternalServerErrorException>()),
+      );
+
+      //! Initial attempt plus the one retry the strategy allows: the derived
+      //! context inherited the retry policy, it did not fall back to none.
+      expect(calls, 2);
+    });
+  });
 }
 
 /// Sentinel thrown by the capturing channel factory in the `.stream` tests to
 /// abort the subscription after the dial URI has been recorded.
 class _StopDial {
   const _StopDial();
+}
+
+/// Allows exactly one immediate retry, so a context that inherited a retry
+/// strategy is distinguishable from one that lost it without waiting out a
+/// real backoff.
+class _RetryOnce implements RetryStrategy {
+  const _RetryOnce();
+
+  @override
+  FutureOr<Duration?> nextDelay(RetryContext context) =>
+      context.attempt > 1 ? null : Duration.zero;
 }
 
 /// A [DPoPSigner] returning a fixed proof so tests do not depend on real

--- a/packages/bluesky/lib/src/bluesky.dart
+++ b/packages/bluesky/lib/src/bluesky.dart
@@ -80,6 +80,15 @@ sealed class Bluesky {
 
   /// Returns a new [Bluesky] backed by an OAuth [manager], which owns DPoP
   /// header building and transparent token refresh.
+  ///
+  /// [Bluesky.fromAtproto] is not the way to share a session here — on the
+  /// OAuth path the [oauth.OAuthSessionManager] is already the shared thing.
+  /// It holds the session, the single in-flight refresh, and its own
+  /// `onSessionUpdated`, none of which live on the context, so passing one
+  /// manager to several clients gives them one session and one refresh even
+  /// though each keeps a context of its own with its own headers. Build the
+  /// manager once and pass it around; [Bluesky.fromOAuthSession] builds a new
+  /// one on every call and does not share.
   factory Bluesky.fromOAuth(
     final oauth.OAuthSessionManager manager, {
     final Map<String, String>? headers,
@@ -108,6 +117,16 @@ sealed class Bluesky {
   ///
   /// Pass [oauthClient] to enable transparent token refresh; without it the
   /// session is used as-is and cannot be refreshed.
+  ///
+  /// This builds a fresh [oauth.OAuthSessionManager] on every call, so a
+  /// second client built this way for the same account does not share the
+  /// session — and what it gets instead is worse than an independent client.
+  /// Each manager holds its own copy of [session], and a rotating refresh
+  /// token is only honoured once: whichever manager refreshes first spends it,
+  /// and the other's refresh comes back as an `OAuthSessionRevokedException`
+  /// — the signal to send the user back through authorization — for a session
+  /// that was working moments earlier. Build the manager yourself and pass it
+  /// to [Bluesky.fromOAuth] when more than one client shares an account.
   factory Bluesky.fromOAuthSession(
     final oauth.OAuthSession session, {
     final oauth.OAuthClient? oauthClient,

--- a/packages/bluesky/lib/src/bluesky_chat.dart
+++ b/packages/bluesky/lib/src/bluesky_chat.dart
@@ -18,26 +18,51 @@ const _kBskyChatProxyHeaders = <String, String>{
 
 /// Provides `chat.bsky.*` services.
 sealed class BlueskyChat {
+  /// Returns a new [BlueskyChat] that shares [atproto]'s session — see
+  /// [atp.ATProto.ctx] — while still routing `chat.bsky.*` calls to the chat
+  /// service.
+  ///
+  /// Reach for this whenever one account needs more than one client. Every
+  /// other factory builds its own [atp.ATProto], and each of those owns a
+  /// separate [core.ServiceContext] holding a separate copy of the session.
+  /// Refresh tokens are single-use, so the moment the access token expires
+  /// those copies race: whichever context notices first spends the refresh
+  /// token, the other one's refresh is rejected by the server, and the losing
+  /// client fails with an `UnauthorizedException` the caller did nothing to
+  /// provoke.
+  ///
+  /// Unlike `Bluesky.fromAtproto` and `OzoneTool.fromAtproto`, this does not
+  /// adopt [atproto]'s context as-is. `chat.bsky.*` is reached through an
+  /// `atproto-proxy` header that the other clients must not send, and headers
+  /// belong to the context, so a context shared verbatim would proxy their
+  /// `app.bsky.*` and `com.atproto.*` calls to the chat service too. This
+  /// derives a context — [core.ServiceContext.withHeaders] — that adds the
+  /// header and shares the session underneath, so one account keeps one
+  /// session, one refresh, and one [onSessionUpdated] no matter how many
+  /// clients read from it.
+  ///
+  /// ```dart
+  /// final atproto = atp.ATProto.fromSession(session);
+  /// final bluesky = Bluesky.fromAtproto(atproto);
+  /// final chat = BlueskyChat.fromAtproto(atproto);
+  ///
+  /// // `bluesky.session` and `chat.session` are the same session, and only
+  /// // `chat` sends the chat proxy header.
+  /// ```
+  factory BlueskyChat.fromAtproto(final atp.ATProto atproto) =
+      _BlueskyChat.fromAtproto;
+
   /// Returns the new instance of [BlueskyChat].
   ///
   /// This builds a fresh [atp.ATProto], and therefore a fresh
-  /// [core.ServiceContext] carrying its own copy of [session].
+  /// [core.ServiceContext] carrying its own copy of [session]. When the same
+  /// account also needs another client, build the [atp.ATProto] once and pass
+  /// it to [BlueskyChat.fromAtproto] instead — two contexts each holding a
+  /// copy of one session race to spend a single-use refresh token.
   ///
-  /// A `chat.bsky.*` client cannot share that context with another client, as
-  /// `Bluesky.fromAtproto` and `OzoneTool.fromAtproto` allow. Routing these
-  /// calls to the chat service takes an `atproto-proxy` header, headers belong
-  /// to the context rather than to the client reading from it, and a shared
-  /// context would therefore proxy the other client's `app.bsky.*` and
-  /// `com.atproto.*` calls to the chat service as well.
-  ///
-  /// That is worth knowing, because refresh tokens are single-use: a
-  /// [BlueskyChat] and any other client for the same account hold two copies
-  /// of one session, and whichever context first notices an expired access
-  /// token spends the refresh token the other one still holds. The other
-  /// client's own refresh is then rejected, and its next call fails with an
-  /// `UnauthorizedException`. Both directions are equally affected, so an app
-  /// that runs both keeps them in step by rebuilding one from the session the
-  /// other's [onSessionUpdated] emits.
+  /// The chat proxy header is added to the context this [BlueskyChat] sends
+  /// through, not to the one [atproto] exposes: `com.atproto.*` calls made
+  /// through [atproto] are not proxied to the chat service.
   factory BlueskyChat.fromSession(
     final core.Session session, {
     final Map<String, String>? headers,
@@ -50,7 +75,7 @@ sealed class BlueskyChat {
     final core.PostClient? postClient,
   }) => _BlueskyChat.fromAtproto(
     atp.ATProto.fromSession(
-      headers: {...?headers, ..._kBskyChatProxyHeaders},
+      headers: headers,
       session,
       protocol: protocol,
       service: service,
@@ -64,6 +89,22 @@ sealed class BlueskyChat {
 
   /// Returns a new [BlueskyChat] backed by an OAuth [manager], which owns
   /// DPoP header building and transparent token refresh.
+  ///
+  /// The [oauth.OAuthSessionManager] is itself the shared thing: it owns the
+  /// session, the single in-flight refresh, and its own `onSessionUpdated`,
+  /// none of which live on the context. Passing one manager to several
+  /// clients therefore gives them one session, one refresh, and one rotation
+  /// stream, even though each keeps a context of its own with its own
+  /// headers. Build the manager once and pass it around.
+  ///
+  /// ```dart
+  /// final manager = oauth.OAuthSessionManager(client, sub: did);
+  /// final bluesky = Bluesky.fromOAuth(manager);
+  /// final chat = BlueskyChat.fromOAuth(manager);
+  /// ```
+  ///
+  /// The session race that [BlueskyChat.fromSession] warns about is specific
+  /// to the app-password path, where the session lives on the context.
   factory BlueskyChat.fromOAuth(
     final oauth.OAuthSessionManager manager, {
     final Map<String, String>? headers,
@@ -77,7 +118,7 @@ sealed class BlueskyChat {
   }) => _BlueskyChat.fromAtproto(
     atp.ATProto.fromOAuth(
       manager,
-      headers: {...?headers, ..._kBskyChatProxyHeaders},
+      headers: headers,
       protocol: protocol,
       service: service,
       relayService: relayService,
@@ -92,6 +133,16 @@ sealed class BlueskyChat {
   ///
   /// Pass [oauthClient] to enable transparent token refresh; without it the
   /// session is used as-is and cannot be refreshed.
+  ///
+  /// This builds a fresh [oauth.OAuthSessionManager] on every call, so it does
+  /// **not** share a session between clients the way passing one manager to
+  /// [BlueskyChat.fromOAuth] does. Two managers restored from one
+  /// [oauth.OAuthSession] each hold their own copy of it, and a rotating
+  /// refresh token is only honoured once: whichever refreshes first spends it,
+  /// and the other's refresh comes back as an
+  /// `OAuthSessionRevokedException`. When the same account needs more than one
+  /// client, build the manager yourself and pass it to
+  /// [BlueskyChat.fromOAuth].
   factory BlueskyChat.fromOAuthSession(
     final oauth.OAuthSession session, {
     final oauth.OAuthClient? oauthClient,
@@ -178,15 +229,22 @@ sealed class BlueskyChat {
 }
 
 final class _BlueskyChat implements BlueskyChat {
-  /// Drives every `chat.bsky.*` service from [atproto]'s own context.
+  /// Drives every `chat.bsky.*` service from a context derived from
+  /// [atproto]'s: the same session state underneath — see [atp.ATProto.ctx] —
+  /// plus the `atproto-proxy` header that routes these calls to the chat
+  /// service.
   ///
-  /// A second context would carry a second copy of the session, and only one
-  /// of the two would ever be refreshed — see [atp.ATProto.ctx]. It is safe to
-  /// adopt this one wholesale: every factory above builds [atproto] with the
-  /// same arguments the discarded context received, `_kBskyChatProxyHeaders`
-  /// included.
-  factory _BlueskyChat.fromAtproto(final atp.ATProto atproto) =>
-      _BlueskyChat._(atproto.ctx, atproto);
+  /// Only the headers differ. A context copied instead of derived would carry
+  /// a second copy of the session, and only one of the two would ever be
+  /// refreshed; a context adopted verbatim would send the proxy header on
+  /// [atproto]'s own `com.atproto.*` calls.
+  factory _BlueskyChat.fromAtproto(final atp.ATProto atproto) => _BlueskyChat._(
+    atproto.ctx.withHeaders({
+      ...atproto.ctx.headers,
+      ..._kBskyChatProxyHeaders,
+    }),
+    atproto,
+  );
 
   _BlueskyChat._(final core.ServiceContext ctx, this.atproto)
     : actor = ActorService(ctx),

--- a/packages/bluesky/lib/src/bluesky_chat.dart
+++ b/packages/bluesky/lib/src/bluesky_chat.dart
@@ -136,13 +136,14 @@ sealed class BlueskyChat {
   ///
   /// This builds a fresh [oauth.OAuthSessionManager] on every call, so it does
   /// **not** share a session between clients the way passing one manager to
-  /// [BlueskyChat.fromOAuth] does. Two managers restored from one
+  /// [BlueskyChat.fromOAuth] does — and what it gives you instead is worse
+  /// than two independent clients. Two managers restored from one
   /// [oauth.OAuthSession] each hold their own copy of it, and a rotating
   /// refresh token is only honoured once: whichever refreshes first spends it,
-  /// and the other's refresh comes back as an
-  /// `OAuthSessionRevokedException`. When the same account needs more than one
-  /// client, build the manager yourself and pass it to
-  /// [BlueskyChat.fromOAuth].
+  /// and the other's refresh comes back as an `OAuthSessionRevokedException`
+  /// — the signal to send the user back through authorization — for a session
+  /// that was working moments earlier. Build the manager yourself and pass it
+  /// to [BlueskyChat.fromOAuth] when more than one client shares an account.
   factory BlueskyChat.fromOAuthSession(
     final oauth.OAuthSession session, {
     final oauth.OAuthClient? oauthClient,

--- a/packages/bluesky/lib/src/ozone_tool.dart
+++ b/packages/bluesky/lib/src/ozone_tool.dart
@@ -89,6 +89,15 @@ sealed class OzoneTool {
 
   /// Returns a new [OzoneTool] backed by an OAuth [manager], which owns DPoP
   /// header building and transparent token refresh.
+  ///
+  /// [OzoneTool.fromAtproto] is not the way to share a session here — on the
+  /// OAuth path the [oauth.OAuthSessionManager] is already the shared thing.
+  /// It holds the session, the single in-flight refresh, and its own
+  /// `onSessionUpdated`, none of which live on the context, so passing one
+  /// manager to several clients gives them one session and one refresh even
+  /// though each keeps a context of its own with its own headers. Build the
+  /// manager once and pass it around; [OzoneTool.fromOAuthSession] builds a
+  /// new one on every call and does not share.
   factory OzoneTool.fromOAuth(
     final oauth.OAuthSessionManager manager, {
     final Map<String, String>? headers,
@@ -117,6 +126,16 @@ sealed class OzoneTool {
   ///
   /// Pass [oauthClient] to enable transparent token refresh; without it the
   /// session is used as-is and cannot be refreshed.
+  ///
+  /// This builds a fresh [oauth.OAuthSessionManager] on every call, so a
+  /// second client built this way for the same account does not share the
+  /// session — and what it gets instead is worse than an independent client.
+  /// Each manager holds its own copy of [session], and a rotating refresh
+  /// token is only honoured once: whichever manager refreshes first spends it,
+  /// and the other's refresh comes back as an `OAuthSessionRevokedException`
+  /// — the signal to send the user back through authorization — for a session
+  /// that was working moments earlier. Build the manager yourself and pass it
+  /// to [OzoneTool.fromOAuth] when more than one client shares an account.
   factory OzoneTool.fromOAuthSession(
     final oauth.OAuthSession session, {
     final oauth.OAuthClient? oauthClient,

--- a/packages/bluesky/test/src/from_atproto_test.dart
+++ b/packages/bluesky/test/src/from_atproto_test.dart
@@ -29,6 +29,10 @@ final class _FakePds {
   /// How many times `com.atproto.server.refreshSession` was called.
   int refreshCalls = 0;
 
+  /// The `atproto-proxy` header seen on every `GET`, keyed by the NSID the
+  /// request was addressed to. Null where the request carried no such header.
+  final Map<String, String?> proxyHeaderByNsid = {};
+
   /// The session handed to the client, holding the tokens this PDS starts
   /// with.
   ///
@@ -45,16 +49,25 @@ final class _FakePds {
     final Uri url, {
     final Map<String, String>? headers,
   }) async {
+    proxyHeaderByNsid[url.path.replaceFirst('/xrpc/', '')] =
+        headers?['atproto-proxy'];
+
     if (headers?['Authorization'] != 'Bearer $_access') {
       return _response(url, 'GET', 401, '{"error":"ExpiredToken"}');
     }
 
-    return _response(
-      url,
-      'GET',
-      200,
-      url.path.contains('tools.ozone.server.getConfig') ? '{}' : '{"feed":[]}',
-    );
+    return _response(url, 'GET', 200, _body(url.path));
+  }
+
+  /// The minimal valid body for each endpoint these tests call.
+  static String _body(final String path) {
+    if (path.contains('chat.bsky.convo.listConvos')) return '{"convos":[]}';
+    if (path.contains('com.atproto.server.getSession')) {
+      return '{"handle":"test.dev","did":"did:plc:testaccount"}';
+    }
+    if (path.contains('tools.ozone.server.getConfig')) return '{}';
+
+    return '{"feed":[]}';
   }
 
   Future<http.Response> post(
@@ -207,6 +220,175 @@ void main() {
         ozone.server.getConfig(),
         throwsA(isA<core.UnauthorizedException>()),
       );
+    });
+  });
+
+  group('BlueskyChat.fromAtproto', () {
+    atp.ATProto atproto(final _FakePds pds) => atp.ATProto.fromSession(
+      pds.initialSession,
+      service: 'pds.test',
+      getClient: pds.get,
+      postClient: pds.post,
+    );
+
+    test('shares the session while keeping the headers apart', () async {
+      final pds = _FakePds();
+      final atp = atproto(pds);
+
+      final bsky = Bluesky.fromAtproto(atp);
+      final chat = BlueskyChat.fromAtproto(atp);
+
+      await bsky.feed.getTimeline();
+      final response = await chat.convo.listConvos();
+
+      //! One refresh: the timeline call spent the refresh token, and the chat
+      //! call went out on the access token that refresh produced rather than
+      //! presenting the spent one for a second time.
+      expect(response.status.code, 200);
+      expect(pds.refreshCalls, 1);
+      expect(chat.session?.accessJwt, 'access-1');
+      expect(bsky.session?.accessJwt, 'access-1');
+      expect(identical(chat.session, bsky.session), isTrue);
+
+      //! And the headers stayed apart, which is the whole reason the chat
+      //! client needs a context of its own: the proxy header routes
+      //! `chat.bsky.*` to the chat service and must not follow `app.bsky.*`
+      //! there.
+      expect(
+        pds.proxyHeaderByNsid['chat.bsky.convo.listConvos'],
+        'did:web:api.bsky.chat#bsky_chat',
+      );
+      expect(pds.proxyHeaderByNsid['app.bsky.feed.getTimeline'], isNull);
+    });
+
+    test('the chat client can drive the refresh instead', () async {
+      final pds = _FakePds();
+      final atp = atproto(pds);
+
+      final chat = BlueskyChat.fromAtproto(atp);
+      final bsky = Bluesky.fromAtproto(atp);
+
+      //! The reverse order: neither client owns the session.
+      await chat.convo.listConvos();
+      final response = await bsky.feed.getTimeline();
+
+      expect(response.status.code, 200);
+      expect(pds.refreshCalls, 1);
+      expect(bsky.session?.accessJwt, 'access-1');
+    });
+
+    test('concurrent expiries across both clients refresh once', () async {
+      final pds = _FakePds();
+      final atp = atproto(pds);
+
+      final bsky = Bluesky.fromAtproto(atp);
+      final chat = BlueskyChat.fromAtproto(atp);
+
+      final responses = await Future.wait([
+        bsky.feed.getTimeline(),
+        chat.convo.listConvos(),
+      ]);
+
+      //! Both clients hit the expired token at once and joined one in-flight
+      //! `refreshSession`. A second POST would have replayed the single-use
+      //! refresh token and been rejected.
+      expect(responses.every((r) => r.status.code == 200), isTrue);
+      expect(pds.refreshCalls, 1);
+    });
+
+    test('announces one refresh on every client listening', () async {
+      final pds = _FakePds();
+      final atp = atproto(pds);
+
+      final bsky = Bluesky.fromAtproto(atp);
+      final chat = BlueskyChat.fromAtproto(atp);
+
+      final fromBsky = <core.Session>[];
+      final fromChat = <core.Session>[];
+      bsky.onSessionUpdated.listen(fromBsky.add);
+      chat.onSessionUpdated.listen(fromChat.add);
+
+      await chat.convo.listConvos();
+      await Future<void>.delayed(Duration.zero);
+
+      //! One stream source: a listener on either client is handed the only
+      //! session worth persisting.
+      expect(fromChat.single.refreshJwt, 'refresh-1');
+      expect(fromBsky.single.refreshJwt, 'refresh-1');
+      expect(identical(fromBsky.single, fromChat.single), isTrue);
+    });
+
+    test('leaves the ATProto it was built from unproxied', () async {
+      final pds = _FakePds();
+      final atp = atproto(pds);
+
+      final chat = BlueskyChat.fromAtproto(atp);
+
+      await chat.convo.listConvos();
+      await chat.atproto.server.getSession();
+
+      //! `chat.atproto` is the caller's own `ATProto`. Its `com.atproto.*`
+      //! calls must reach the PDS, not the chat service.
+      expect(
+        pds.proxyHeaderByNsid['chat.bsky.convo.listConvos'],
+        'did:web:api.bsky.chat#bsky_chat',
+      );
+      expect(pds.proxyHeaderByNsid['com.atproto.server.getSession'], isNull);
+      expect(identical(chat.atproto, atp), isTrue);
+    });
+
+    test('two independent contexts race for the single-use token', () async {
+      final pds = _FakePds();
+      final session = pds.initialSession;
+
+      //! What a caller writes without `fromAtproto`: a `Bluesky` and a
+      //! `BlueskyChat` built separately own a context each, and each of those
+      //! a copy of `session`.
+      final bsky = Bluesky.fromSession(
+        session,
+        service: 'pds.test',
+        getClient: pds.get,
+        postClient: pds.post,
+      );
+      final chat = BlueskyChat.fromSession(
+        session,
+        service: 'pds.test',
+        getClient: pds.get,
+        postClient: pds.post,
+      );
+
+      await bsky.feed.getTimeline();
+
+      expect(chat.session?.refreshJwt, 'refresh-0');
+      await expectLater(
+        chat.convo.listConvos(),
+        throwsA(isA<core.UnauthorizedException>()),
+      );
+    });
+  });
+
+  group('BlueskyChat.fromSession (proxy header placement)', () {
+    test('sends the proxy header on chat.bsky.* and nowhere else', () async {
+      final pds = _FakePds();
+
+      final chat = BlueskyChat.fromSession(
+        pds.initialSession,
+        service: 'pds.test',
+        getClient: pds.get,
+        postClient: pds.post,
+      );
+
+      await chat.convo.listConvos();
+      await chat.atproto.server.getSession();
+
+      expect(
+        pds.proxyHeaderByNsid['chat.bsky.convo.listConvos'],
+        'did:web:api.bsky.chat#bsky_chat',
+      );
+      //! The header belongs to the chat context alone; the nested `ATProto`
+      //! the caller can read back is an ordinary PDS client.
+      expect(pds.proxyHeaderByNsid['com.atproto.server.getSession'], isNull);
+      expect(chat.atproto.headers.containsKey('atproto-proxy'), isFalse);
     });
   });
 

--- a/packages/bluesky/test/src/oauth_session_sharing_test.dart
+++ b/packages/bluesky/test/src/oauth_session_sharing_test.dart
@@ -1,0 +1,323 @@
+// Copyright (c) 2023-2025, Shinya Kato.
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// Dart imports:
+import 'dart:convert';
+
+// Package imports:
+import 'package:atproto_core/atproto_core.dart' as core;
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:test/test.dart';
+
+// Project imports:
+import 'package:bluesky/atproto_oauth.dart';
+import 'package:bluesky/src/bluesky.dart';
+import 'package:bluesky/src/bluesky_chat.dart';
+
+/// A fake authorization server that enforces the one rule these tests are
+/// about: a rotating refresh token is single-use.
+///
+/// `POST /oauth/token` rotates only when it carries the current refresh token
+/// and answers `invalid_grant` otherwise, exactly as a server does for a
+/// client working from a stale copy of the session.
+final class _FakeAuthServer {
+  _FakeAuthServer({final String access = 'access-1'}) : _access = access;
+
+  String _access;
+  String _refresh = 'refresh-1';
+  int _rotations = 1;
+
+  /// How many token requests reached the server.
+  int tokenPosts = 0;
+
+  /// The `atproto-proxy` header seen on every PDS `GET`, keyed by the NSID the
+  /// request was addressed to. Null where the request carried no such header.
+  final Map<String, String?> proxyHeaderByNsid = {};
+
+  http.Client get client => MockClient((request) async {
+    if (request.url.path == '/.well-known/oauth-authorization-server') {
+      return _json({
+        'issuer': 'https://bsky.social',
+        'token_endpoint': 'https://bsky.social/oauth/token',
+      });
+    }
+
+    if (request.url.path == '/oauth/token') {
+      tokenPosts++;
+
+      if (Uri.splitQueryString(request.body)['refresh_token'] != _refresh) {
+        //! The refresh token was already spent by someone else.
+        return _json({'error': 'invalid_grant'}, status: 400);
+      }
+
+      _rotations++;
+      _access = 'access-$_rotations';
+      _refresh = 'refresh-$_rotations';
+
+      return _json({
+        'access_token': _access,
+        'token_type': 'DPoP',
+        'refresh_token': _refresh,
+        'expires_in': 3600,
+        'sub': 'did:plc:testaccount',
+        'scope': 'atproto',
+      });
+    }
+
+    return http.Response('unexpected', 500);
+  });
+
+  /// A PDS `GET` client that rejects anything but the access token the
+  /// authorization server most recently issued.
+  Future<http.Response> get(
+    final Uri url, {
+    final Map<String, String>? headers,
+  }) async {
+    proxyHeaderByNsid[url.path.replaceFirst('/xrpc/', '')] =
+        headers?['atproto-proxy'];
+
+    if (headers?['Authorization'] != 'DPoP $_access') {
+      return http.Response(
+        '{"error":"ExpiredToken"}',
+        401,
+        headers: {'content-type': 'application/json'},
+        request: http.Request('GET', url),
+      );
+    }
+
+    return http.Response(
+      url.path.contains('chat.bsky.convo.listConvos')
+          ? '{"convos":[]}'
+          : '{"feed":[]}',
+      200,
+      headers: {'content-type': 'application/json'},
+      request: http.Request('GET', url),
+    );
+  }
+
+  static http.Response _json(
+    final Map<String, dynamic> body, {
+    final int status = 200,
+  }) => http.Response(
+    jsonEncode(body),
+    status,
+    headers: {'content-type': 'application/json'},
+  );
+}
+
+OAuthClientMetadata _clientMetadata() => const OAuthClientMetadata(
+  clientId: 'cid',
+  applicationType: 'web',
+  clientName: 'Test',
+  clientUri: 'https://client.example',
+  redirectUris: ['https://client.example/callback'],
+  scope: 'atproto',
+  tokenEndpointAuthMethod: 'none',
+);
+
+DateTime _expired() =>
+    DateTime.now().toUtc().subtract(const Duration(minutes: 5));
+
+void main() {
+  //! The default signer performs real EC crypto, and both the manager and the
+  //! `OAuthClient` reach for it, so these sessions carry a real key pair.
+  late DPoPKeyPair keyPair;
+
+  setUpAll(() async {
+    keyPair = await const PointyCastleDPoPSigner().generateKeyPair();
+  });
+
+  OAuthSession session({final DateTime? expiresAt}) => OAuthSession(
+    accessToken: 'access-1',
+    refreshToken: 'refresh-1',
+    scope: 'atproto',
+    expiresAt: expiresAt,
+    sub: 'did:plc:testaccount',
+    issuer: 'https://bsky.social',
+    pds: 'https://pds.test',
+    clientId: 'cid',
+    dpopPublicKey: keyPair.publicKey,
+    dpopPrivateKey: keyPair.privateKey,
+  );
+
+  group('one OAuthSessionManager shared between clients', () {
+    //! The OAuth path never puts the session on the context: `ATProto.fromOAuth`
+    //! passes the manager and no `session:`, so the manager owns the
+    //! credentials, the single in-flight refresh, and the rotation stream —
+    //! and passing one manager to several clients already shares all three.
+    //! These tests hold that shape, which the doc comments now describe.
+
+    test('refreshes an expired session exactly once for both', () async {
+      final server = _FakeAuthServer();
+      final manager = OAuthSessionManager.fromSession(
+        session(expiresAt: _expired()),
+        client: OAuthClient(_clientMetadata(), httpClient: server.client),
+      );
+
+      final bsky = Bluesky.fromOAuth(
+        manager,
+        service: 'pds.test',
+        getClient: server.get,
+      );
+      final chat = BlueskyChat.fromOAuth(
+        manager,
+        service: 'pds.test',
+        getClient: server.get,
+      );
+
+      final timeline = await bsky.feed.getTimeline();
+      final convos = await chat.convo.listConvos();
+
+      expect(timeline.status.code, 200);
+      expect(convos.status.code, 200);
+      //! One session, one refresh: the second client never replayed the
+      //! refresh token the first one spent.
+      expect(server.tokenPosts, 1);
+      expect(
+        identical(bsky.oAuthSessionManager, chat.oAuthSessionManager),
+        isTrue,
+      );
+      expect(manager.currentSession?.accessToken, 'access-2');
+    });
+
+    test('one 401-driven refresh is enough for both', () async {
+      //! The PDS has already moved on from `access-1`, and the session carries
+      //! no `expiresAt`, so nothing refreshes pre-flight: the `401` is what
+      //! drives this.
+      final server = _FakeAuthServer(access: 'access-2');
+      final manager = OAuthSessionManager.fromSession(
+        session(),
+        client: OAuthClient(_clientMetadata(), httpClient: server.client),
+      );
+
+      final bsky = Bluesky.fromOAuth(
+        manager,
+        service: 'pds.test',
+        getClient: server.get,
+      );
+      final chat = BlueskyChat.fromOAuth(
+        manager,
+        service: 'pds.test',
+        getClient: server.get,
+      );
+
+      final timeline = await bsky.feed.getTimeline();
+      final convos = await chat.convo.listConvos();
+
+      expect(timeline.status.code, 200);
+      expect(convos.status.code, 200);
+      expect(server.tokenPosts, 1);
+    });
+
+    test('emits one rotation on the manager both clients read', () async {
+      final server = _FakeAuthServer();
+      final manager = OAuthSessionManager.fromSession(
+        session(expiresAt: _expired()),
+        client: OAuthClient(_clientMetadata(), httpClient: server.client),
+      );
+
+      final updates = <OAuthSession>[];
+      manager.onSessionUpdated.listen(updates.add);
+
+      final bsky = Bluesky.fromOAuth(
+        manager,
+        service: 'pds.test',
+        getClient: server.get,
+      );
+      final chat = BlueskyChat.fromOAuth(
+        manager,
+        service: 'pds.test',
+        getClient: server.get,
+      );
+
+      final fromBsky = <core.Session>[];
+      final fromChat = <core.Session>[];
+      bsky.onSessionUpdated.listen(fromBsky.add);
+      chat.onSessionUpdated.listen(fromChat.add);
+
+      await bsky.feed.getTimeline();
+      await chat.convo.listConvos();
+      await Future<void>.delayed(Duration.zero);
+
+      //! One stream, one rotation to persist — the OAuth counterpart of
+      //! `ServiceContext.onSessionUpdated`.
+      expect(updates.single.refreshToken, 'refresh-2');
+      //! And the legacy stream stays silent on OAuth-backed clients, as its
+      //! own doc comment promises: there is no `Session` to announce.
+      expect(fromBsky, isEmpty);
+      expect(fromChat, isEmpty);
+    });
+
+    test('sends the chat proxy header on chat.bsky.* alone', () async {
+      final server = _FakeAuthServer();
+      final manager = OAuthSessionManager.fromSession(
+        session(expiresAt: _expired()),
+        client: OAuthClient(_clientMetadata(), httpClient: server.client),
+      );
+
+      final bsky = Bluesky.fromOAuth(
+        manager,
+        service: 'pds.test',
+        getClient: server.get,
+      );
+      final chat = BlueskyChat.fromOAuth(
+        manager,
+        service: 'pds.test',
+        getClient: server.get,
+      );
+
+      await bsky.feed.getTimeline();
+      await chat.convo.listConvos();
+
+      //! Separate contexts, separate headers, one session underneath — the
+      //! same split the app-password path now gets from `withHeaders`.
+      expect(
+        server.proxyHeaderByNsid['chat.bsky.convo.listConvos'],
+        'did:web:api.bsky.chat#bsky_chat',
+      );
+      expect(server.proxyHeaderByNsid['app.bsky.feed.getTimeline'], isNull);
+      expect(chat.atproto.headers.containsKey('atproto-proxy'), isFalse);
+    });
+  });
+
+  group('fromOAuthSession does not share', () {
+    test('the second manager replays the spent refresh token', () async {
+      final server = _FakeAuthServer();
+      final client = OAuthClient(_clientMetadata(), httpClient: server.client);
+      final stale = session(expiresAt: _expired());
+
+      //! Each of these builds an `OAuthSessionManager` of its own, and each
+      //! manager its own copy of the session.
+      final bsky = Bluesky.fromOAuthSession(
+        stale,
+        oauthClient: client,
+        service: 'pds.test',
+        getClient: server.get,
+      );
+      final chat = BlueskyChat.fromOAuthSession(
+        stale,
+        oauthClient: client,
+        service: 'pds.test',
+        getClient: server.get,
+      );
+
+      expect(
+        identical(bsky.oAuthSessionManager, chat.oAuthSessionManager),
+        isFalse,
+      );
+
+      await bsky.feed.getTimeline();
+
+      //! The chat manager never saw the rotation, so it presents the refresh
+      //! token the timeline call already spent and the server revokes it. This
+      //! is why `fromOAuth` with a manager the caller owns is the way to share.
+      await expectLater(
+        chat.convo.listConvos(),
+        throwsA(isA<OAuthSessionRevokedException>()),
+      );
+      expect(server.tokenPosts, 2);
+    });
+  });
+}


### PR DESCRIPTION
Stacked on #2503 — review that one first; the base retargets to `main` when it merges.

## Problem

#2503 added `Bluesky.fromAtproto` and `OzoneTool.fromAtproto`, but could not extend the same treatment to `BlueskyChat`: the `atproto-proxy` header that routes `chat.bsky.*` to the chat service was merged into the **context**, and `ServiceContext._headers` is context-wide. A shared context would have proxied the other client's `app.bsky.*` and `com.atproto.*` calls too.

The root cause is that mutable session state and per-client request headers lived in the same object. So a chat client always held its own copy of the session and raced any other client for the same account's single-use refresh token — the loser's refresh is rejected and its next call fails with an `UnauthorizedException` the caller did nothing to provoke.

## Change

`ServiceContext`'s mutable state (session, in-flight refresh, rotation stream, JWT-derived caches) moves into a private `_SessionState` holder, and

```dart
ServiceContext withHeaders(Map<String, String> headers)   // atproto_core
BlueskyChat.fromAtproto(ATProto atproto)                  // bluesky
```

derive a context that **shares the session but carries its own headers**. Headers belong to the client; the session belongs to the account.

The holder is deliberately private. `OAuthSessionManager` is public because callers supply its DPoP signer, nonce cache and client; the legacy holder has nothing a caller would substitute, and exposing it would add a `session:` vs `sessionManager:` exclusivity rule to explain.

The proxy-header derivation lives in the single private constructor every `BlueskyChat` factory already funnels through, so no future factory can forget it.

`ServiceContext.onRefreshSession` becomes a getter. This is source-compatible: `ServiceContext` is a `base class`, so `implements` is prohibited at the language level, and nothing extends it.

## Behaviour change worth calling out

`BlueskyChat.fromSession(...).atproto` no longer sends the chat proxy header on `com.atproto.*` calls made through it. That was unintended — an identity or server call was being routed to the chat service. `BlueskyChat.headers` itself is unchanged. The tests pin that the header is now absent; they cannot show what a real server would have done with it, and no claim is made about that.

## The OAuth path was already correct

`ATProto.fromOAuth` passes only `oAuthSessionManager:` and never `session:`, so all mutable state already lives in the manager. Passing **one** manager to several clients has always given one session, one refresh, one rotation stream — with separate contexts and separate headers. The race was app-password-only.

That was documented nowhere, and #2503's doc comment implied the opposite. Fixed here, along with a trap that was silent across the whole API: `fromOAuthSession` mints a fresh manager per call, so two clients built from one `OAuthSession` do not merely fail to share — they revoke each other, surfacing `OAuthSessionRevokedException` from a session that was valid. Now documented on all seven OAuth factories across `ATProto`, `Bluesky`, `BlueskyChat` and `OzoneTool`.

## Tests

`+23` (`atproto_core` 149, `bluesky` 896).

- `withHeaders`: both directions of the header split asserted on the wire; a refresh driven from either side reaches the other; the derived context sends the refreshed token; **concurrent expiries across both contexts issue exactly one refresh**, so the in-flight future itself is shared, not just the session; the pre-flight expiry path shares too; and protocol/service/relay/timeout/retry/clients/OAuth-manager all carry across.
- `bluesky`: one refresh between a `Bluesky` and a `BlueskyChat` while `chat.bsky.*` carries `atproto-proxy` and `app.bsky.*` does not; either client can drive the refresh; the negative control — two `fromSession` clients — still reproduces the `UnauthorizedException`.
- OAuth sharing is backed by tests rather than only by the new prose, including the `fromOAuthSession` revocation case.

`_FakePds` enforces genuine single-use semantics (a replayed refresh token 400s), so these are real refreshes.

## Refactor safety

Baselines captured before the change: `atproto_core` 138, `atproto` 388, `bluesky` 884 — afterwards 149 / 388 / 896, with the deltas exactly the new tests and every pre-existing test still present and passing. The existing suite already pins the pre-flight expiry check, the reactive 401 path, single-flight deduplication and `onSessionUpdated`; none of those tests were modified.

Mutation-checked: making `withHeaders` copy the state instead of sharing it fails exactly the five sharing tests and leaves the header tests green.

## Note on versioning

No `pubspec.yaml` or `CHANGELOG.md` is touched. Versions and changelog entries land in a single release PR once this batch is complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)