### PR TITLE
fix(ci): publish the Flutter package with dart pub, not flutter pub

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -252,20 +252,31 @@ jobs:
       - name: Install dependencies
         run: flutter pub get
 
-      # OIDC token is auto-exchanged because `id-token: write` is granted above.
+      # Publishes with `dart pub`, not `flutter pub`, even though this is a
+      # Flutter package. `flutter pub publish` does not reach pub.dev's OIDC
+      # exchange: both 0.1.3 and 0.1.4 got as far as "Publishing ... to
+      # https://pub.dev:" and then printed "Pub needs your authorization",
+      # i.e. it fell straight through to the browser OAuth flow and sat on a
+      # localhost redirect until the timeout killed it. The same workflow,
+      # same `id-token: write`, same `--force` and the same confirmed-present
+      # OIDC token endpoint publishes every Dart package here without a
+      # prompt, so the wrapper — not the credentials and not pub.dev — is what
+      # differs. `flutter pub get` above still does the resolving, which is the
+      # part that genuinely needs the Flutter SDK; `dart pub publish` only has
+      # to package and upload, and validates this package cleanly.
       - name: Publish to pub.dev
         run: |
           set -o pipefail
           log="$RUNNER_TEMP/publish.log"
           status=0
-          timeout 10m flutter pub publish --force 2>&1 | tee "$log" || status=$?
+          timeout 10m dart pub publish --force 2>&1 | tee "$log" || status=$?
           if [[ "$status" -eq 0 ]]; then
             exit 0
           fi
 
           if grep -q 'Pub needs your authorization' "$log"; then
-            echo "::error::pub fell back to interactive OAuth, so OIDC publishing was rejected. Check 'Automated publishing' for 'bluesky_text_flutter' on pub.dev (Admin tab -> repository myConsciousness/atproto.dart, tag pattern bluesky_text_flutter-v{{version}})."
+            echo "::error::pub fell back to interactive OAuth, so OIDC publishing was rejected. Either 'Automated publishing' for 'bluesky_text_flutter' does not match this push (pub.dev Admin tab -> repository myConsciousness/atproto.dart, tag pattern bluesky_text_flutter-v{{version}}, 'Require GitHub Actions environment' left unchecked because no job here declares one), or the publishing command stopped reaching the OIDC exchange."
           elif [[ "$status" -eq 124 ]]; then
-            echo "::error::'flutter pub publish' did not finish within 10 minutes and was killed."
+            echo "::error::'dart pub publish' did not finish within 10 minutes and was killed."
           fi
           exit "$status"


### PR DESCRIPTION
`bluesky_text_flutter` has never published from CI. Both 0.1.3 and 0.1.4 failed identically:

```
Publishing bluesky_text_flutter 0.1.4 to https://pub.dev:
Pub needs your authorization to upload packages on your behalf.
In a web browser, go to https://accounts.google.com/o/oauth2/auth?...
Waiting for your authorization...      ← 10 min later: exit 124
```

`flutter pub publish` gets as far as contacting pub.dev and then falls straight through to the browser OAuth flow, waiting on a localhost redirect that can never arrive on a runner.

Nothing about the credentials explains it. The job verifies the OIDC token endpoint is present before publishing and logs `OIDC token endpoint is available`; `id-token: write` is granted workflow-wide; `--force` is passed; neither job declares an `environment:`. The Dart job is identical in every one of those respects and published nine packages in the same run without a prompt. The wrapper is the only remaining difference, so this switches the upload to `dart pub publish`.

`flutter pub get` still does the resolving — that is the part that genuinely needs the Flutter SDK. `dart pub publish` only has to package and upload, and validates this package with 0 warnings locally (Flutter 3.44.8, bundled Dart 3.12.2).

Also drops the misleading error text. On seeing the OAuth fallback the step asserted that pub.dev's "Automated publishing" was unset — that was the step's own guess, not pub.dev's answer, and it sent this investigation down the wrong path for a while. It now names both possibilities.

After merge, re-running the failed `bluesky_text_flutter-v0.1.4` publish is enough; the tag already exists and nothing was uploaded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)