### PR TITLE
chore: release actorDid, isAmbiguousFailure, and cross-client session sharing

### DIFF
--- a/packages/atproto/CHANGELOG.md
+++ b/packages/atproto/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release Note
 
+## v2.3.0
+
+- feat: added `ATProto.actorDid`, surfacing `ServiceContext.actorDid` so callers can ask which actor a client is authenticated as without branching on the auth kind. Named `actorDid` rather than `repo`, which is already the `com.atproto.repo.*` service on this class.
+- docs: `fromOAuth` now records that one shared `OAuthSessionManager` is what makes several clients share a session, and `fromOAuthSession` that it mints a fresh manager per call. Two managers restored from one `OAuthSession` do not merely fail to share: because a rotating refresh token is only honoured once, they revoke each other, surfacing `OAuthSessionRevokedException` from a session that was valid.
+- chore: bump `atproto_core` to `^2.3.0`.
+
 ## v2.2.1
 
 - chore: widen `atproto_core` to `^2.2.0` and `xrpc` to `^1.1.3`.

--- a/packages/atproto/pubspec.yaml
+++ b/packages/atproto/pubspec.yaml
@@ -1,7 +1,7 @@
 name: atproto
 resolution: workspace
 description: The most famous and powerful Dart/Flutter library for AT Protocol.
-version: 2.2.1
+version: 2.3.0
 homepage: https://atprotodart.com
 documentation: https://atprotodart.com/docs/packages/atproto
 repository: https://github.com/myConsciousness/atproto.dart/tree/main/packages/atproto
@@ -18,7 +18,7 @@ topics:
   - api
 
 dependencies:
-  atproto_core: ^2.2.0
+  atproto_core: ^2.3.0
   xrpc: ^1.1.3
   freezed_annotation: ^3.1.0
   json_annotation: ^4.9.0

--- a/packages/atproto_core/CHANGELOG.md
+++ b/packages/atproto_core/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Release Note
 
+## v2.3.0
+
+- feat: added `ServiceContext.actorDid`, the DID of the authenticated actor regardless of how the context was authenticated. `session` is set only for the legacy (app-password) path and `oAuthSessionManager` only for the OAuth one, so neither answers that on its own and callers were left composing the two by hand. `repo` is now defined in terms of it, so the two cannot drift.
+- feat: added `isAmbiguousFailure`, a pure predicate reporting whether a caught error leaves it uncertain that the request reached the server. The retry engine already drew this distinction but only exposed it to a `RetryStrategy`; once retries were exhausted the original error was rethrown unchanged — a `TimeoutException` or an `http.ClientException` cannot carry an extra field — so a caller writing records could not tell a safe retry from one risking a duplicate. The retry layer now consumes the same predicate, so the classification callers see cannot drift from the behavior they observe.
+- feat: `atproto_core.dart` now re-exports `TidGenerator` from `at_primitives`, alongside the existing `AtUri` and `NSID` re-exports, so a caller allocating record keys ahead of a write does not need a direct dependency on `at_primitives`.
+- feat: added `ServiceContext.withHeaders`, deriving a context that shares this one's session while carrying its own request headers. Mutable session state now lives in a holder the derived contexts share, so a refresh — including the deduplicated in-flight one — is seen by all of them. Headers belong to the client; the session belongs to the account.
+
 ## v2.2.0
 
 - feat: added `computeRecordCid`, which returns the CID a PDS will assign to a record by canonically DAG-CBOR-encoding it and hashing to a CIDv1. This lets a caller reference a record before it is written — for example to chain reply references across records submitted in one `com.atproto.repo.applyWrites` batch.

--- a/packages/atproto_core/pubspec.yaml
+++ b/packages/atproto_core/pubspec.yaml
@@ -1,7 +1,7 @@
 name: atproto_core
 resolution: workspace
 description: Core library for clients and tools. This package is mainly used by https://atprotodart.com packages.
-version: 2.2.0
+version: 2.3.0
 homepage: https://atprotodart.com
 documentation: https://atprotodart.com/docs/intro
 repository: https://github.com/myConsciousness/atproto.dart/tree/main/packages/atproto_core

--- a/packages/bluesky/CHANGELOG.md
+++ b/packages/bluesky/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release Note
 
