### PR TITLE
chore(ci): revert the Flutter publish command and record what was ruled out

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -199,7 +199,7 @@ jobs:
           # status with `||` rather than an `if`: a failing `if` condition with
           # no `else` leaves `$?` at 0, which would report the failure as a
           # successful publish.
-          timeout 10m dart pub publish --force 2>&1 | tee "$log" || status=$?
+          timeout 10m flutter pub publish --force 2>&1 | tee "$log" || status=$?
           if [[ "$status" -eq 0 ]]; then
             exit 0
           fi
@@ -207,7 +207,7 @@ jobs:
           if grep -q 'Pub needs your authorization' "$log"; then
             echo "::error::pub fell back to interactive OAuth, so OIDC publishing was rejected. Enable 'Automated publishing' for '$PACKAGE' on pub.dev (Admin tab -> repository myConsciousness/atproto.dart, tag pattern {{package}}-v{{version}})."
           elif [[ "$status" -eq 124 ]]; then
-            echo "::error::'dart pub publish' did not finish within 10 minutes and was killed."
+            echo "::error::'flutter pub publish' did not finish within 10 minutes and was killed."
           fi
           exit "$status"
 
@@ -252,24 +252,30 @@ jobs:
       - name: Install dependencies
         run: flutter pub get
 
-      # Publishes with `dart pub`, not `flutter pub`, even though this is a
-      # Flutter package. `flutter pub publish` does not reach pub.dev's OIDC
-      # exchange: both 0.1.3 and 0.1.4 got as far as "Publishing ... to
-      # https://pub.dev:" and then printed "Pub needs your authorization",
-      # i.e. it fell straight through to the browser OAuth flow and sat on a
-      # localhost redirect until the timeout killed it. The same workflow,
-      # same `id-token: write`, same `--force` and the same confirmed-present
-      # OIDC token endpoint publishes every Dart package here without a
-      # prompt, so the wrapper — not the credentials and not pub.dev — is what
-      # differs. `flutter pub get` above still does the resolving, which is the
-      # part that genuinely needs the Flutter SDK; `dart pub publish` only has
-      # to package and upload, and validates this package cleanly.
+      # OIDC token is auto-exchanged because `id-token: write` is granted above.
+      #
+      # This package has never published from CI: 0.1.3 and 0.1.4 both reached
+      # "Publishing ... to https://pub.dev:", printed "Pub needs your
+      # authorization", and then sat on a browser OAuth redirect that cannot
+      # arrive on a runner until the timeout killed the job. If that happens
+      # again, do not go looking for it in here. The following were each ruled
+      # out by experiment, so re-testing them is wasted time:
+      #   * the command — 0.1.4 was retried with `dart pub publish --force`,
+      #     the exact invocation that published nine Dart packages in one run
+      #     minutes earlier, and it failed identically;
+      #   * this workflow — the Dart and Flutter jobs are line-for-line
+      #     equivalent in permissions, `--force`, the OIDC pre-check (which
+      #     logged "OIDC token endpoint is available") and the timeout;
+      #   * ownership — `bluesky_text_flutter` sits under the same pub.dev
+      #     publisher (`atprotodart.com`) as every package that does publish.
+      # What is left is this package's own "Automated publishing" entry on
+      # pub.dev, which is per-package and cannot be read from CI.
       - name: Publish to pub.dev
         run: |
           set -o pipefail
           log="$RUNNER_TEMP/publish.log"
           status=0
-          timeout 10m dart pub publish --force 2>&1 | tee "$log" || status=$?
+          timeout 10m flutter pub publish --force 2>&1 | tee "$log" || status=$?
           if [[ "$status" -eq 0 ]]; then
             exit 0
           fi
@@ -277,6 +283,6 @@ jobs:
           if grep -q 'Pub needs your authorization' "$log"; then
             echo "::error::pub fell back to interactive OAuth, so OIDC publishing was rejected. Either 'Automated publishing' for 'bluesky_text_flutter' does not match this push (pub.dev Admin tab -> repository myConsciousness/atproto.dart, tag pattern bluesky_text_flutter-v{{version}}, 'Require GitHub Actions environment' left unchecked because no job here declares one), or the publishing command stopped reaching the OIDC exchange."
           elif [[ "$status" -eq 124 ]]; then
-            echo "::error::'dart pub publish' did not finish within 10 minutes and was killed."
+            echo "::error::'flutter pub publish' did not finish within 10 minutes and was killed."
           fi
           exit "$status"


### PR DESCRIPTION
#2522 switched the Flutter upload to `dart pub publish` on the theory that `flutter pub` was not reaching pub.dev's OIDC exchange. **That theory is wrong.** The retry with `dart pub publish --force` — the exact invocation that had published nine Dart packages minutes earlier in the same workflow — failed at the same point:

```
Publishing bluesky_text_flutter 0.1.4 to https://pub.dev:
Pub needs your authorization to upload packages on your behalf.
Waiting for your authorization...      ← 10 min later: exit 124
```

So the command is reverted, and the comment now records what has been eliminated **by experiment** rather than by reasoning, so the next person does not repeat it:

- **the command** — `dart pub publish --force` fails identically;
- **this workflow** — the Dart and Flutter jobs are line-for-line equivalent in permissions, `--force`, the OIDC pre-check (which logs `OIDC token endpoint is available`) and the timeout;
- **ownership** — `bluesky_text_flutter` sits under the same pub.dev publisher (`atprotodart.com`) as every package that does publish.

What is left is the package's own "Automated publishing" entry on pub.dev, which is per-package and cannot be read from CI.

`bluesky_text_flutter` 0.1.4 is tagged and unpublished; pub.dev is still on 0.1.2. Once the pub.dev side is sorted, delete and re-push `bluesky_text_flutter-v0.1.4` — a real tag push is the only event pub.dev accepts, as this workflow already documents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)