### PR TITLE
fix(bluesky_text): flag email-shaped display text in isLinkFacade

### DIFF
--- a/packages/bluesky_text/lib/src/link_facade.dart
+++ b/packages/bluesky_text/lib/src/link_facade.dart
@@ -20,6 +20,16 @@ final _authorityEndRegex = RegExp(r'[/?#]');
 
 final _digitsRegex = RegExp(r'^[0-9]+$');
 
+/// The local part of an email address, as loosely as it can be defined: at
+/// least one character, none of them a space or a second `@`.
+///
+/// This is deliberately far looser than RFC 5322, because the local part is
+/// discarded either way. All it decides is whether the text reads as a single
+/// address rather than prose that happens to contain an `@` — `Meet me @
+/// bsky.app` and `3 @ $5` fail it, and so does `@alice.bsky.social`, whose
+/// local part is empty.
+final _emailLocalPartRegex = RegExp(r'^[^\s@]+$');
+
 /// Zero-width and directional formatting characters. They are invisible, so
 /// they change nothing about how a display text reads to a human, but they
 /// would break the domain match and let a facade slip through unflagged.
@@ -61,15 +71,39 @@ const _wwwPrefix = 'www.';
 /// `run.sh`) does read as a host — to this function and to every other link
 /// detector on the network alike.
 ///
-/// A display text with no scheme containing `@` before the path is read as an
-/// email address and is never flagged, matching the linkifier, which produces
-/// no facet for an email. With an explicit scheme the `@` is userinfo, and a
-/// userinfo that itself reads as a domain is the host a reader believes they
-/// are seeing: `https://bsky.app@evil.example.com` is compared as `bsky.app`,
-/// so pointing it at `evil.example.com` is flagged even though that host is
-/// the one the URL really resolves to. A userinfo that is an ordinary
-/// user name (`https://alice@example.com`) is ignored and the real host is
-/// compared.
+/// ## Display text with an `@`
+///
+/// An email address carries a host and reads as one: `support@paypal.com` is
+/// at least as reassuring to a reader as `paypal.com` is. So a schemeless
+/// display text that is email-shaped is compared on the domain after its last
+/// `@`, under the same rules as any other host — the `validDomain` gate,
+/// `www.` stripping, punycode decoding, case and trailing-dot normalization,
+/// and the subdomain relation. `support@paypal.com` linking to
+/// `evil.example.com` is flagged; `alice@example.com` linking to
+/// `evil.example.com` is not, because that host sits under the domain the
+/// address names, and whoever owns a domain owns what is beneath it.
+///
+/// This matters only when rendering: the byte range of a facet on a post from
+/// the network was chosen by that post's author, so a link facet can be laid
+/// over any text at all, including an address. On the composition side it
+/// changes nothing, because this package produces no facet of any kind over an
+/// email — a caller checking facets it just built from `BlueskyText` can never
+/// hand this function one.
+///
+/// Text is email-shaped only when the part before the last `@` is a single
+/// token: at least one character, no whitespace and no second `@`. Prose that
+/// merely contains an `@` (`Meet me @ bsky.app`, `3 @ $5`) is not, and neither
+/// is a handle mention (`@alice.bsky.social`), whose local part is empty. That
+/// last one is the important exclusion: a handle is a domain and would sail
+/// through `validDomain`, so reading mentions as addresses would fire a
+/// warning on text that names a person rather than a site.
+///
+/// With an explicit scheme the `@` is userinfo instead, and a userinfo that
+/// itself reads as a domain is the host a reader believes they are seeing:
+/// `https://bsky.app@evil.example.com` is compared as `bsky.app`, so pointing
+/// it at `evil.example.com` is flagged even though that host is the one the
+/// URL really resolves to. A userinfo that is an ordinary user name
+/// (`https://alice@example.com`) is ignored and the real host is compared.
 ///
 /// ## When two hosts match
 ///
@@ -148,22 +182,25 @@ String? _resolveDisplayHost(final String displayText) {
   }
   if (authority.isEmpty) return null;
 
