### PR TITLE
feat(bluesky_text): add isLinkFacade and toDisplayHost

### DIFF
--- a/packages/bluesky_text/README.md
+++ b/packages/bluesky_text/README.md
@@ -33,6 +33,7 @@ Have you ever had trouble parsing mentions or links in the text you post when us
 - ✅ Supports **Automatic Conversion** to **Facet**
 - ✅ **100% Compatible with [bluesky](https://atprotodart.com/docs/packages/bluesky)**
 - ✅ Supports **Unicode Grapheme Clusters**
+- ✅ Flags **Link Facades**, where display text and link host disagree
 - ✅ Supports **Safe Text Splitting**
 - ✅ **Works in All Languages**
 - ✅ Supports **Markdown Style Links**
@@ -92,3 +93,4 @@ See **[example](https://github.com/myConsciousness/atproto.dart/blob/main/packag
 - **[Unicode Grapheme Clusters](https://atprotodart.com/docs/packages/bluesky_text#unicode-grapheme-clusters)**
 - **[Use with `bluesky`](https://atprotodart.com/docs/packages/bluesky_text#use-with-bluesky)**
 - **[Split Text](https://atprotodart.com/docs/packages/bluesky_text#split-text)**
+- **[Warn About Link Facades](https://atprotodart.com/docs/packages/bluesky_text#warn-about-link-facades)**

--- a/packages/bluesky_text/lib/bluesky_text.dart
+++ b/packages/bluesky_text/lib/bluesky_text.dart
@@ -9,6 +9,8 @@ export 'package:bluesky_text/src/entities/entities.dart';
 export 'package:bluesky_text/src/entities/entity.dart';
 export 'package:bluesky_text/src/facet.dart';
 export 'package:bluesky_text/src/facet_segmenter.dart' show renderFacets;
+export 'package:bluesky_text/src/link_facade.dart'
+    show isLinkFacade, toDisplayHost;
 export 'package:bluesky_text/src/text_length_overflow.dart';
 export 'package:bluesky_text/src/text_segment.dart';
 export 'package:bluesky_text/src/unicode_string.dart'

--- a/packages/bluesky_text/lib/src/link_facade.dart
+++ b/packages/bluesky_text/lib/src/link_facade.dart
@@ -1,0 +1,269 @@
+// Copyright (c) 2023-2025, Shinya Kato.
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// Project imports:
+import 'punycode.dart';
+import 'regex/valid_domain.dart';
+import 'utils.dart';
+
+/// Matches an explicit `http://` or `https://` scheme at the start of a
+/// display text. Only these two schemes are recognized, because they are the
+/// only ones this package ever links.
+final _schemeRegex = RegExp(r'^https?:\/\/', caseSensitive: false);
+
+/// The whole string must be a domain this package would linkify on its own.
+final _domainRegex = RegExp('^$validDomain\$', caseSensitive: false);
+
+/// The first character that ends the authority part of a URL.
+final _authorityEndRegex = RegExp(r'[/?#]');
+
+final _digitsRegex = RegExp(r'^[0-9]+$');
+
+/// Zero-width and directional formatting characters. They are invisible, so
+/// they change nothing about how a display text reads to a human, but they
+/// would break the domain match and let a facade slip through unflagged.
+final _invisibleRegex = RegExp(
+  r'[\u00AD\u200B-\u200F\u202A-\u202E\u2060-\u2064\uFEFF]',
+);
+
+const _wwwPrefix = 'www.';
+
+/// Returns true when [displayText] reads as a URL or a host that does not
+/// match the host of [uri] — the classic link facade, where a post renders
+/// `bsky.app` as the visible text while the link points somewhere else.
+///
+/// Only hosts are compared. The path, query, fragment, port and userinfo of
+/// either side are ignored: a display text of `bsky.app/profile/alice` for a
+/// link to `https://bsky.app/profile/alice?ref=x` is an ordinary shortened
+/// label, not a facade, and flagging it would train users to dismiss the
+/// warning.
+///
+/// ## When a display text counts as a URL
+///
+/// Text that is plainly not a URL is never flagged, no matter where the link
+/// goes. `click here`, `my blog` and `read the docs` all return false, because
+/// a warning that fires on ordinary link text is worse than no warning at all.
+/// [displayText] is treated as a URL in exactly two cases:
+///
+/// 1. It starts with an explicit `http://` or `https://` scheme. The scheme
+///    alone settles the question, so the host after it may be anything
+///    non-empty — `localhost`, an IP literal, an intranet name.
+/// 2. It has no scheme, and the part before the first `/`, `?` or `#` is a
+///    domain that this package would linkify on its own (`validDomain`: at
+///    least two labels ending in a known gTLD, ccTLD or punycode label).
+///
+/// The second rule deliberately reuses the package's own link detection, so
+/// this function flags a bare-host display text if and only if `BlueskyText`
+/// would have turned that same text into a link. `Node.js`, `main.dart` and
+/// `e.g.` are not domains under that rule and are never flagged. The flip side
+/// is that a filename whose extension happens to be a TLD (`report.zip`,
+/// `run.sh`) does read as a host — to this function and to every other link
+/// detector on the network alike.
+///
+/// A display text with no scheme containing `@` before the path is read as an
+/// email address and is never flagged, matching the linkifier, which produces
+/// no facet for an email. With an explicit scheme the `@` is userinfo, and a
+/// userinfo that itself reads as a domain is the host a reader believes they
+/// are seeing: `https://bsky.app@evil.example.com` is compared as `bsky.app`,
+/// so pointing it at `evil.example.com` is flagged even though that host is
+/// the one the URL really resolves to. A userinfo that is an ordinary
+/// user name (`https://alice@example.com`) is ignored and the real host is
+/// compared.
+///
+/// ## When two hosts match
+///
+/// Both hosts are normalized before comparison: percent-decoded (Dart
+/// percent-encodes non-ASCII in [Uri.host]), lower-cased, stripped of a
+/// trailing root dot and of a leading `www.`, and punycode-decoded label by
+/// label. They then match when they are equal, or when one is a subdomain of
+/// the other — `bsky.app` displayed for a link to `staging.bsky.app` is not
+/// flagged, and neither is the reverse, where the real host is fully visible
+/// at the end of the display text. A suffix relation only counts between two
+/// multi-label hosts, so a single-label target can never swallow a displayed
+/// domain.
+///
+/// The comparison is host-to-host, never registrable-domain-to-registrable
+/// domain: there is no Public Suffix List here, and guessing one would call
+/// `foo.github.io` and `bar.github.io` the same site when they belong to
+/// different people. Two hosts under a shared public suffix are therefore
+/// reported as a mismatch, which is the safe direction.
+///
+/// ## What this does not do
+///
+/// This function compares hosts; it does not judge them. A homograph — a host
+/// spelled with Cyrillic characters that render like Latin ones — is a
+/// different problem, and this function makes no claim about it. Displaying
+/// `apple.com` while linking to the Cyrillic look-alike is flagged, because
+/// the two hosts genuinely differ, but a post that displays and links to the
+/// same look-alike host is not flagged, and never will be by a host
+/// comparison. Detecting confusable scripts needs Unicode confusable data that
+/// this package does not carry. [toDisplayHost] is provided so a warning can
+/// at least show the decoded host and let the reader see it.
+///
+/// A [uri] with no host — `mailto:`, `at://`, a relative reference — is not
+/// flagged either, since there is no host to compare. A [uri] that is a bare
+/// domain with no scheme is read as `https://`, the same prefix this package
+/// applies when it builds a facet out of a bare-domain link.
+bool isLinkFacade({required final String displayText, required final Uri uri}) {
+  final displayHost = _resolveDisplayHost(displayText);
+  if (displayHost == null) return false;
+
+  final targetHost = _resolveTargetHost(uri);
+  if (targetHost == null) return false;
+
+  return !_isSameHost(displayHost, targetHost);
+}
+
+/// Returns [host] in the form to show a human: any punycode (`xn--`) label
+/// decoded to the Unicode it stands for, percent escapes resolved, ASCII
+/// lower-cased and a trailing root dot dropped.
+///
+/// `xn--bcher-kva.de` becomes `bücher.de`. A host with no punycode label comes
+/// back unchanged apart from that normalization, and a label that fails to
+/// decode is left exactly as it was — a host that cannot be decoded still has
+/// to be shown to someone. This never throws.
+///
+/// This is a display convenience, not IDNA processing: it performs no
+/// validation, no normalization of the decoded characters, and no confusable
+/// detection. The decoded form is what the host *says*, which is precisely the
+/// thing worth showing next to a link warning; whether what it says is
+/// trustworthy is the caller's judgement.
+String toDisplayHost(final String host) => _normalizeHost(host);
+
+/// Extracts the comparable host from [displayText], or `null` when the text
+/// does not read as a URL at all.
+String? _resolveDisplayHost(final String displayText) {
+  final text = displayText.replaceAll(_invisibleRegex, '').trim();
+  if (text.isEmpty) return null;
+
+  final scheme = _schemeRegex.firstMatch(text);
+  final hasScheme = scheme != null;
+
+  var authority = hasScheme ? text.substring(scheme.end) : text;
+
+  final authorityEnd = authority.indexOf(_authorityEndRegex);
+  if (authorityEnd >= 0) {
+    authority = authority.substring(0, authorityEnd);
+  }
+  if (authority.isEmpty) return null;
+
+  final userInfoEnd = authority.lastIndexOf('@');
+  if (userInfoEnd >= 0) {
+    //* Without a scheme this is an email address, which this package never
+    //* linkifies, so it is not a URL-looking display text.
+    if (!hasScheme) return null;
+
+    //* `https://bsky.app@evil.example.com` is a URL whose host is
+    //* `evil.example.com`, but a reader sees a host right after the scheme.
+    //* When the userinfo itself reads as a domain it is the host the display
+    //* text claims, so it is the one that has to match the link.
+    final decoy = _normalizeHost(
+      authority.substring(0, userInfoEnd).split(':').first,
+    );
+    if (_domainRegex.hasMatch(decoy)) return _stripWww(decoy);
+
+    authority = authority.substring(userInfoEnd + 1);
+  }
+
+  final host = _normalizeHost(_stripPort(authority));
+  if (host.isEmpty) return null;
+
+  //* A bare host has to look like a domain the linkifier would recognize; an
+  //* explicit scheme already settles that the text reads as a URL.
+  if (!hasScheme && !_domainRegex.hasMatch(host)) return null;
+
+  return _stripWww(host);
+}
+
+/// Extracts the comparable host from [uri], or `null` when it has none.
+String? _resolveTargetHost(final Uri uri) {
+  var resolved = uri;
+
+  if (!uri.hasScheme && uri.host.isEmpty) {
+    //* A bare-domain link such as `bsky.app` parses as a path-only URI. The
+    //* package posts those with an `https://` prefix, so read them that way.
+    try {
+      resolved = Uri.parse(getPrefixedUri(uri.toString()));
+    } on FormatException {
+      return null;
+    }
+  }
+
+  final host = _normalizeHost(resolved.host);
+
+  return host.isEmpty ? null : _stripWww(host);
+}
+
+/// Normalizes [host] for comparison and for display: percent escapes resolved,
+/// lower-cased, trailing root dots dropped and punycode labels decoded.
+String _normalizeHost(final String host) {
+  var value = host.trim();
+  if (value.isEmpty) return '';
+
+  value = _percentDecode(value).toLowerCase();
+
+  while (value.endsWith('.')) {
+    value = value.substring(0, value.length - 1);
+  }
+
+  if (value.isEmpty) return '';
+  if (!value.contains(punycodePrefix)) return value;
+
+  return value
+      .split('.')
+      .map((label) => decodePunycodeLabel(label) ?? label)
+      .join('.');
+}
+
+/// Returns [value] with its percent escapes resolved, or [value] itself when
+/// the escapes are malformed. [Uri.host] percent-encodes every non-ASCII byte,
+/// so an internationalized host arrives here as `b%C3%BCcher.de`.
+String _percentDecode(final String value) {
+  if (!value.contains('%')) return value;
+
+  try {
+    return Uri.decodeComponent(value);
+  } on ArgumentError {
+    return value;
+  } on FormatException {
+    return value;
+  }
+}
+
+/// Strips the port from [authority], including the brackets of an IPv6
+/// literal, so the result lines up with what [Uri.host] reports.
+String _stripPort(final String authority) {
+  if (authority.startsWith('[')) {
+    final end = authority.indexOf(']');
+
+    return end < 0 ? authority : authority.substring(1, end);
+  }
+
+  final portStart = authority.lastIndexOf(':');
+  if (portStart < 0) return authority;
+
+  final port = authority.substring(portStart + 1);
+  if (port.isNotEmpty && !_digitsRegex.hasMatch(port)) return authority;
+
+  return authority.substring(0, portStart);
+}
+
+/// Drops a leading `www.`, which readers and browsers alike treat as the same
+/// site.
+String _stripWww(final String host) =>
+    host.startsWith(_wwwPrefix) && host.length > _wwwPrefix.length
+    ? host.substring(_wwwPrefix.length)
+    : host;
+
+/// Returns true when [a] and [b] are the same host, or one is a subdomain of
+/// the other.
+bool _isSameHost(final String a, final String b) {
+  if (a == b) return true;
+
+  //* A single-label host is never treated as the parent of a domain; `app`
+  //* must not match `bsky.app`.
+  if (!a.contains('.') || !b.contains('.')) return false;
+
+  return a.endsWith('.$b') || b.endsWith('.$a');
+}

--- a/packages/bluesky_text/lib/src/punycode.dart
+++ b/packages/bluesky_text/lib/src/punycode.dart
@@ -1,0 +1,156 @@
+// Copyright (c) 2023-2025, Shinya Kato.
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// The ACE (ASCII Compatible Encoding) prefix that marks a punycode-encoded
+/// domain label, as defined by IDNA.
+const punycodePrefix = 'xn--';
+
+//* Bootstring parameters for punycode, RFC 3492 section 5.
+const _base = 36;
+const _tMin = 1;
+const _tMax = 26;
+const _skew = 38;
+const _damp = 700;
+const _initialBias = 72;
+const _initialN = 128;
+const _delimiter = '-';
+
+//* The RFC works in 32-bit arithmetic; Dart ints are 64-bit, so the bound has
+//* to be enforced explicitly instead of relying on wrap-around.
+const _maxInt = 0x7FFFFFFF;
+
+/// Decodes a single punycode-encoded domain [label] — a label carrying the
+/// [punycodePrefix], such as `xn--bcher-kva` — into its Unicode form
+/// (`bücher`), following the decoding procedure of RFC 3492.
+///
+/// Returns `null` when [label] does not carry the prefix, when the encoded
+/// part is malformed (a non-basic character in the literal part, an invalid
+/// digit, an arithmetic overflow, or a decoded value that is not a Unicode
+/// scalar value), or when the decoded label would contain a control or
+/// invisible formatting character. Callers are expected to fall back to the
+/// original label in that case, since a host that fails to decode is still a
+/// host that has to be shown to someone.
+String? decodePunycodeLabel(final String label) {
+  if (label.length <= punycodePrefix.length) return null;
+  if (!label.toLowerCase().startsWith(punycodePrefix)) return null;
+
+  final input = label.substring(punycodePrefix.length);
+
+  //* Everything before the last delimiter is copied verbatim; the encoded
+  //* insertions follow it. A missing delimiter means the whole input is
+  //* encoded and the literal part is empty.
+  final lastDelimiter = input.lastIndexOf(_delimiter);
+  final basicLength = lastDelimiter < 0 ? 0 : lastDelimiter;
+
+  final output = <int>[];
+  for (int i = 0; i < basicLength; i++) {
+    final codeUnit = input.codeUnitAt(i);
+    if (codeUnit >= 0x80) return null;
+    if (!_isDisplayable(codeUnit)) return null;
+
+    output.add(codeUnit);
+  }
+
+  int index = basicLength > 0 ? basicLength + 1 : 0;
+  int n = _initialN;
+  int i = 0;
+  int bias = _initialBias;
+
+  while (index < input.length) {
+    final oldI = i;
+    int weight = 1;
+
+    for (int k = _base; ; k += _base) {
+      if (index >= input.length) return null;
+
+      final digit = _decodeDigit(input.codeUnitAt(index++));
+      if (digit >= _base) return null;
+      if (digit > (_maxInt - i) ~/ weight) return null;
+
+      i += digit * weight;
+
+      final int threshold;
+      if (k <= bias) {
+        threshold = _tMin;
+      } else if (k >= bias + _tMax) {
+        threshold = _tMax;
+      } else {
+        threshold = k - bias;
+      }
+
+      if (digit < threshold) break;
+
+      final baseMinusThreshold = _base - threshold;
+      if (weight > _maxInt ~/ baseMinusThreshold) return null;
+
+      weight *= baseMinusThreshold;
+    }
+
+    final outLength = output.length + 1;
+    bias = _adaptBias(i - oldI, outLength, oldI == 0);
+
+    if (i ~/ outLength > _maxInt - n) return null;
+
+    n += i ~/ outLength;
+    i %= outLength;
+
+    if (!_isScalarValue(n) || !_isDisplayable(n)) return null;
+
+    output.insert(i++, n);
+  }
+
+  if (output.isEmpty) return null;
+
+  return String.fromCharCodes(output);
+}
+
+/// Returns the numeric value of the basic code point [codeUnit], or [_base]
+/// when it is not a valid punycode digit.
+int _decodeDigit(final int codeUnit) {
+  if (codeUnit >= 0x30 && codeUnit <= 0x39) return codeUnit - 0x30 + 26; // 0-9
+  if (codeUnit >= 0x41 && codeUnit <= 0x5A) return codeUnit - 0x41; // A-Z
+  if (codeUnit >= 0x61 && codeUnit <= 0x7A) return codeUnit - 0x61; // a-z
+
+  return _base;
+}
+
+/// The bias adaptation of RFC 3492 section 6.1.
+int _adaptBias(int delta, final int numPoints, final bool firstTime) {
+  delta = firstTime ? delta ~/ _damp : delta >> 1;
+  delta += delta ~/ numPoints;
+
+  int k = 0;
+  while (delta > ((_base - _tMin) * _tMax) ~/ 2) {
+    delta = delta ~/ (_base - _tMin);
+    k += _base;
+  }
+
+  return k + (((_base - _tMin + 1) * delta) ~/ (delta + _skew));
+}
+
+/// Returns true when [value] is a Unicode scalar value, i.e. within range and
+/// not a surrogate — the only values [String.fromCharCodes] can represent
+/// faithfully.
+bool _isScalarValue(final int value) =>
+    value <= 0x10FFFF && (value < 0xD800 || value > 0xDFFF);
+
+/// Returns false for code points that must never reach a rendered host: the
+/// C0/C1 control characters, and the invisible formatting characters that
+/// could hide or reorder part of the host in whatever surface shows it.
+///
+/// A label decoding to one of these is reported as undecodable, so the caller
+/// keeps the literal `xn--` form — visible, inert and honest — instead of
+/// rendering something the reader cannot see. Emoji sequences joined with
+/// U+200D are refused for the same reason, and stay in their encoded form.
+bool _isDisplayable(final int value) {
+  if (value < 0x20) return false; // C0 controls
+  if (value >= 0x7F && value <= 0x9F) return false; // DEL and C1 controls
+  if (value == 0x00AD) return false; // soft hyphen
+  if (value >= 0x200B && value <= 0x200F) return false; // zero width, bidi
+  if (value >= 0x202A && value <= 0x202E) return false; // bidi overrides
+  if (value >= 0x2060 && value <= 0x2064) return false; // word joiner
+  if (value == 0xFEFF) return false; // byte order mark
+
+  return true;
+}

--- a/packages/bluesky_text/test/src/link_facade_test.dart
+++ b/packages/bluesky_text/test/src/link_facade_test.dart
@@ -1,0 +1,289 @@
+// Copyright (c) 2023-2025, Shinya Kato.
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// Package imports:
+import 'package:test/test.dart';
+
+// Project imports:
+import 'package:bluesky_text/bluesky_text.dart';
+
+/// Asserts that [displayText] over [uri] is *not* reported as a facade.
+///
+/// These are the expectations that matter most: a check that fires on ordinary
+/// link text teaches people to dismiss it.
+void expectHonest(final String displayText, final String uri) => expect(
+  isLinkFacade(displayText: displayText, uri: Uri.parse(uri)),
+  isFalse,
+  reason: '"$displayText" -> $uri must not be flagged',
+);
+
+/// Asserts that [displayText] over [uri] is reported as a facade.
+void expectFacade(final String displayText, final String uri) => expect(
+  isLinkFacade(displayText: displayText, uri: Uri.parse(uri)),
+  isTrue,
+  reason: '"$displayText" -> $uri must be flagged',
+);
+
+void main() {
+  group('isLinkFacade flags', () {
+    test('a bare host displayed over a link to another host', () {
+      expectFacade('bsky.app', 'https://evil.example.com/login');
+      expectFacade('bsky.app', 'https://bsky.app.evil.example.com/login');
+      expectFacade('example.com', 'https://example.org');
+    });
+
+    test('a full URL displayed over a link to another host', () {
+      expectFacade(
+        'https://bsky.app/profile/alice',
+        'https://evil.example.com',
+      );
+      expectFacade('http://bsky.app', 'https://evil.example.com');
+      expectFacade(
+        'https://bsky.app/profile/alice',
+        'https://evil.example.com/profile/alice',
+      );
+    });
+
+    test('a host displayed over a link to its punycode look-alike', () {
+      //* `xn--80ak6aa92e.com` decodes to the Cyrillic `аррӏе.com`, which is a
+      //* different host from `apple.com` however much it looks like it.
+      expectFacade('apple.com', 'https://xn--80ak6aa92e.com');
+      expectFacade('apple.com', 'https://аррӏе.com');
+    });
+
+    test('two hosts that merely share a public suffix', () {
+      //* There is no Public Suffix List here, and pretending the registrable
+      //* domain is "the last two labels" would call these the same site. They
+      //* belong to different people.
+      expectFacade('foo.github.io', 'https://bar.github.io');
+      expectFacade('alice.bsky.social', 'https://mallory.bsky.social');
+    });
+
+    test('a host hidden behind userinfo', () {
+      //* The reader sees a host right after the scheme; the URL resolves to
+      //* the one after the `@`.
+      expectFacade(
+        'https://bsky.app@evil.example.com',
+        'https://evil.example.com',
+      );
+      expectFacade(
+        'https://bsky.app:password@evil.example.com',
+        'https://evil.example.com',
+      );
+    });
+
+    test('a display text disguised with invisible characters', () {
+      //* A zero-width space and a bidi mark change nothing about how the text
+      //* reads, so they must not buy an attacker a pass.
+      expectFacade('bsky\u200B.app', 'https://evil.example.com');
+      expectFacade('bsky.app\u200E', 'https://evil.example.com');
+      expectFacade('\u202Absky.app\u202C', 'https://evil.example.com');
+    });
+
+    test('regardless of the case or the surrounding whitespace', () {
+      expectFacade('BSKY.APP', 'https://evil.example.com');
+      expectFacade('  bsky.app  ', 'https://evil.example.com');
+      expectFacade('Bsky.App', 'https://EVIL.example.com');
+    });
+  });
+
+  group('isLinkFacade does not flag', () {
+    test('display text that is plainly not a URL', () {
+      expectHonest('click here', 'https://evil.example.com');
+      expectHonest('my blog', 'https://evil.example.com');
+      expectHonest('read the docs', 'https://evil.example.com');
+      expectHonest('こちら', 'https://evil.example.com');
+      expectHonest('👀', 'https://evil.example.com');
+      expectHonest('1', 'https://evil.example.com');
+      expectHonest('...', 'https://evil.example.com');
+    });
+
+    test('prose that merely contains a dot', () {
+      expectHonest('e.g.', 'https://evil.example.com');
+      expectHonest('i.e.', 'https://evil.example.com');
+      expectHonest('Node.js', 'https://evil.example.com');
+      expectHonest('main.dart', 'https://evil.example.com');
+      expectHonest('index.html', 'https://evil.example.com');
+      expectHonest('v1.2.3', 'https://evil.example.com');
+      expectHonest('1.2.3.4', 'https://evil.example.com');
+      expectHonest('Dr. Smith', 'https://evil.example.com');
+      expectHonest('the docs. read them', 'https://evil.example.com');
+    });
+
+    test('an email address, which this package never linkifies', () {
+      expectHonest('support@example.com', 'https://evil.example.com');
+      expectHonest('alice.smith@example.com', 'https://evil.example.com');
+    });
+
+    test('an exact host match', () {
+      expectHonest('bsky.app', 'https://bsky.app');
+      expectHonest('https://bsky.app', 'https://bsky.app');
+      expectHonest('BSKY.APP', 'https://bsky.app');
+      expectHonest('bsky.app', 'https://BSKY.APP');
+    });
+
+    test('a different path, query, fragment or port on the same host', () {
+      //* Only hosts are compared; a shortened or prettified path is normal.
+      expectHonest('bsky.app', 'https://bsky.app/profile/alice?ref=x#top');
+      expectHonest('bsky.app/profile/alice', 'https://bsky.app/profile/bob');
+      expectHonest('bsky.app:443', 'https://bsky.app');
+      expectHonest('bsky.app', 'https://bsky.app:8443/x');
+      expectHonest('http://bsky.app', 'https://bsky.app');
+    });
+
+    test('a trailing root dot on either side', () {
+      expectHonest('bsky.app.', 'https://bsky.app');
+      expectHonest('bsky.app', 'https://bsky.app.');
+      expectHonest('bsky.app.', 'https://bsky.app.');
+    });
+
+    test('a leading www. on either side', () {
+      expectHonest('www.bsky.app', 'https://bsky.app');
+      expectHonest('bsky.app', 'https://www.bsky.app');
+      expectHonest('www.bsky.app', 'https://www.bsky.app');
+      expectHonest('WWW.BSKY.APP', 'https://bsky.app');
+    });
+
+    test('a subdomain of the displayed host', () {
+      //* Whoever owns `bsky.app` owns everything under it, so a link into a
+      //* subdomain stays inside the authority the display text names.
+      expectHonest('bsky.app', 'https://staging.bsky.app');
+      expectHonest('bsky.app', 'https://a.b.c.bsky.app/x');
+      expectHonest('https://bsky.app', 'https://staging.bsky.app');
+    });
+
+    test('a host that the displayed subdomain sits under', () {
+      //* The reverse direction: the real host is fully visible at the end of
+      //* the display text, so nothing is being hidden from the reader.
+      expectHonest('staging.bsky.app', 'https://bsky.app');
+      expectHonest('docs.flutter.dev', 'https://flutter.dev');
+    });
+
+    test('punycode and its decoded form as the same host', () {
+      expectHonest('bücher.de', 'https://xn--bcher-kva.de');
+      expectHonest('xn--bcher-kva.de', 'https://bücher.de');
+      expectHonest('bücher.de', 'https://bücher.de');
+      expectHonest('xn--bcher-kva.de', 'https://xn--bcher-kva.de');
+      expectHonest('中国.cn', 'https://xn--fiqs8s.cn');
+      expectHonest('BÜCHER.de', 'https://xn--bcher-kva.de');
+      //* Punycode equivalence composes with the subdomain rule.
+      expectHonest('bücher.de', 'https://shop.xn--bcher-kva.de');
+    });
+
+    test('a link with no host to compare', () {
+      expectHonest('bsky.app', 'mailto:alice@example.com');
+      expectHonest('bsky.app', 'tel:+81-3-0000-0000');
+      expectHonest('bsky.app', '/relative/path');
+    });
+
+    test('a schemeless link, which is read as https', () {
+      expectHonest('bsky.app', 'bsky.app');
+      expectHonest('bsky.app', 'bsky.app/profile/alice');
+      expectHonest('www.bsky.app', 'bsky.app');
+    });
+
+    test('userinfo that is an ordinary user name', () {
+      expectHonest('https://alice@example.com', 'https://example.com');
+      expectHonest('https://alice@example.com', 'https://sub.example.com');
+    });
+
+    test('malformed or empty input', () {
+      expectHonest('', 'https://evil.example.com');
+      expectHonest('   ', 'https://evil.example.com');
+      expectHonest('\u200B\u200B', 'https://evil.example.com');
+      expectHonest('https://', 'https://evil.example.com');
+      expectHonest('http:///', 'https://evil.example.com');
+      expectHonest('://bsky.app', 'https://evil.example.com');
+      expectHonest('bsky.app', 'https://');
+      expectHonest('bsky.app', '');
+      expectHonest('%%%.app', 'https://evil.example.com');
+      expectHonest('...app', 'https://evil.example.com');
+      expectHonest('bsky.app)', 'https://evil.example.com');
+      expectHonest('bsky.app,', 'https://evil.example.com');
+    });
+
+    test('a display text whose punycode is undecodable', () {
+      //* An `xn--` label that decodes to nothing usable stays as it is, so it
+      //* still compares equal to the same literal label on the other side.
+      expectHonest('xn--zzzzzz.de', 'https://xn--zzzzzz.de');
+    });
+  });
+
+  group('isLinkFacade edge behaviour', () {
+    test('a scheme makes any non-empty host comparable', () {
+      //* The scheme settles that the text reads as a URL, so a host that is
+      //* not a public domain still counts.
+      expectFacade('http://localhost:3000', 'https://evil.example.com');
+      expectHonest('http://localhost:3000', 'http://localhost:8080');
+      expectFacade('https://192.168.0.1', 'https://evil.example.com');
+      expectHonest('https://192.168.0.1', 'https://192.168.0.1/admin');
+    });
+
+    test(
+      'a bare host must look like a domain, so a bare IP does not count',
+      () {
+        //* `1.2.3.4` is as likely to be a version number as an address, and a
+        //* version number in link text is not a phishing signal.
+        expectHonest('192.168.0.1', 'https://evil.example.com');
+      },
+    );
+
+    test('a filename whose extension is a TLD reads as a host', () {
+      //* A known limitation, shared with every other link detector: `.zip` and
+      //* `.sh` really are top-level domains.
+      expectFacade('report.zip', 'https://drive.example.com/report.zip');
+      expectFacade('deploy.sh', 'https://gist.example.com/deploy.sh');
+    });
+
+    test('a single label host never matches a domain by suffix', () {
+      //* `app` must not be treated as the parent of `bsky.app`.
+      expectFacade('bsky.app', 'https://app');
+      expectFacade('https://app', 'https://bsky.app');
+    });
+  });
+
+  group('toDisplayHost', () {
+    test('decodes punycode labels', () {
+      expect(toDisplayHost('xn--bcher-kva.de'), 'bücher.de');
+      expect(toDisplayHost('xn--fiqs8s.cn'), '中国.cn');
+      expect(toDisplayHost('shop.xn--bcher-kva.de'), 'shop.bücher.de');
+      expect(toDisplayHost('xn--ls8h.la'), '💩.la');
+    });
+
+    test('decodes the host a look-alike is really made of', () {
+      //* The point of the helper: a warning can show what the host says.
+      expect(toDisplayHost('xn--80ak6aa92e.com'), 'аррӏе.com');
+    });
+
+    test('leaves a host with no punycode label alone', () {
+      expect(toDisplayHost('bsky.app'), 'bsky.app');
+      expect(toDisplayHost('bücher.de'), 'bücher.de');
+      expect(toDisplayHost(''), '');
+    });
+
+    test('normalizes case, percent escapes and the trailing root dot', () {
+      expect(toDisplayHost('XN--BCHER-KVA.DE'), 'bücher.de');
+      expect(toDisplayHost('BSKY.APP'), 'bsky.app');
+      //* `Uri.host` percent-encodes every non-ASCII byte.
+      expect(toDisplayHost(Uri.parse('https://bücher.de').host), 'bücher.de');
+      expect(toDisplayHost('bsky.app.'), 'bsky.app');
+    });
+
+    test('keeps a label it cannot decode', () {
+      expect(toDisplayHost('xn--zzzzzz.de'), 'xn--zzzzzz.de');
+      expect(toDisplayHost('xn--.de'), 'xn--.de');
+      //* A well-formed encoding of an invisible character is refused too.
+      expect(toDisplayHost('xn--a.de'), 'xn--a.de');
+    });
+
+    test('never throws on malformed input', () {
+      expect(toDisplayHost('%%%.de'), '%%%.de');
+      //* An escape that cannot be resolved is kept as it is, lower-cased with
+      //* the rest of the host.
+      expect(toDisplayHost('%E0%A4%A.de'), '%e0%a4%a.de');
+      expect(toDisplayHost('   '), '');
+      expect(toDisplayHost('...'), '');
+    });
+  });
+}

--- a/packages/bluesky_text/test/src/punycode_test.dart
+++ b/packages/bluesky_text/test/src/punycode_test.dart
@@ -1,0 +1,76 @@
+// Copyright (c) 2023-2025, Shinya Kato.
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// Package imports:
+import 'package:test/test.dart';
+
+// Project imports:
+import 'package:bluesky_text/src/punycode.dart';
+
+void main() {
+  group('decodePunycodeLabel', () {
+    test('decodes the RFC 3492 sample labels', () {
+      //* Every expectation below was cross-checked against Python's
+      //* `str.decode('punycode')`, an independent implementation.
+      expect(decodePunycodeLabel('xn--maana-pta'), 'mañana');
+      expect(decodePunycodeLabel('xn--bcher-kva'), 'bücher');
+      expect(decodePunycodeLabel('xn--kda'), 'ó');
+      expect(decodePunycodeLabel('xn--fiqs8s'), '中国');
+      expect(decodePunycodeLabel('xn--zckzah'), 'テスト');
+      expect(decodePunycodeLabel('xn--ihqwcrb4cv8a8dqg056pqjye'), '他们为什么不说中文');
+      expect(
+        decodePunycodeLabel('xn--egbpdaj6bu4bxfgehfvwxn'),
+        'ليهمابتكلموشعربي؟',
+      );
+    });
+
+    test('decodes a label whose code points are outside the BMP', () {
+      expect(decodePunycodeLabel('xn--ls8h'), '💩');
+    });
+
+    test('decodes a label mixing basic and encoded code points', () {
+      //* The literal part before the last delimiter is copied verbatim.
+      expect(decodePunycodeLabel('xn--3-8sbde'), '3абв');
+    });
+
+    test('ignores the case of the prefix and the digits', () {
+      //* RFC 3492 treats the extended digits case-insensitively and copies the
+      //* literal part verbatim, so the case of the literal part survives. Both
+      //* callers in this package lower-case the host before decoding, so the
+      //* decoded form they show is always lower case.
+      expect(decodePunycodeLabel('xn--bcher-KVA'), 'bücher');
+      expect(decodePunycodeLabel('XN--BCHER-KVA'), 'BüCHER');
+      expect(decodePunycodeLabel('Xn--Bcher-Kva'), 'Bücher');
+    });
+
+    test('returns null for a label without the ACE prefix', () {
+      expect(decodePunycodeLabel('bsky'), isNull);
+      expect(decodePunycodeLabel('bücher'), isNull);
+      expect(decodePunycodeLabel(''), isNull);
+      expect(decodePunycodeLabel('xn-'), isNull);
+      expect(decodePunycodeLabel('xn--'), isNull);
+    });
+
+    test('returns null for malformed encodings', () {
+      //* Not a valid digit sequence.
+      expect(decodePunycodeLabel('xn--zzzzzz'), isNull);
+      //* Non-ASCII in the encoded part.
+      expect(decodePunycodeLabel('xn--bcher-kvá'), isNull);
+      //* Digits that overflow the RFC's 32-bit arithmetic.
+      expect(decodePunycodeLabel('xn--9999999999'), isNull);
+      //* An empty literal part followed by an unterminated digit sequence.
+      expect(decodePunycodeLabel('xn---x'), isNull);
+    });
+
+    test('refuses to decode into control or invisible characters', () {
+      //* `xn--a` is a well-formed encoding of U+0080, a C1 control. Handing an
+      //* invisible character back as "the real host" is worse than keeping the
+      //* encoded form.
+      expect(decodePunycodeLabel('xn--a'), isNull);
+      //* `xn--ab-p1t` encodes `a`, U+200E (a bidi mark) and `b`; the mark
+      //* could reorder the host in whatever renders it.
+      expect(decodePunycodeLabel('xn--ab-p1t'), isNull);
+    });
+  });
+}

--- a/website/docs/products/packages/bluesky_text.md
+++ b/website/docs/products/packages/bluesky_text.md
@@ -26,6 +26,7 @@ For complete Bluesky API integration, see **[bluesky](./bluesky.md)**.
 - ✅ Supports **Safe Text Splitting** against both post limits
 - ✅ Reports the **overflowing range** and a ready-to-render **segmentation**
 - ✅ Renders **server-provided facets** for display
+- ✅ Flags **link facades**, where display text and link host disagree
 - ✅ **Works in All Languages**
 - ✅ Supports **Markdown Style Links**
 - ✅ **Well Documented** and **Well Tested**
@@ -453,6 +454,33 @@ void main() {
 <!-- /snippet -->
 
 `renderFacets` returns the same `TextSegment` type as `segments`, but each styled segment carries a `feature` (the resolved DID, URI or tag) rather than a re-detected `entity`. `TextSegment.type` works for both paths, so one `TextSpan` builder can serve your composer and your timeline.
+
+### Warn about link facades
+
+A facet's display text and its link are independent, so a post can render `bsky.app` as the visible text while the link points somewhere else. `isLinkFacade` answers one question: does this display text read as a URL or host that does not match the host it links to?
+
+```dart
+final link = Uri.parse('https://evil.example.com/login');
+
+// The visible text names one host; the link points at another.
+print(isLinkFacade(displayText: 'bsky.app', uri: link)); // true
+
+// Display text that does not read as a URL is never flagged.
+print(isLinkFacade(displayText: 'click here', uri: link)); // false
+
+// Nor is a subdomain of the host the display text names.
+final staging = Uri.parse('https://staging.bsky.app');
+print(isLinkFacade(displayText: 'bsky.app', uri: staging)); // false
+
+// Shows what a punycode host actually says.
+print(toDisplayHost('xn--80ak6aa92e.com')); // аррӏе.com
+```
+
+Display text counts as a URL only when it carries an explicit `http`/`https` scheme or is a domain this package would linkify on its own, so ordinary link text such as `click here`, `Node.js` or `main.dart` is never flagged. Two hosts match when they are equal or one is a subdomain of the other, ignoring case, `www.`, a trailing root dot, the port and the path — and an `xn--` host is the same host as its decoded Unicode form. `toDisplayHost` decodes that form, so a warning can show the reader what the host says.
+
+:::caution
+This compares a display text against a link host, and nothing more. It does not detect homographs (a host spelled in Cyrillic that renders like Latin), redirects and link shorteners, or deceptive display text that is not a URL at all. It is a check for one specific shape, not a general phishing filter.
+:::
 
 ## Related Packages
 


### PR DESCRIPTION
## Problem

A facet's display text and its target URI are independent: a post can render `bsky.app` as the visible text while the link points somewhere else. That is an actively-used phishing shape, and every client wanting to warn about it reinvents the same check — deciding whether the text even looks like a URL, normalizing it, comparing hosts, handling punycode.

## Change

```dart
bool isLinkFacade({required String displayText, required Uri uri});
String toDisplayHost(String host);
```

## The rules, and why

**When does display text "look like a URL"?** Either an explicit `http`/`https` scheme, or — with no scheme — the part before the first `/`, `?`, `#` matches the package's own `validDomain` regex.

Reusing `validDomain` is the important decision: a bare host is flagged **iff `BlueskyText` would itself have linkified that same text**. The false-positive boundary is therefore a property of the package rather than a hand-rolled heuristic that drifts away from it. `click here`, `Node.js`, `e.g.`, `main.dart`, `v1.2.3`, `Dr. Smith` are all not URL-looking, and each is pinned by a test. **False positives matter more than false negatives here** — a check that fires on ordinary link text teaches users to dismiss the warning, which is worse than no warning.

**Host match**, after percent-decode → lowercase → strip trailing root dot → decode punycode → strip leading `www.`: equal, **or one is a subdomain of the other**. Whoever owns the displayed host owns everything beneath it, and in the reverse direction the real host is fully visible at the end of the display text. A single-label target can never swallow a multi-label one.

Explicitly **no Public Suffix List and no registrable-domain guessing**: "last two labels" would call `foo.github.io` and `bar.github.io` the same site. They are different owners, so shared-public-suffix pairs are reported as mismatches.

**Path, query, fragment and port are ignored entirely** — showing `bsky.app` for `https://bsky.app/profile/alice?ref=x` is ordinary shortening.

**Punycode**: `bücher.de` and `xn--bcher-kva.de` are the same host in either direction, and equivalence composes with the subdomain rule.

Two rules beyond a pure host comparison, called out because they judge the display text on its own:

- **Invisible characters** (zero-width, bidi, soft hyphen) are stripped before analysis, so `bsky<ZWSP>.app` cannot dodge the domain match.
- **Userinfo decoys**: `https://bsky.app@evil.example.com` pointing at `https://evil.example.com` is flagged even though the hosts technically agree, because a reader sees a host right after the scheme. An ordinary userinfo (`https://alice@example.com`) is ignored and the real host compared.

## What it explicitly does not do

Documented in the API and on the website, so nobody mistakes it for a general phishing filter:

- **Homographs.** A post that displays *and* links the same look-alike host is not flagged, and no host comparison ever will be — that needs Unicode confusable data this package does not carry. `toDisplayHost` exists so a warning can at least show the decoded host.
- Redirects and shorteners — nothing about where the URL ends up.
- Deceptive non-URL text (`Official Bluesky Login` → anywhere), by design.

## No new dependency

Nothing in the workspace ships punycode/IDNA (`valid_punycode.dart` is a validation pattern; `at_primitives` says outright that it does not validate punycode) and Dart's `Uri` does not decode it, so RFC 3492 decoding is implemented in-package with the RFC's overflow bounds enforced.

The decoder's test vectors are cross-checked against Python's independent `punycode` codec rather than pinned to its own output. One assertion I first wrote was wrong and the *test* was corrected, not the code: RFC 3492 copies the literal part verbatim, so `XN--BCHER-KVA` decodes to `BüCHER`. Both callers lowercase first.

## Tests

39 new (446 total). The false-positive side is the larger half: non-URL prose, emails, exact matches, case, whitespace, trailing root dots, `www.` on either side, subdomains both ways, punycode equivalence both ways, path/query/port differences, hostless and schemeless URIs, malformed input, undecodable `xn--` labels.

## Docs

Website gets a feature bullet and a "Warn about link facades" tip with a runnable example — the example was executed against the built package before being pasted. README gets a feature bullet and a tip link.

## Note on versioning

No `CHANGELOG.md` or `pubspec.yaml` touched. Versions for this batch are assigned in a single release PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)