+## v2.3.0
+
+- feat: added `Bluesky.fromAtproto`, `BlueskyChat.fromAtproto` and `OzoneTool.fromAtproto`, which drive their services from an `ATProto` the caller already owns instead of building a new one. Every factory used to build its own, and each of those owned a context holding its own copy of the session — so an app needing more than one client for the same account held two copies of one session. Refresh tokens are single-use, so those copies raced the moment the access token expired: the context that noticed first spent the token, and the other's refresh was rejected, surfacing as an `UnauthorizedException` the caller did nothing to provoke. Passing one `ATProto` to each client gives them one session, one deduplicated refresh, and one `onSessionUpdated` stream.
+- feat: added `actorDid` to `Bluesky`, `BlueskyChat` and `OzoneTool`, so the authenticated actor can be read without branching on the auth kind.
+- feat: added `bluesky.feed.createThreadAtomic`, which publishes a whole thread in a single `com.atproto.repo.applyWrites` commit. Record keys and reply CIDs are computed locally, so every post references the previous one without waiting for it to be written, and the thread is committed atomically rather than post by post. Also added `ThreadPost`, `ThreadBatch`, `CreatedThread` and `ThreadVerificationException`; `ThreadBatch` builds and verifies a batch without a client, exposing the record keys before the write and allowing an extra write — an `app.bsky.feed.threadgate`, say — in the same commit. `Bluesky.feed` is now `FeedServiceImpl`, a subclass of `FeedService` matching `Bluesky.video`; existing calls are unaffected.
+- feat: added `VideoServiceImpl.uploadVideoAndAwait`, which uploads a video and resolves with the resulting blob once the processing job terminates, polling `getJobStatus` at a caller-chosen interval and bounding the whole operation with a timeout. Added `VideoUploadException` with `VideoJobFailedException`, `VideoJobMissingBlobException` and `VideoUploadTimeoutException`, so a caller can tell a video the server rejected from one it gave up waiting for, and can show the server's own reason. A job that completes without a blob is reported as a failure rather than a success.
+- fix: a `BlueskyChat`'s own `atproto` no longer sends the `atproto-proxy` chat header on the `com.atproto.*` calls made through it. The header identifies the chat service and belongs to `chat.bsky.*` alone; routing an identity or server call to it was unintended. `BlueskyChat.headers` is unchanged, and chat calls still carry the header.
+- docs: every OAuth factory now records that one shared `OAuthSessionManager` is what makes clients share a session, and that `fromOAuthSession` mints a fresh manager per call — two managers restored from one `OAuthSession` revoke each other rather than sharing.
+- chore: bump `atproto_core` to `^2.3.0` and `atproto` to `^2.3.0` (dev: `bluesky_text` `^1.6.0`).
+
 ## v2.2.3
 
 - feat: added `app.bsky.ageassurance.defs#configRegion.platforms`

--- a/packages/bluesky/pubspec.yaml
+++ b/packages/bluesky/pubspec.yaml
@@ -1,7 +1,7 @@
 name: bluesky
 resolution: workspace
 description: The most famous and powerful Dart/Flutter library for Bluesky Social.
-version: 2.2.3
+version: 2.3.0
 homepage: https://atprotodart.com
 documentation: https://atprotodart.com/docs/packages/bluesky
 repository: https://github.com/myConsciousness/atproto.dart/tree/main/packages/bluesky
@@ -18,8 +18,8 @@ topics:
   - api
 
 dependencies:
-  atproto_core: ^2.2.0
-  atproto: ^2.2.1
+  atproto_core: ^2.3.0
+  atproto: ^2.3.0
   freezed_annotation: ^3.1.0
   json_annotation: ^4.9.0
   characters: ^1.4.0
@@ -34,7 +34,7 @@ dev_dependencies:
     git:
       url: https://github.com/myConsciousness/import_sorter.git
       ref: fix/monorepo-pub-workspaces
-  bluesky_text: ^1.5.4
+  bluesky_text: ^1.6.0
 
   atproto_test:
     path: ../atproto_test

--- a/packages/bluesky_cli/CHANGELOG.md
+++ b/packages/bluesky_cli/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Note
 
+## v0.6.6
+
+- chore: widen `bluesky_text` to `^1.6.0`.
+
 ## v0.6.5
 
 - chore: regenerated from synced lexicons

--- a/packages/bluesky_cli/pubspec.yaml
+++ b/packages/bluesky_cli/pubspec.yaml
@@ -1,7 +1,7 @@
 name: bluesky_cli
 resolution: workspace
 description: A powerful CLI tool that allows Bluesky Social's APIs to be executed from the command line powered by Dart language.
-version: 0.6.5
+version: 0.6.6
 homepage: https://atprotodart.com
 repository: https://github.com/myConsciousness/atproto.dart/tree/main/packages/bluesky_cli
 issue_tracker: https://github.com/myConsciousness/atproto.dart/issues
@@ -27,7 +27,7 @@ dependencies:
   args: ^2.7.0
   cli_launcher: ^0.3.1
   cli_util: ^0.5.1
-  bluesky_text: ^1.5.4
+  bluesky_text: ^1.6.0
 
 dev_dependencies:
   http: ^1.4.0