-  final userInfoEnd = authority.lastIndexOf('@');
-  if (userInfoEnd >= 0) {
-    //* Without a scheme this is an email address, which this package never
-    //* linkifies, so it is not a URL-looking display text.
-    if (!hasScheme) return null;
+  final atSignEnd = authority.lastIndexOf('@');
+  if (atSignEnd >= 0) {
+    final beforeAtSign = authority.substring(0, atSignEnd);
 
-    //* `https://bsky.app@evil.example.com` is a URL whose host is
-    //* `evil.example.com`, but a reader sees a host right after the scheme.
-    //* When the userinfo itself reads as a domain it is the host the display
-    //* text claims, so it is the one that has to match the link.
-    final decoy = _normalizeHost(
-      authority.substring(0, userInfoEnd).split(':').first,
-    );
-    if (_domainRegex.hasMatch(decoy)) return _stripWww(decoy);
+    if (hasScheme) {
+      //* `https://bsky.app@evil.example.com` is a URL whose host is
+      //* `evil.example.com`, but a reader sees a host right after the scheme.
+      //* When the userinfo itself reads as a domain it is the host the display
+      //* text claims, so it is the one that has to match the link.
+      final decoy = _normalizeHost(beforeAtSign.split(':').first);
+      if (_domainRegex.hasMatch(decoy)) return _stripWww(decoy);
+    } else if (!_emailLocalPartRegex.hasMatch(beforeAtSign)) {
+      //* Not an email address, just some text with an `@` in it. A handle
+      //* mention lands here, and must: `@alice.bsky.social` names a person,
+      //* not a site, and its empty local part is what says so.
+      return null;
+    }
 
-    authority = authority.substring(userInfoEnd + 1);
+    authority = authority.substring(atSignEnd + 1);
   }
 
   final host = _normalizeHost(_stripPort(authority));

--- a/packages/bluesky_text/test/src/link_facade_test.dart
+++ b/packages/bluesky_text/test/src/link_facade_test.dart
@@ -73,6 +73,28 @@ void main() {
       );
     });
 
