### PR TITLE
feat(bluesky): add uploadVideoAndAwait

### DIFF
--- a/packages/bluesky/lib/bluesky.dart
+++ b/packages/bluesky/lib/bluesky.dart
@@ -6,6 +6,7 @@ export 'package:bluesky/src/bluesky.dart';
 
 export 'package:bluesky/src/services/app/bsky/feed_service.dart';
 export 'package:bluesky/src/services/app/bsky/feed/thread.dart';
+export 'package:bluesky/src/services/app/bsky/video_upload_exception.dart';
 
 export 'package:bluesky/src/tools/utils/grouped_notification_reason.dart';
 

--- a/packages/bluesky/lib/src/services/app/bsky/video_service.dart
+++ b/packages/bluesky/lib/src/services/app/bsky/video_service.dart
@@ -19,8 +19,36 @@ import '../../../ids.g.dart' as bsky_id;
 import '../../codegen/app/bsky/video/getJobStatus/output.dart';
 import '../../codegen/app/bsky/video/getUploadLimits/output.dart';
 import '../../codegen/app/bsky/video_service.dart';
+import 'video_upload_exception.dart';
 
 const _videoService = 'video.bsky.app';
+
+/// The default interval between two `getJobStatus` polls.
+const _defaultPollInterval = Duration(seconds: 3);
+
+/// The default budget for an entire upload-and-wait operation.
+const _defaultTimeout = Duration(minutes: 5);
+
+/// Returns the video blob of a terminal [status], or null while the job is
+/// still in process.
+///
+/// The terminal set is exactly what `app.bsky.video.defs#jobStatus` declares as
+/// known values for `state`, because that lexicon also says: "All values not
+/// listed as a known value indicate that the job is in process." So an
+/// unrecognized state is a job still running, not an error — the generated
+/// [JobStatusState] union already draws the line in the right place, and the
+/// exhaustive switch below turns any newly generated known value into a
+/// compile error rather than a silently mishandled state.
+Blob? _terminalBlobOf(final JobStatus status) => switch (status.state) {
+  JobStatusStateKnownValue(data: KnownJobStatusState.jOB_STATE_COMPLETED) =>
+    //! A completed job with no blob is a failure. The blob is the whole
+    //! point of the upload, so returning null here would hand the caller a
+    //! "success" it cannot post.
+    status.blob ?? (throw VideoJobMissingBlobException(status)),
+  JobStatusStateKnownValue(data: KnownJobStatusState.jOB_STATE_FAILED) =>
+    throw VideoJobFailedException(status),
+  JobStatusStateUnknown() => null,
+};
 
 final class VideoServiceImpl extends VideoService {
   VideoServiceImpl(super.ctx);
@@ -67,6 +95,135 @@ final class VideoServiceImpl extends VideoService {
     $headers: $headers,
     $unknown: $unknown,
   );
+
+  /// Uploads [bytes] and waits for the video service to finish processing it,
+  /// returning the blob to embed in a post.
+  ///
+  /// [uploadVideo] only *starts* a job; the blob does not exist until that job
+  /// terminates. This drives the whole ceremony — upload, then poll
+  /// [getJobStatus] every [pollInterval] until the job reaches a terminal state
+  /// — and resolves only once there is a real blob to hand back.
+  ///
+  /// ## Parameters
+  ///
+  /// * [bytes] - Video file data as bytes
+  /// * [pollInterval] - Wait between two [getJobStatus] calls. Defaults to 3
+  ///   seconds
+  /// * [timeout] - Budget for the whole operation, upload included. Defaults to
+  ///   5 minutes
+  /// * [onProgress] - Called with every job status observed, the terminal one
+  ///   included, so a UI can render [JobStatus.progress]
+  /// * [$service] - Optional service endpoint (defaults to video.bsky.app),
+  ///   used for both the upload and the polling
+  /// * [$headers], [$parameters] - Applied to the upload request only; the
+  ///   polling requests are sent with the context's own authentication
+  ///
+  /// ## Throws
+  ///
+  /// Every failure mode is a [VideoUploadException], and the subtype says which
+  /// one it was:
+  ///
+  /// * [VideoJobFailedException] - the service rejected the video. Carries the
+  ///   final status, so the server's own reason can be shown
+  /// * [VideoJobMissingBlobException] - the job completed but carried no blob,
+  ///   which is a failure rather than a success
+  /// * [VideoUploadTimeoutException] - [timeout] expired while the job was
+  ///   still running. Distinct from the two above so "the server rejected this
+  ///   video" is never confused with "we gave up waiting"
+  ///
+  /// [timeout] releases the caller; it does not necessarily stop the work.
+  /// Polling does stop, so an abandoned job costs no further requests, but an
+  /// upload request already in flight when the budget expires cannot be
+  /// cancelled and runs to its own completion in the background — bounded by
+  /// the service context's per-request timeout, not by this one. A caller
+  /// accounting for memory or sockets should expect [bytes] to stay reachable
+  /// for a little longer than this method takes to throw. The job itself also
+  /// keeps running server-side, which is why the exception carries the last
+  /// status: its [JobStatus.jobId] can be handed to [getJobStatus] later.
+  ///
+  /// Anything [onProgress] throws is caught and discarded: it exists to drive a
+  /// UI, and a broken progress indicator must not fail an upload the server
+  /// accepted. Being `void`, an `async` [onProgress] is not awaited either, so
+  /// its errors are equally invisible here.
+  ///
+  /// ## Example
+  ///
+  /// ```dart
+  /// final blob = await bsky.video.uploadVideoAndAwait(
+  ///   bytes: videoBytes,
+  ///   onProgress: (status) => print('${status.progress ?? 0}%'),
+  /// );
+  ///
+  /// await bsky.feed.post(
+  ///   text: 'Look at this',
+  ///   embed: UFeedPostEmbed.embedVideo(data: EmbedVideo(video: blob)),
+  /// );
+  /// ```
+  Future<Blob> uploadVideoAndAwait({
+    required Uint8List bytes,
+    Duration pollInterval = _defaultPollInterval,
+    Duration timeout = _defaultTimeout,
+    void Function(JobStatus status)? onProgress,
+    String? $service,
+    Map<String, String>? $headers,
+    Map<String, String>? $parameters,
+  }) async {
+    JobStatus? lastStatus;
+    var expired = false;
+
+    void report(final JobStatus status) {
+      lastStatus = status;
+      if (onProgress == null) return;
+
+      try {
+        onProgress(status);
+      } catch (_) {
+        //! Best-effort by contract: a throwing progress callback is the
+        //! caller's UI problem, never a reason to fail an upload the video
+        //! service is handling perfectly well.
+      }
+    }
+
+    Future<Blob> pollUntilTerminal() async {
+      final uploaded = await uploadVideo(
+        bytes: bytes,
+        $service: $service,
+        $headers: $headers,
+        $parameters: $parameters,
+      );
+
+      var status = uploaded.data;
+      while (true) {
+        report(status);
+
+        final blob = _terminalBlobOf(status);
+        if (blob != null) return blob;
+
+        await Future<void>.delayed(pollInterval);
+
+        //! `timeout` below completes the future the caller is awaiting, but it
+        //! cannot stop this loop. Without this check a job that never
+        //! terminates would keep polling the service forever, long after
+        //! everyone stopped listening. The thrown exception is discarded by
+        //! the already-completed `timeout`.
+        if (expired) throw VideoUploadTimeoutException(timeout, lastStatus);
+
+        status = (await getJobStatus(
+          jobId: status.jobId,
+          $service: $service,
+        )).data.jobStatus;
+      }
+    }
+
+    return await pollUntilTerminal().timeout(
+      timeout,
+      onTimeout: () {
+        expired = true;
+
+        throw VideoUploadTimeoutException(timeout, lastStatus);
+      },
+    );
+  }
 
   /// Uploads a video using a service authentication token.
   ///

--- a/packages/bluesky/lib/src/services/app/bsky/video_upload_exception.dart
+++ b/packages/bluesky/lib/src/services/app/bsky/video_upload_exception.dart
@@ -1,0 +1,150 @@
+// Copyright (c) 2023-2026, Shinya Kato.
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// Project imports:
+import '../../../../app_bsky_video_defs.dart';
+
+/// The ways `uploadVideoAndAwait` can end without a usable video blob.
+///
+/// Sealed so a caller can `switch` over every failure mode and be told by the
+/// compiler when a new one appears:
+///
+/// ```dart
+/// try {
+///   final blob = await bsky.video.uploadVideoAndAwait(bytes);
+/// } on VideoUploadException catch (e) {
+///   final reason = switch (e) {
+///     VideoJobFailedException(:final status) => status.error ?? 'rejected',
+///     VideoJobMissingBlobException() => 'the video produced no file',
+///     VideoUploadTimeoutException() => 'still processing, try again later',
+///   };
+/// }
+/// ```
+sealed class VideoUploadException implements Exception {
+  /// Returns the new instance of [VideoUploadException].
+  const VideoUploadException();
+
+  /// The last job status observed before this exception was thrown.
+  ///
+  /// Null only on [VideoUploadTimeoutException], and only when the upload
+  /// itself never returned a status to begin with.
+  JobStatus? get status;
+}
+
+/// This exception indicates that the video service finished the processing job
+/// in [KnownJobStatusState.jOB_STATE_FAILED].
+///
+/// The server's own explanation is carried on [status] as
+/// [JobStatus.error] and [JobStatus.message]; show that instead of a generic
+/// message, since it is the only thing that tells the user whether the file was
+/// too long, the wrong codec, or over quota.
+final class VideoJobFailedException extends VideoUploadException {
+  /// Returns the new instance of [VideoJobFailedException].
+  const VideoJobFailedException(this.status);
+
+  /// The terminal, failed job status reported by the video service.
+  @override
+  final JobStatus status;
+
+  @override
+  String toString() {
+    final buffer = StringBuffer()
+      ..write('VideoJobFailedException:')
+      ..write(' job ')
+      ..write(status.jobId)
+      ..write(' ended in ')
+      ..write(status.state.toJson());
+
+    final reason = [
+      status.error,
+      status.message,
+    ].whereType<String>().join(': ');
+    if (reason.isNotEmpty) {
+      buffer
+        ..write(' - ')
+        ..write(reason);
+    }
+
+    return buffer.toString();
+  }
+}
+
+/// This exception indicates that the video service finished the processing job
+/// in [KnownJobStatusState.jOB_STATE_COMPLETED] but attached no blob to it.
+///
+/// A completed job is not a successful one on its own: the blob is the entire
+/// point of the upload, and there is nothing to embed in a post without it.
+/// Treating this as success is the classic way a video upload silently produces
+/// a post with no video, so it is reported as a failure of its own kind rather
+/// than folded into [VideoJobFailedException].
+final class VideoJobMissingBlobException extends VideoUploadException {
+  /// Returns the new instance of [VideoJobMissingBlobException].
+  const VideoJobMissingBlobException(this.status);
+
+  /// The terminal, blob-less job status reported by the video service.
+  @override
+  final JobStatus status;
+
+  @override
+  String toString() {
+    final buffer = StringBuffer()
+      ..write('VideoJobMissingBlobException:')
+      ..write(' job ')
+      ..write(status.jobId)
+      ..write(' reported ')
+      ..write(status.state.toJson())
+      ..write(' without a blob');
+
+    final reason = [
+      status.error,
+      status.message,
+    ].whereType<String>().join(': ');
+    if (reason.isNotEmpty) {
+      buffer
+        ..write(' - ')
+        ..write(reason);
+    }
+
+    return buffer.toString();
+  }
+}
+
+/// This exception indicates that the processing job had still not reached a
+/// terminal state when the caller's overall time budget ran out.
+///
+/// This is deliberately a different type from [VideoJobFailedException]: the
+/// server has not rejected anything, so the job may well finish afterwards.
+/// [status] holds the last state seen, whose [JobStatus.jobId] can be handed to
+/// `getJobStatus` later to pick the job back up.
+final class VideoUploadTimeoutException extends VideoUploadException {
+  /// Returns the new instance of [VideoUploadTimeoutException].
+  const VideoUploadTimeoutException(this.timeout, this.status);
+
+  /// The time budget that expired.
+  final Duration timeout;
+
+  /// The last job status observed, or null when the upload request itself did
+  /// not return before the budget expired.
+  @override
+  final JobStatus? status;
+
+  @override
+  String toString() {
+    final buffer = StringBuffer()
+      ..write('VideoUploadTimeoutException:')
+      ..write(' gave up waiting after ')
+      ..write(timeout);
+
+    final current = status;
+    if (current != null) {
+      buffer
+        ..write(' - job ')
+        ..write(current.jobId)
+        ..write(' was last seen in ')
+        ..write(current.state.toJson());
+    }
+
+    return buffer.toString();
+  }
+}

--- a/packages/bluesky/pubspec.yaml
+++ b/packages/bluesky/pubspec.yaml
@@ -40,3 +40,4 @@ dev_dependencies:
     path: ../atproto_test
   atproto_oauth: ^0.5.1
   http: any
+  fake_async: ^1.3.3

--- a/packages/bluesky/test/src/services/app/bsky/video_upload_and_await_test.dart
+++ b/packages/bluesky/test/src/services/app/bsky/video_upload_and_await_test.dart
@@ -1,0 +1,384 @@
+// Dart imports:
+import 'dart:convert';
+import 'dart:typed_data';
+
+// Package imports:
+import 'package:atproto_core/atproto_core.dart' as core;
+import 'package:fake_async/fake_async.dart';
+import 'package:http/http.dart' as http;
+import 'package:test/test.dart';
+
+// Project imports:
+import 'package:bluesky/src/services/app/bsky/video_service.dart';
+import 'package:bluesky/src/services/app/bsky/video_upload_exception.dart';
+import 'package:bluesky/src/services/codegen/app/bsky/video/defs/job_status.dart';
+
+final _bytes = Uint8List.fromList([1, 2, 3, 4]);
+
+const _blobJson = {
+  r'$type': 'blob',
+  'ref': {r'$link': 'bafyreivideoblob'},
+  'mimeType': 'video/mp4',
+  'size': 2048,
+};
+
+/// Builds an `app.bsky.video.defs#jobStatus` payload.
+///
+/// [state] is passed through verbatim so a test can send a state the lexicon
+/// does not list as a known value.
+Map<String, dynamic> _jobStatus(
+  final String state, {
+  final String jobId = 'job-123',
+  final int? progress,
+  final Map<String, dynamic>? blob,
+  final String? error,
+  final String? message,
+}) => {
+  r'$type': 'app.bsky.video.defs#jobStatus',
+  'jobId': jobId,
+  'did': 'did:plc:testaccount',
+  'state': state,
+  'progress': ?progress,
+  'blob': ?blob,
+  'error': ?error,
+  'message': ?message,
+};
+
+http.Response _ok(final Uri url, final String method, final Object body) =>
+    http.Response(
+      jsonEncode(body),
+      200,
+      headers: {'content-type': 'application/json; charset=utf-8'},
+      request: http.Request(method, url),
+    );
+
+/// Builds a service whose upload returns [upload] and whose Nth `getJobStatus`
+/// returns `polls[N]`, the last entry repeating forever once exhausted.
+///
+/// [onPoll] is invoked for every poll, letting a test record when it happened.
+VideoServiceImpl _service({
+  required final Map<String, dynamic> upload,
+  final List<Map<String, dynamic>> polls = const [],
+  final void Function()? onPoll,
+}) {
+  var index = 0;
+
+  return VideoServiceImpl(
+    core.ServiceContext(
+      postClient: (url, {headers, body, encoding}) async =>
+          _ok(url, 'POST', upload),
+      getClient: (url, {headers}) async {
+        onPoll?.call();
+        final status = polls[index < polls.length ? index : polls.length - 1];
+        index++;
+
+        return _ok(url, 'GET', {'jobStatus': status});
+      },
+    ),
+  );
+}
+
+void main() {
+  group('VideoServiceImpl.uploadVideoAndAwait', () {
+    test('returns the blob of a job that completes after several polls', () {
+      fakeAsync((async) {
+        final seen = <JobStatus>[];
+        var polls = 0;
+
+        final service = _service(
+          upload: _jobStatus('JOB_STATE_CREATED'),
+          polls: [
+            // Neither of these is a known value in `app.bsky.video.defs`, and
+            // that lexicon says every unknown value means the job is still in
+            // process. So they must be polled through, not treated as
+            // terminal.
+            _jobStatus('JOB_STATE_ENCODING', progress: 40),
+            _jobStatus('JOB_STATE_SCANNING', progress: 80),
+            _jobStatus('JOB_STATE_COMPLETED', progress: 100, blob: _blobJson),
+          ],
+          onPoll: () => polls++,
+        );
+
+        core.Blob? blob;
+        Object? error;
+        service
+            .uploadVideoAndAwait(
+              bytes: _bytes,
+              pollInterval: const Duration(seconds: 3),
+              onProgress: seen.add,
+            )
+            .then<void>(
+              (value) {
+                blob = value;
+              },
+              onError: (Object e) {
+                error = e;
+              },
+            );
+
+        async.elapse(const Duration(seconds: 30));
+
+        expect(error, isNull);
+        expect(blob, isNotNull);
+        expect(blob!.ref.link, 'bafyreivideoblob');
+        expect(blob!.mimeType, 'video/mp4');
+        expect(blob!.size, 2048);
+
+        // Three polls: the upload's own status is inspected first, so an
+        // already-terminal upload response would need none at all.
+        expect(polls, 3);
+
+        // `onProgress` sees the upload status and every poll, terminal
+        // included.
+        expect(seen.length, 4);
+        expect(seen.map((e) => e.state.toJson()).toList(), [
+          'JOB_STATE_CREATED',
+          'JOB_STATE_ENCODING',
+          'JOB_STATE_SCANNING',
+          'JOB_STATE_COMPLETED',
+        ]);
+        expect(seen.last.progress, 100);
+      });
+    });
+
+    test('never polls when the upload response is already terminal', () {
+      fakeAsync((async) {
+        var polls = 0;
+        final service = _service(
+          upload: _jobStatus('JOB_STATE_COMPLETED', blob: _blobJson),
+          onPoll: () => polls++,
+        );
+
+        core.Blob? blob;
+        service.uploadVideoAndAwait(bytes: _bytes).then<void>((value) {
+          blob = value;
+        });
+
+        async.elapse(const Duration(seconds: 30));
+
+        expect(blob, isNotNull);
+        expect(polls, isZero);
+      });
+    });
+
+    test('waits pollInterval between polls instead of spinning', () {
+      fakeAsync((async) {
+        final pollTimes = <Duration>[];
+
+        final service = _service(
+          upload: _jobStatus('JOB_STATE_CREATED'),
+          polls: [
+            _jobStatus('JOB_STATE_ENCODING'),
+            _jobStatus('JOB_STATE_ENCODING'),
+            _jobStatus('JOB_STATE_COMPLETED', blob: _blobJson),
+          ],
+          onPoll: () => pollTimes.add(async.elapsed),
+        );
+
+        core.Blob? blob;
+        service
+            .uploadVideoAndAwait(
+              bytes: _bytes,
+              pollInterval: const Duration(seconds: 3),
+            )
+            .then<void>((value) {
+              blob = value;
+            });
+
+        // Nothing may be polled before the first interval has fully elapsed.
+        async.elapse(const Duration(milliseconds: 2999));
+        expect(pollTimes, isEmpty);
+        expect(blob, isNull);
+
+        async.elapse(const Duration(milliseconds: 1));
+        expect(pollTimes, [const Duration(seconds: 3)]);
+
+        // ...and the second poll waits another full interval rather than
+        // firing immediately after the first response arrives.
+        async.elapse(const Duration(milliseconds: 2999));
+        expect(pollTimes.length, 1);
+
+        async.elapse(const Duration(milliseconds: 1));
+        expect(pollTimes, [
+          const Duration(seconds: 3),
+          const Duration(seconds: 6),
+        ]);
+
+        async.elapse(const Duration(seconds: 3));
+        expect(pollTimes, [
+          const Duration(seconds: 3),
+          const Duration(seconds: 6),
+          const Duration(seconds: 9),
+        ]);
+        expect(blob, isNotNull);
+      });
+    });
+
+    test('throws VideoJobFailedException carrying the final status', () {
+      fakeAsync((async) {
+        final service = _service(
+          upload: _jobStatus('JOB_STATE_CREATED'),
+          polls: [
+            _jobStatus(
+              'JOB_STATE_FAILED',
+              error: 'UNSUPPORTED_FORMAT',
+              message: 'The video codec is not supported.',
+            ),
+          ],
+        );
+
+        Object? error;
+        final seen = <JobStatus>[];
+        service
+            .uploadVideoAndAwait(
+              bytes: _bytes,
+              pollInterval: const Duration(seconds: 3),
+              onProgress: seen.add,
+            )
+            .then<void>(
+              (_) {},
+              onError: (Object e) {
+                error = e;
+              },
+            );
+
+        async.elapse(const Duration(seconds: 30));
+
+        expect(error, isA<VideoJobFailedException>());
+        final failure = error! as VideoJobFailedException;
+        expect(failure.status.state.toJson(), 'JOB_STATE_FAILED');
+        expect(failure.status.error, 'UNSUPPORTED_FORMAT');
+        expect(failure.status.message, 'The video codec is not supported.');
+        expect(failure.status.jobId, 'job-123');
+        expect(
+          failure.toString(),
+          contains('The video codec is not supported.'),
+        );
+
+        // A caller that only wants to know "job or timeout" can catch the base
+        // type, and the failing status reaches the progress callback too.
+        expect(failure, isA<VideoUploadException>());
+        expect(seen.last.state.toJson(), 'JOB_STATE_FAILED');
+      });
+    });
+
+    test('treats a completed job with no blob as a failure', () {
+      fakeAsync((async) {
+        final service = _service(
+          upload: _jobStatus('JOB_STATE_CREATED'),
+          // Completed, progress 100, and yet nothing to embed.
+          polls: [_jobStatus('JOB_STATE_COMPLETED', progress: 100)],
+        );
+
+        Object? error;
+        var completed = false;
+        service
+            .uploadVideoAndAwait(
+              bytes: _bytes,
+              pollInterval: const Duration(seconds: 3),
+            )
+            .then<void>(
+              (_) {
+                completed = true;
+              },
+              onError: (Object e) {
+                error = e;
+              },
+            );
+
+        async.elapse(const Duration(seconds: 30));
+
+        expect(completed, isFalse);
+        expect(error, isA<VideoJobMissingBlobException>());
+        final failure = error! as VideoJobMissingBlobException;
+        expect(failure.status.state.toJson(), 'JOB_STATE_COMPLETED');
+        expect(failure.status.blob, isNull);
+        expect(failure, isA<VideoUploadException>());
+      });
+    });
+
+    test('throws VideoUploadTimeoutException and stops polling on expiry', () {
+      fakeAsync((async) {
+        var polls = 0;
+        final service = _service(
+          upload: _jobStatus('JOB_STATE_CREATED'),
+          // A job that never terminates: the naive loop polls forever.
+          polls: [_jobStatus('JOB_STATE_ENCODING', progress: 10)],
+          onPoll: () => polls++,
+        );
+
+        Object? error;
+        service
+            .uploadVideoAndAwait(
+              bytes: _bytes,
+              pollInterval: const Duration(seconds: 3),
+              timeout: const Duration(seconds: 10),
+            )
+            .then<void>(
+              (_) {},
+              onError: (Object e) {
+                error = e;
+              },
+            );
+
+        async.elapse(const Duration(seconds: 10));
+
+        expect(error, isA<VideoUploadTimeoutException>());
+        final expiry = error! as VideoUploadTimeoutException;
+        expect(expiry.timeout, const Duration(seconds: 10));
+        // The last status seen is kept so the caller can resume the job later.
+        expect(expiry.status, isNotNull);
+        expect(expiry.status!.jobId, 'job-123');
+        expect(expiry.status!.state.toJson(), 'JOB_STATE_ENCODING');
+
+        // A timeout is not a job failure, and must be distinguishable from one.
+        expect(expiry, isNot(isA<VideoJobFailedException>()));
+        expect(expiry, isNot(isA<VideoJobMissingBlobException>()));
+
+        // Polls at 3s, 6s and 9s; the 12s one must never happen because the
+        // operation was abandoned at 10s.
+        expect(polls, 3);
+        async.elapse(const Duration(minutes: 5));
+        expect(polls, 3);
+      });
+    });
+
+    test('a throwing onProgress cannot break the upload', () {
+      fakeAsync((async) {
+        var calls = 0;
+        final service = _service(
+          upload: _jobStatus('JOB_STATE_CREATED'),
+          polls: [_jobStatus('JOB_STATE_COMPLETED', blob: _blobJson)],
+        );
+
+        core.Blob? blob;
+        Object? error;
+        service
+            .uploadVideoAndAwait(
+              bytes: _bytes,
+              pollInterval: const Duration(seconds: 3),
+              onProgress: (_) {
+                calls++;
+
+                throw StateError('the UI blew up');
+              },
+            )
+            .then<void>(
+              (value) {
+                blob = value;
+              },
+              onError: (Object e) {
+                error = e;
+              },
+            );
+
+        async.elapse(const Duration(seconds: 30));
+
+        expect(calls, 2);
+        expect(error, isNull);
+        expect(blob, isNotNull);
+        expect(blob!.ref.link, 'bafyreivideoblob');
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Problem

Uploading a video through `app.bsky.video.*` is a fixed ceremony every client reimplements: call `uploadVideo`, poll `getJobStatus` until the job terminates, tell success from failure, pull out the blob, and bound the whole thing so a stuck job does not hang forever. The loop is identical everywhere and easy to get subtly wrong.

## Change

```dart
final blob = await bluesky.video.uploadVideoAndAwait(
  bytes: bytes,
  pollInterval: const Duration(seconds: 3),
  timeout: const Duration(minutes: 5),
  onProgress: (status) { ... },
);
```

plus a sealed `VideoUploadException` with `VideoJobFailedException`, `VideoJobMissingBlobException` and `VideoUploadTimeoutException`. Sealed so a caller can `switch` exhaustively and be told by the compiler when a mode is added.

A job that reports completion **without a blob** is its own type rather than folded into the failure case: `status.error` / `status.message` are typically empty there, so a shared type would leave a caller with nothing to show.

## Terminal states come from the lexicon, not from guesswork

`lexicons/app/bsky/video/defs.json` declares `jobStatus.state` with `knownValues: ["JOB_STATE_COMPLETED", "JOB_STATE_FAILED"]` and the description *"All values not listed as a known value indicate that the job is in process."* So the terminal set is exactly those two and an unrecognized state keeps polling — the lexicon's stated contract.

The check is an exhaustive switch over the generated union, so a regenerated lexicon adding a third known value **breaks the build** rather than silently falling into "still processing". `timeout` is the backstop for an unknown state that never terminates.

## Timeout actually stops the polling

`Future.timeout` cannot cancel the loop it wraps, so an `expired` flag is checked after each wait and the loop stops instead of polling a dead job forever. There is a test for it.

What the timeout cannot do is documented rather than left as a trap: it releases the caller without stopping an upload request already in flight, and the server-side job keeps running — which is why the exception carries the last status, so its `jobId` can be handed to `getJobStatus` later.

A throwing `onProgress` is caught and discarded: a broken progress indicator must not fail an upload the server accepted. Also documented, along with the fact that an `async` callback is not awaited.

## Tests

7 tests, all under `fake_async` — a five-minute timeout is asserted in microseconds, nothing sleeps. Covers completion after several polls through in-process states, an already-terminal upload, terminal failure, completion with no blob, the timeout path, and a throwing callback.

`pollInterval` is pinned as behaviour, not just passed through: nothing polls at 2.999s, one poll at exactly 3s, still one at 5.999s, two at 6s — so it waits rather than spins.

Mutation-checked: removing the `expired` guard, treating a null blob as "still processing", or dropping the `onProgress` try/catch each fail exactly one test.

## One pubspec line

`fake_async` is added to `bluesky`'s **`dev_dependencies`** — it was already resolving transitively through `test`, so `pubspec.lock` is unchanged; this only declares what was there. `version:` is untouched and no runtime dependency changes.

## Verification

`bluesky` 908 passed, `dart analyze` clean, `dart format` no diff.

## Note on versioning

No `CHANGELOG.md` and no `version:` change. Versions for this batch are assigned in a single release PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)