--- a/packages/bluesky_text/CHANGELOG.md
+++ b/packages/bluesky_text/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release Note
 
+## v1.6.0
+
+- feat: added `isLinkFacade`, which reports when a facet's display text reads as a URL or host that does not match the host its link points at — the link-facade phishing shape. Display text that is not URL-looking is never flagged: a bare host is flagged only when this package would itself have linkified that same text. Hosts match on equality or a subdomain relation, ignoring `www.`, trailing root dots, case, ports, paths and punycode encoding. It does not detect homographs, redirects or deceptive non-URL text, and says so.
+- feat: added `toDisplayHost`, which decodes a punycode (`xn--`) host into the Unicode it stands for, so a link warning can show what the host actually says.
+- fix: the facet maps returned by `Entity.toFacet`, `Entities.toFacets`, `Entities.toFacetsResult` and `BlueskyText.toPostData` are now wire-complete. The facet carries `"$type": "app.bsky.richtext.facet"` and its `index` carries `"$type": "app.bsky.richtext.facet#byteSlice"`, matching what the lexicon models serialize to — previously only the individual features were typed, and the returned map did not even pass `RichtextFacet.validate`. Callers going through `feed.post.create` never noticed, since the generated converter fills them in; callers assembling a record map themselves, for `com.atproto.repo.applyWrites` or to compute a record CID locally, silently produced a record that differed from the converter's output. The "no facet" results (an unresolvable handle, a raw markdown link) are still an empty map.
+
 ## v1.5.4
 
 - chore: bump `xrpc` to `^1.1.3`.

--- a/packages/bluesky_text/pubspec.yaml
+++ b/packages/bluesky_text/pubspec.yaml
@@ -1,7 +1,7 @@
 name: bluesky_text
 resolution: workspace
 description: Provides the easiest and most powerful way to analyze the text for Bluesky Social.
-version: 1.5.4
+version: 1.6.0
 homepage: https://atprotodart.com
 repository: https://github.com/myConsciousness/atproto.dart/tree/main/packages/bluesky_text
 issue_tracker: https://github.com/myConsciousness/atproto.dart/issues


### PR DESCRIPTION
Assigns versions for the five changes merged in #2500, #2501, #2502, #2503 and #2504. Those PRs deliberately touched no `pubspec.yaml`, so that this batch releases once rather than tagging `main` on every merge, and so the changelog reads as one release note instead of five independently-worded ones.

| package | | notes |
|---|---|---|
| `atproto_core` | 2.2.0 → **2.3.0** | |
| `atproto` | 2.2.1 → **2.3.0** | `atproto_core: ^2.3.0` |
| `bluesky` | 2.2.3 → **2.3.0** | `atproto_core: ^2.3.0`, `atproto: ^2.3.0`, dev `bluesky_text: ^1.6.0` |
| `bluesky_text` | 1.5.4 → **1.6.0** | |
| `bluesky_text_flutter` | 0.1.2 unchanged | uses only `overflow`/`segments`, never the facet APIs that changed; `^1.5.2` already admits 1.6.0 |

## The constraint bumps are load-bearing

`atproto` uses `ServiceContext.actorDid`, and `bluesky` uses both that and `ServiceContext.withHeaders` — all new in `atproto_core` 2.3.0. **A pub workspace resolves every package together, so leaving `^2.2.0` in place would still build in this repo** while an external consumer resolving `bluesky` 2.3.0 against `atproto_core` 2.2.0 would fail to compile. `bluesky_cli` and `atproto_test` use none of the new APIs and their existing caret ranges already admit the new versions, so they are untouched.

## One behaviour change is in this release

`bluesky` carries a `fix`, not only features: a `BlueskyChat`'s own `atproto` no longer sends the `atproto-proxy` chat header on `com.atproto.*` calls made through it. `BlueskyChat.headers` is unchanged and chat calls still carry the header. Nothing is source-breaking.

## Publish ordering — worth watching

`release_tags.yml` pushes all four tags atomically, and each fires its own `publish.yml` run with no ordering between them. `bluesky` 2.3.0 requires `atproto_core` 2.3.0, so if its run reaches the publish step before `atproto_core` is live on pub.dev, resolution fails and that run goes red. Nothing is corrupted if it happens — the tag exists, so re-running the failed job once the dependency is published completes the release.

Staging this as two releases (`atproto_core` + `bluesky_text` first, then `atproto` + `bluesky`) would avoid the race entirely, at the cost of two merges.

## Verification

Full suites on this branch after the version and constraint changes: `atproto_core` 171, `atproto` 389, `bluesky` 901, `bluesky_text` 407 — all passing, `dart analyze` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)