+    test('an email address whose domain is not the linked host', () {
+      //* An address reads as a host and reassures exactly as much as the bare
+      //* domain does, so it has to be held to the same rule.
+      expectFacade('support@paypal.com', 'https://evil.example.com');
+      expectFacade('alice.smith@paypal.com', 'https://evil.example.com');
+      expectFacade('support@paypal.com', 'https://paypal.com.evil.example.com');
+      expectFacade('SUPPORT@PayPal.COM', 'https://evil.example.com');
+      expectFacade('  support@paypal.com  ', 'https://evil.example.com');
+      expectFacade('support@www.paypal.com', 'https://evil.example.com');
+      expectFacade('support@paypal.com.', 'https://evil.example.com');
+      expectFacade('support@pay\u200Bpal.com', 'https://evil.example.com');
+      //* Two addresses under a shared public suffix are still a mismatch.
+      expectFacade('alice@foo.github.io', 'https://bar.github.io');
+      //* A `mailto:` in the text is not a scheme this package reads, so the
+      //* rest still reads as an address.
+      expectFacade('mailto:support@paypal.com', 'https://evil.example.com');
+    });
+
+    test('an email address whose domain is punycode of the linked host', () {
+      expectFacade('info@apple.com', 'https://xn--80ak6aa92e.com');
+    });
+
     test('a display text disguised with invisible characters', () {
       //* A zero-width space and a bidi mark change nothing about how the text
       //* reads, so they must not buy an attacker a pass.
@@ -111,9 +133,55 @@ void main() {
       expectHonest('the docs. read them', 'https://evil.example.com');
     });
 
-    test('an email address, which this package never linkifies', () {
+    test('an email address whose domain covers the linked host', () {
+      //* The domain of an address is compared exactly like a bare host, so
+      //* every rule that spares a bare host spares an address too.
+      expectHonest('support@bsky.app', 'https://bsky.app');
+      expectHonest('support@bsky.app', 'https://bsky.app/help?ref=x#top');
+      expectHonest('SUPPORT@BSKY.APP', 'https://bsky.app');
+      expectHonest('support@www.bsky.app', 'https://bsky.app');
+      expectHonest('support@bsky.app.', 'https://bsky.app');
+      expectHonest('info@bücher.de', 'https://xn--bcher-kva.de');
+      //* Whoever owns the domain owns what is beneath it, so a link into a
+      //* subdomain of the address's domain is not a facade. These two were
+      //* the cases the old "an email is never flagged" test pinned, and they
+      //* still hold — now because of the subdomain rule, not an exemption.
+      expectHonest('alice@example.com', 'https://evil.example.com');
       expectHonest('support@example.com', 'https://evil.example.com');
       expectHonest('alice.smith@example.com', 'https://evil.example.com');
+      expectHonest('support@bsky.app', 'https://staging.bsky.app');
+      //* And the reverse: the linked host is fully visible in the address.
+      expectHonest('alice@staging.bsky.app', 'https://bsky.app');
+    });
+
+    test('a handle mention, which names a person and not a site', () {
+      //* This is the exclusion that matters most. A handle is a domain and
+      //* would sail through `validDomain`, so reading a mention as an address
+      //* would fire a warning on every mention a renderer passed in. The empty
+      //* local part before the `@` is what tells the two apart.
+      expectHonest('@alice.bsky.social', 'https://evil.example.com');
+      expectHonest(
+        '@alice.bsky.social',
+        'https://bsky.app/profile/alice.bsky.social',
+      );
+      expectHonest('@bsky.app', 'https://evil.example.com');
+      expectHonest('@alice.bsky.social', 'https://alice.bsky.social');
+    });
+
+    test('text with an @ that is not an email address', () {
+      //* The local part has to be a single token. Prose that merely contains
+      //* an `@` is prose, exactly as it is without one.
+      expectHonest('Meet me @ bsky.app', 'https://evil.example.com');
+      expectHonest('3 @ \$5', 'https://evil.example.com');
+      expectHonest('email me @ support@bsky.app', 'https://evil.example.com');
+      expectHonest('a@b@bsky.app', 'https://evil.example.com');
+      //* A domain the linkifier would not recognize is not a host here
+      //* either, address-shaped or not.
+      expectHonest('user@localhost', 'https://evil.example.com');
+      expectHonest('root@192.168.0.1', 'https://evil.example.com');
+      expectHonest('alice@example', 'https://evil.example.com');
+      expectHonest('support@', 'https://evil.example.com');
+      expectHonest('@', 'https://evil.example.com');
     });
 
     test('an exact host match', () {
@@ -240,6 +308,43 @@ void main() {
       //* `app` must not be treated as the parent of `bsky.app`.
       expectFacade('bsky.app', 'https://app');
       expectFacade('https://app', 'https://bsky.app');
+    });
+  });
+
+  group('isLinkFacade on the composition side', () {
+    test('this package produces no entity over an email address', () {
+      //* This is why the email rule cannot invent a warning for a caller
+      //* checking text it is about to post: there is no facet over an address
+      //* for such a caller to pass in. Only a post from the network, whose
+      //* facet ranges its author chose, can put a link over one.
+      for (final text in [
+        'support@paypal.com',
+        'Contact support@paypal.com now',
+        'alice.smith@example.com',
+      ]) {
+        expect(
+          BlueskyText(text).entities,
+          isEmpty,
+          reason: '"$text" must not produce an entity',
+        );
+      }
+    });
+
+    test('a handle entity covers the leading @ of the mention', () {
+      //* The mention exclusion reads the empty local part before the `@`, so
+      //* it only holds if the `@` is really inside the facet range.
+      const text = 'Hi @alice.bsky.social';
+      final entities = BlueskyText(text).entities;
+
+      expect(entities, hasLength(1));
+      expect(entities.first.type, EntityType.handle);
+      expect(
+        text.substring(
+          entities.first.indices.start,
+          entities.first.indices.end,
+        ),
+        '@alice.bsky.social',
+      );
     });
   });
 

--- a/website/docs/products/packages/bluesky_text.md
+++ b/website/docs/products/packages/bluesky_text.md
@@ -472,11 +472,19 @@ print(isLinkFacade(displayText: 'click here', uri: link)); // false
 final staging = Uri.parse('https://staging.bsky.app');
 print(isLinkFacade(displayText: 'bsky.app', uri: staging)); // false
 
+// An email address carries a host too, and is compared on its domain.
+print(isLinkFacade(displayText: 'support@bsky.app', uri: link)); // true
+
+// A handle mention names a person, not a site, so it is never flagged.
+print(isLinkFacade(displayText: '@alice.bsky.social', uri: link)); // false
+
 // Shows what a punycode host actually says.
 print(toDisplayHost('xn--80ak6aa92e.com')); // аррӏе.com
 ```
 
-Display text counts as a URL only when it carries an explicit `http`/`https` scheme or is a domain this package would linkify on its own, so ordinary link text such as `click here`, `Node.js` or `main.dart` is never flagged. Two hosts match when they are equal or one is a subdomain of the other, ignoring case, `www.`, a trailing root dot, the port and the path — and an `xn--` host is the same host as its decoded Unicode form. `toDisplayHost` decodes that form, so a warning can show the reader what the host says.
+Display text counts as a host-bearing when it carries an explicit `http`/`https` scheme, is a domain this package would linkify on its own, or is an email address — whose domain is then compared like any other host. Ordinary link text such as `click here`, `Node.js` or `main.dart` is never flagged, and neither is a handle mention such as `@alice.bsky.social`, nor prose that merely contains an `@` such as `Meet me @ bsky.app`. Two hosts match when they are equal or one is a subdomain of the other, ignoring case, `www.`, a trailing root dot, the port and the path — and an `xn--` host is the same host as its decoded Unicode form. `toDisplayHost` decodes that form, so a warning can show the reader what the host says.
+
+The email rule only ever matters when rendering a post from the network, where the facet's byte range was chosen by that post's author and can be laid over any text at all. It is inert on the composition side, because this package produces no facet of any kind over an email address, so text you just ran through `BlueskyText` can never present one.
 
 :::caution
 This compares a display text against a link host, and nothing more. It does not detect homographs (a host spelled in Cyrillic that renders like Latin), redirects and link shorteners, or deceptive display text that is not a URL at all. It is a check for one specific shape, not a general phishing filter.


### PR DESCRIPTION
## The gap

`isLinkFacade` never flagged display text that looks like an email address, on the rationale that this package does not linkify an email, so no facet is ever produced over one.

That reasoning holds on the **composition** side — you are checking text you are about to post, and the facets came from this package. It does not hold on the **rendering** side: when displaying a post received from the network, the facet's byte range was chosen by the post's author, so a link facet can be laid over any text at all.

Against 1.6.0:

| display text | link target | before |
|---|---|---|
| `paypal.com` | `https://evil.example.com` | `true` |
| `support@paypal.com` | `https://evil.example.com` | **`false`** |

The second reads at least as trustworthy as the first. A renderer that warns on one and stays silent on the other hands an attacker a free bypass.

## Change

The schemeless `@` branch in `_resolveDisplayHost` no longer bails out: it strips the local part and lets the domain fall through the **existing** path — `_normalizeHost`, `_stripPort`, the `validDomain` gate, `_stripWww`, `_isSameHost`. No parallel normalization; the new code is one regex and a branch. The `hasScheme` userinfo/decoy logic is untouched.

## Handle mentions are never flagged

This was the case worth getting right. A handle *is* a domain and sails through `validDomain`, so a naive reading would flag every mention a renderer passes in — including the legitimate `@alice.bsky.social` → `https://bsky.app/profile/alice.bsky.social` shape, where a client resolves a mention to a profile URL on a different host. That false positive would be far worse than the gap being closed.

It falls out of the rule rather than a special case: the local part must match `^[^\s@]+$`, and a mention's local part is **empty**. The mention's byte range genuinely includes the leading `@` (`BlueskyText('Hi @alice.bsky.social').entities` → `EntityType.handle` at `ByteIndices(start: 3, end: 21)`, 18 bytes), so the exclusion rests on a real property — and that property is now pinned by a test. The same regex rejects `Meet me @ bsky.app` and `3 @ $5` for free.

## Composition-side callers are unaffected

Verified rather than assumed: `BlueskyText('Contact support@paypal.com now').entities` is `[]`, as are `'alice.smith@example.com'` and `'support@paypal.com'`. The package emits no entity over an address — not even a link over the domain inside it — so a caller checking facets it just built can never present an email display text. Pinned by a new test group.

## The existing test that changed

It pinned `support@example.com` and `alice.smith@example.com` over `https://evil.example.com` as unflagged, citing the never-linkifies-an-email rationale this change retires.

**Both assertions are kept and both still pass** — for a different reason. `evil.example.com` is a subdomain of `example.com`, so they fall out of the subdomain rule. The old test never actually exercised the exemption it claimed to.

Worth stating plainly: the first draft of the new test asserted `alice.smith@example.com` → `evil.example.com` must now be flagged. That test failed and **the code was right**; the case was changed to `alice.smith@paypal.com` rather than the assertion weakened.

## One behaviour that follows rather than was designed

`mailto:support@paypal.com` as display text is now flagged — `_schemeRegex` recognizes only `http`/`https`, so `mailto:support` reads as an ordinary local part. That text does read as paypal, so this looks correct and is pinned, but it is a consequence of the local-part rule rather than an intended addition.

## Verification

`bluesky_text` 452 passed (was 446), `bluesky` 937 passed, `dart analyze` clean, `dart format` no diff.

Post-change: `paypal.com` → `true`, `support@paypal.com` → `true`, `alice@example.com` → `false`, `@alice.bsky.social` → `false`, `Meet me @ bsky.app` → `false`, `3 @ $5` → `false`, `user@localhost` → `false`.

## Note on versioning

No `CHANGELOG.md` or `pubspec.yaml` touched. For whoever cuts the next `bluesky_text` release: `isLinkFacade` now flags email-shaped display text whose domain does not cover the link host; handle mentions and non-email `@` text remain unflagged; behaviour is unchanged for callers checking facets produced by this package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)