### PR TITLE
chore(bluesky_text_flutter): bump bluesky_text to ^1.7.0

### DIFF
--- a/packages/bluesky_text_flutter/CHANGELOG.md
+++ b/packages/bluesky_text_flutter/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Release Note
 
-## v0.1.3
+## v0.1.4
 
-- chore: bump `bluesky_text` to `^1.6.0` (now published).
+- chore: bump `bluesky_text` to `^1.7.0`, picking up `checkLinkFacade`/`LinkFacadeVerdict` and the `isLinkFacade` hardening against display text that IDNA maps onto a trusted host, plus entity extraction that is linear rather than quadratic in the length of the text.
+- note: v0.1.3 was tagged but never reached pub.dev — its publish run failed — so this release also carries that version's `bluesky_text` `^1.6.0` bump. Nothing was published as 0.1.3, so upgrading goes straight from 0.1.2.
 
 ## v0.1.2
 

--- a/packages/bluesky_text_flutter/pubspec.yaml
+++ b/packages/bluesky_text_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: bluesky_text_flutter
 description: Flutter widgets for bluesky_text — a rich-text editing controller that highlights entities and the over-limit tail as you type, and a viewer for fetched posts.
-version: 0.1.3
+version: 0.1.4
 homepage: https://atprotodart.com
 repository: https://github.com/myConsciousness/atproto.dart/tree/main/packages/bluesky_text_flutter
 issue_tracker: https://github.com/myConsciousness/atproto.dart/issues
@@ -20,7 +20,7 @@ topics:
 dependencies:
   flutter:
     sdk: flutter
-  bluesky_text: ^1.6.0
+  bluesky_text: ^1.7.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
`bluesky_text_flutter` sits outside the pub workspace and resolves from pub.dev, so it is bumped after the workspace release rather than in lockstep with it. `bluesky_text` 1.7.0 is now published, so this picks it up: `checkLinkFacade`/`LinkFacadeVerdict`, the `isLinkFacade` hardening against display text that IDNA maps onto a trusted host, and entity extraction that is linear rather than quadratic in the length of the text.

Goes to **0.1.4** rather than reusing 0.1.3. That version was tagged, but its publish run hung on an interactive OAuth prompt and was killed by the 10-minute timeout, so nothing was ever published as 0.1.3 — pub.dev is still on 0.1.2. Its `^1.6.0` bump is folded in here and the CHANGELOG says so.

Verified locally with Flutter 3.44.8: `flutter analyze` clean, `flutter test` 9 passing, `flutter pub publish --dry-run` clean apart from the expected "not an incremental update" hint about skipping 0.1.3.

Note that the 0.1.3 publish failed because pub.dev rejected the OIDC token and `flutter pub publish` fell back to interactive OAuth. The workflow itself looks correct — `--force` is passed, `id-token: write` is granted workflow-wide, and the job logged `OIDC token endpoint is available` — so if this release hits the same wall, the cause is on the pub.dev side rather than in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)