### PR TITLE
fix(ci): push release tags one at a time so publish actually fires

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,8 +38,18 @@ on:
     tags:
       # melos tag format: `<package>-v<major>.<minor>.<patch>`.
       - "*-v[0-9]+.[0-9]+.[0-9]+"
-  # Allow manual runs. Dispatch MUST target a matching tag ref (choose the tag
-  # under "Use workflow from"), otherwise tag parsing below fails fast.
+  # Manual runs reach the publish step but CANNOT publish: pub.dev refuses
+  # OIDC from a dispatch, with "publishing is not allowed from
+  # 'workflow_dispath' events" (its typo, not ours). Verified on 2026-07-26
+  # against `atproto_core-v2.3.0` and `bluesky_text-v1.6.0`.
+  #
+  # So this is a dry run, not a safety valve: useful to confirm the tag parses
+  # and the package builds, never to ship. To actually release a tag whose
+  # push event was lost, delete the tag and push it again -- a real tag push
+  # is the only event pub.dev accepts.
+  #
+  # Dispatch MUST still target a matching tag ref (choose the tag under "Use
+  # workflow from"), otherwise tag parsing below fails fast.
   workflow_dispatch:
 
 # OIDC token minting requires `id-token: write`. `contents: read` is all the

--- a/.github/workflows/release_tags.yml
+++ b/.github/workflows/release_tags.yml
@@ -119,9 +119,35 @@ jobs:
             exit 0
           fi
 
-          # One atomic push: either every tag lands or none does, so a partial
-          # release cannot leave half the workspace published.
-          git push --atomic origin "${tags[@]}"
+          # One tag per push, deliberately NOT `git push --atomic` with the
+          # whole list.
+          #
+          # GitHub does not create a `push` event for every tag when several
+          # arrive in a single push -- the documented limit is three -- and
+          # `publish.yml` is triggered by exactly that event. A five-tag atomic
+          # push on 2026-07-26 landed all five tags and started zero publish
+          # runs, while a three-tag push earlier the same day started three.
+          # The atomicity was real; it just guaranteed that nothing shipped.
+          #
+          # Pushing one at a time trades that atomicity for tags that actually
+          # trigger a release. A failure mid-loop can now leave the workspace
+          # half-tagged, so the loop keeps going, reports every failure, and
+          # exits non-zero -- a rerun re-pushes only what is still missing,
+          # since an existing tag is skipped above.
+          failed=()
+          for tag in "${tags[@]}"; do
+            if git push origin "$tag"; then
+              echo "Pushed $tag."
+            else
+              echo "::error::Failed to push $tag."
+              failed+=("$tag")
+            fi
+          done
+
+          if [[ ${#failed[@]} -gt 0 ]]; then
+            echo "::error::${#failed[@]} tag(s) failed to push: ${failed[*]}"
+            exit 1
+          fi
 
           echo "::notice::Pushed ${#tags[@]} release tag(s): ${tags[*]}"
           {


### PR DESCRIPTION
## What happened

Today's release merged, `release_tags.yml` succeeded, all five tags landed on the remote — and **nothing published**. pub.dev still served the old versions.

## Why

`release_tags.yml` pushed every new tag in a single `git push --atomic`. GitHub does not create a `push` event for each tag when several arrive in one push (the documented limit is three), and `publish.yml` triggers on exactly that event.

Same workflow, same token, same day:

| time | tags in one push | publish runs started |
|---|---|---|
| 02:29 | 1 | **1** |
| 02:39 | 3 | **3** |
| 05:40 | **5** | **0** |

Releases had never exceeded three tags before, so the ceiling went unnoticed. The atomicity was real — either every tag landed or none did — and then nothing shipped. The safety measure defeated the trigger it existed to serve.

## Fix

Push one tag at a time.

That gives up atomicity, so the loop no longer stops at the first failure: it continues, reports each failed tag as an error annotation, and exits non-zero. A rerun re-pushes only what is still missing, since the existing-tag check above already skips what landed. A half-tagged workspace is recoverable; a fully-tagged workspace that publishes nothing is the failure mode we actually hit.

## Also: `workflow_dispatch` on `publish.yml` is not a safety valve

`publish.yml` advertised manual dispatch as the way to release a tag that was missed. It cannot be — pub.dev refuses OIDC publishing from a dispatch:

> The calling GitHub Action is not allowed to publish, because: publishing is not allowed from 'workflow_dispath' events

(pub.dev's typo, not ours.) Verified today against `atproto_core-v2.3.0` and `bluesky_text-v1.6.0`: both runs reached the upload step and were rejected there.

The comment now says what it really is — a dry run that confirms the tag parses and the package builds — and records that recovering a lost tag push means deleting the tag and pushing it again, since a real tag push is the only event pub.dev accepts.

## Verification

Both workflow files parse as YAML, and the new loop passes `bash -n`. The behaviour itself is only observable on a real release; the next one exercises it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)