### PR TITLE
chore(bluesky_text_flutter): bump bluesky_text to ^1.6.0

### DIFF
--- a/packages/bluesky_text_flutter/CHANGELOG.md
+++ b/packages/bluesky_text_flutter/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Note
 
+## v0.1.3
+
+- chore: bump `bluesky_text` to `^1.6.0` (now published).
+
 ## v0.1.2
 
 - docs: documented `BlueskyRichText`'s primary `onFeatureTap` callback (`FeatureTapCallback = void Function(FacetFeature feature)`) alongside the typed `onMentionTap`/`onLinkTap`/`onTagTap` conveniences, plus the `featureStyle`, `style`, `textAlign`, `maxLines`, and `overflow` styling parameters.

--- a/packages/bluesky_text_flutter/pubspec.yaml
+++ b/packages/bluesky_text_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: bluesky_text_flutter
 description: Flutter widgets for bluesky_text — a rich-text editing controller that highlights entities and the over-limit tail as you type, and a viewer for fetched posts.
-version: 0.1.2
+version: 0.1.3
 homepage: https://atprotodart.com
 repository: https://github.com/myConsciousness/atproto.dart/tree/main/packages/bluesky_text_flutter
 issue_tracker: https://github.com/myConsciousness/atproto.dart/issues
@@ -20,7 +20,7 @@ topics:
 dependencies:
   flutter:
     sdk: flutter
-  bluesky_text: ^1.5.2
+  bluesky_text: ^1.6.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
The follow-up `scripts/validate_dependencies.dart` describes for this package. It is in `_excludePackages` because it lives outside the Dart pub workspace and resolves from pub.dev, so it can only reference *published* workspace versions — the script's own comment says it "is bumped/republished after the workspace packages it depends on". `bluesky_text` 1.6.0 published today, so this is that step.

## This is chore-only, and worth deciding on deliberately

The package uses `BlueskyText.overflow` and `.segments`, and `BlueskyRichText` renders server-provided `PostFacet`s. None of that is touched by 1.6.0, whose changes were the wire-complete facet maps (`Entity.toFacet` and friends) and the new `isLinkFacade` / `toDisplayHost`.

**The existing `^1.5.2` range already resolves 1.6.0**, so nothing is broken today and no consumer is blocked. What this buys is the declared constraint matching the current version, consistent with every workspace package, and it follows the precedent in this package's own history — v0.1.2 was exactly this (`chore: bump bluesky_text to ^1.5.2 (now published)`).

Merging publishes 0.1.3 to pub.dev, a version with no functional change. That is the trade; if you would rather let it ride until this package has a real change to ship, closing this PR costs nothing.

## Verification

`flutter analyze` — no issues. `flutter test` — 9 passed, against `bluesky_text` 1.6.0 resolved from pub.dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)