### PR TITLE
fix(ci): mint the pub.dev OIDC token in the Flutter publish job

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,4 +1,11 @@
-# Package-specific labels
+# Package-specific labels.
+#
+# The list below must cover every member of the root `pubspec.yaml` `workspace:`
+# list, plus `packages/bluesky_text_flutter` (a Flutter package that is not a
+# workspace member). This file is read by actions/labeler, so unlike the test
+# workflow it cannot derive the list at runtime -- adding a workspace member
+# means adding a rule here and a color in `.github/labels.yml`. It drifted once
+# already and left `atproto_identity` and `templates/feed_generator` unlabelled.
 at_primitives:
 - changed-files:
   - any-glob-to-any-file: packages/at_primitives/**
@@ -29,6 +36,9 @@ did_plc:
 atproto:
 - changed-files:
   - any-glob-to-any-file: packages/atproto/**
+atproto_identity:
+- changed-files:
+  - any-glob-to-any-file: packages/atproto_identity/**
 bluesky_text:
 - changed-files:
   - any-glob-to-any-file: packages/bluesky_text/**
@@ -42,10 +52,17 @@ bluesky_cli:
 - changed-files:
   - any-glob-to-any-file: packages/bluesky_cli/**
 
+# Workspace members outside `packages/`.
+feed_generator:
+- changed-files:
+  - any-glob-to-any-file: templates/feed_generator/**
+
 # Test-related changes
 test:
 - changed-files:
-  - any-glob-to-any-file: packages/*/test/**/*.dart
+  - any-glob-to-any-file:
+    - packages/*/test/**/*.dart
+    - templates/*/test/**/*.dart
 
 # Documentation changes
 documentation:
@@ -53,6 +70,8 @@ documentation:
   - any-glob-to-any-file:
     - packages/*/CHANGELOG.md
     - packages/*/README.md
+    - templates/*/CHANGELOG.md
+    - templates/*/README.md
     - CODE_OF_CONDUCT.md
     - CONTRIBUTING.md
     - README.md
@@ -63,6 +82,7 @@ ci:
   - any-glob-to-any-file:
     - .github/workflows/**
     - .github/labeler.yml
+    - .github/labels.yml
     - .github/dependabot.yml
     - melos.yaml
     - pubspec.yaml
@@ -76,3 +96,5 @@ build:
     - scripts/**
     - packages/*/pubspec.yaml
     - packages/*/analysis_options.yaml
+    - templates/*/pubspec.yaml
+    - templates/*/analysis_options.yaml

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -31,6 +31,9 @@
 - name: atproto
   color: "00897B"
   description: "A label indicating the package `atproto`."
+- name: atproto_identity
+  color: "26A69A"
+  description: "A label indicating the package `atproto_identity`."
 - name: atproto_oauth
   color: "00ACC1"
   description: "A label indicating the package `atproto_oauth`."
@@ -53,6 +56,11 @@
 - name: lex_gen
   color: "EF6C00"
   description: "A label indicating the package `lex_gen`."
+
+# --- Templates (amber) ---
+- name: feed_generator
+  color: "FFB300"
+  description: "A label indicating the template `templates/feed_generator`."
 
 # --- Test infrastructure (gray) ---
 - name: atproto_test

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -199,7 +199,7 @@ jobs:
           # status with `||` rather than an `if`: a failing `if` condition with
           # no `else` leaves `$?` at 0, which would report the failure as a
           # successful publish.
-          timeout 10m dart pub publish --force 2>&1 | tee "$log" || status=$?
+          timeout 10m flutter pub publish --force 2>&1 | tee "$log" || status=$?
           if [[ "$status" -eq 0 ]]; then
             exit 0
           fi
@@ -207,7 +207,7 @@ jobs:
           if grep -q 'Pub needs your authorization' "$log"; then
             echo "::error::pub fell back to interactive OAuth, so OIDC publishing was rejected. Enable 'Automated publishing' for '$PACKAGE' on pub.dev (Admin tab -> repository myConsciousness/atproto.dart, tag pattern {{package}}-v{{version}})."
           elif [[ "$status" -eq 124 ]]; then
-            echo "::error::'dart pub publish' did not finish within 10 minutes and was killed."
+            echo "::error::'flutter pub publish' did not finish within 10 minutes and was killed."
           fi
           exit "$status"
 
@@ -229,6 +229,19 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: stable
+
+      # This is what authenticates the publish, and it is easy to mistake for
+      # redundant SDK setup. `subosito/flutter-action` installs Flutter and
+      # nothing else; `dart-lang/setup-dart` additionally runs its
+      # `createPubOIDCToken()`, which mints a GitHub OIDC token for audience
+      # `https://pub.dev`, exports it as `PUB_TOKEN`, and registers it with
+      # `dart pub token add https://pub.dev --env-var PUB_TOKEN`. Without that
+      # step pub holds no pub.dev credential at all, so it falls through to the
+      # browser OAuth flow and waits on a `http://localhost:<port>` redirect
+      # that can never arrive on a runner -- which is how 0.1.3 and 0.1.4 burned
+      # three ten-minute timeouts. The credential lands in the shared pub
+      # config, so the `flutter pub` call below picks it up.
+      - uses: dart-lang/setup-dart@v1
 
       - name: Verify an OIDC token is available
         run: |
@@ -252,24 +265,15 @@ jobs:
       - name: Install dependencies
         run: flutter pub get
 
-      # Publishes with `dart pub`, not `flutter pub`, even though this is a
-      # Flutter package. `flutter pub publish` does not reach pub.dev's OIDC
-      # exchange: both 0.1.3 and 0.1.4 got as far as "Publishing ... to
-      # https://pub.dev:" and then printed "Pub needs your authorization",
-      # i.e. it fell straight through to the browser OAuth flow and sat on a
-      # localhost redirect until the timeout killed it. The same workflow,
-      # same `id-token: write`, same `--force` and the same confirmed-present
-      # OIDC token endpoint publishes every Dart package here without a
-      # prompt, so the wrapper — not the credentials and not pub.dev — is what
-      # differs. `flutter pub get` above still does the resolving, which is the
-      # part that genuinely needs the Flutter SDK; `dart pub publish` only has
-      # to package and upload, and validates this package cleanly.
+      # Credentials come from the `dart-lang/setup-dart` step above, not from
+      # `id-token: write` alone: that permission only makes an OIDC token
+      # mintable, and something still has to mint it and hand it to pub.
       - name: Publish to pub.dev
         run: |
           set -o pipefail
           log="$RUNNER_TEMP/publish.log"
           status=0
-          timeout 10m dart pub publish --force 2>&1 | tee "$log" || status=$?
+          timeout 10m flutter pub publish --force 2>&1 | tee "$log" || status=$?
           if [[ "$status" -eq 0 ]]; then
             exit 0
           fi
@@ -277,6 +281,6 @@ jobs:
           if grep -q 'Pub needs your authorization' "$log"; then
             echo "::error::pub fell back to interactive OAuth, so OIDC publishing was rejected. Either 'Automated publishing' for 'bluesky_text_flutter' does not match this push (pub.dev Admin tab -> repository myConsciousness/atproto.dart, tag pattern bluesky_text_flutter-v{{version}}, 'Require GitHub Actions environment' left unchecked because no job here declares one), or the publishing command stopped reaching the OIDC exchange."
           elif [[ "$status" -eq 124 ]]; then
-            echo "::error::'dart pub publish' did not finish within 10 minutes and was killed."
+            echo "::error::'flutter pub publish' did not finish within 10 minutes and was killed."
           fi
           exit "$status"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -187,6 +187,16 @@ jobs:
       - name: Analyze
         run: dart analyze $DART_DIRS
 
+      # Runs BEFORE the resolve below, because it is what makes that resolve's
+      # failure legible. `website` is not a workspace member, so any workspace
+      # package it reaches without a path override is fetched from pub.dev --
+      # fine until a release bumps that package to a version that does not exist
+      # there yet, at which point `dart pub get` fails with a version-solving
+      # error that names the symptom and not the cause (#2519). This asserts the
+      # override list still covers the full transitive closure.
+      - name: Validate website dependency overrides
+        run: dart run ./scripts/validate_website_overrides.dart
+
       # `website` is not a workspace member -- it pins the packages by path and
       # resolves on its own -- so it needs a separate resolve before analysis.
       # Its snippets are the source of every code example in the docs, so this

--- a/.github/workflows/validate_dependencies.yml
+++ b/.github/workflows/validate_dependencies.yml
@@ -5,6 +5,15 @@ on:
   pull_request:
     paths:
       - "packages/*/pubspec.yaml"
+      # Not every workspace member lives under `packages/`:
+      # `templates/feed_generator` is one, and its constraints on workspace
+      # packages must stay in lockstep too -- a stale one breaks the root
+      # `dart pub get` for the whole repo.
+      - "templates/*/pubspec.yaml"
+      # The `workspace:` list decides which packages get validated at all.
+      - "pubspec.yaml"
+      - "scripts/validate_dependencies.dart"
+      - "scripts/utils.dart"
 
 # Cancel superseded runs for the same ref (e.g. rapid pushes to a PR branch).
 concurrency:

--- a/packages/did_plc/lib/src/cache/memory_cache.dart
+++ b/packages/did_plc/lib/src/cache/memory_cache.dart
@@ -11,8 +11,6 @@ class _CacheEntry<T> {
 
   final T data;
   final DateTime expiresAt;
-
-  bool get isExpired => DateTime.now().isAfter(expiresAt);
 }
 
 /// A memory-based cache implementation with TTL and LRU eviction support.
@@ -26,9 +24,15 @@ class MemoryCache<T> {
   /// This cache does not start any background timers. Expired entries are
   /// purged lazily on read and when new entries are inserted, so it never
   /// keeps the isolate alive and is safe to leave un-disposed.
-  MemoryCache(this._policy);
+  ///
+  /// [now] supplies the current time for TTL and LRU bookkeeping. It defaults
+  /// to [DateTime.now]; pass a controllable clock to make expiry deterministic
+  /// instead of dependent on wall-clock delays.
+  MemoryCache(this._policy, {final DateTime Function()? now})
+    : _now = now ?? DateTime.now;
 
   final CachePolicy _policy;
+  final DateTime Function() _now;
   final Map<String, _CacheEntry<T>> _cache = {};
   final Map<String, DateTime> _accessTimes = {};
 
@@ -48,7 +52,7 @@ class MemoryCache<T> {
       return null;
     }
 
-    if (entry.isExpired) {
+    if (_isExpired(entry)) {
       _remove(key);
       _recordMiss();
       return null;
@@ -56,7 +60,7 @@ class MemoryCache<T> {
 
     // Update access time for LRU tracking
     if (_policy.shouldUseLru) {
-      _accessTimes[key] = DateTime.now();
+      _accessTimes[key] = _now();
     }
 
     _recordHit();
@@ -70,7 +74,7 @@ class MemoryCache<T> {
   void put(String key, T value) {
     if (!_policy.isEnabled) return;
 
-    final expiresAt = DateTime.now().add(_policy.effectiveTtl);
+    final expiresAt = _now().add(_policy.effectiveTtl);
     final entry = _CacheEntry(value, expiresAt);
 
     // Check if we need to evict entries. Purge expired entries first so we
@@ -84,7 +88,7 @@ class MemoryCache<T> {
 
     _cache[key] = entry;
     if (_policy.shouldUseLru) {
-      _accessTimes[key] = DateTime.now();
+      _accessTimes[key] = _now();
     }
   }
 
@@ -110,7 +114,7 @@ class MemoryCache<T> {
     final entry = _cache[key];
     if (entry == null) return false;
 
-    if (entry.isExpired) {
+    if (_isExpired(entry)) {
       _remove(key);
       return false;
     }
@@ -145,6 +149,8 @@ class MemoryCache<T> {
 
   // Private methods
 
+  bool _isExpired(_CacheEntry<T> entry) => _now().isAfter(entry.expiresAt);
+
   void _remove(String key) {
     _cache.remove(key);
     _accessTimes.remove(key);
@@ -177,7 +183,7 @@ class MemoryCache<T> {
   }
 
   void _cleanupExpired() {
-    final now = DateTime.now();
+    final now = _now();
     final expiredKeys = <String>[];
 
     for (final entry in _cache.entries) {

--- a/packages/did_plc/test/cache_test.dart
+++ b/packages/did_plc/test/cache_test.dart
@@ -22,14 +22,21 @@ void main() {
   );
 
   group('MemoryCache TTL', () {
-    test('expires entries after the TTL elapses', () async {
+    test('expires entries after the TTL elapses', () {
+      // Driven by an injected clock rather than a real delay: a wall-clock
+      // margin is only as reliable as the machine's spare capacity.
+      var now = DateTime.utc(2026, 1, 1, 12);
       final cache = MemoryCache<String>(
-        const CachePolicy(ttl: Duration(milliseconds: 50)),
+        const CachePolicy(ttl: Duration(minutes: 5)),
+        now: () => now,
       );
       cache.put('k', 'v');
       expect(cache.get('k'), equals('v'));
 
-      await Future<void>.delayed(const Duration(milliseconds: 80));
+      now = now.add(const Duration(minutes: 4));
+      expect(cache.get('k'), equals('v'), reason: 'still within the TTL');
+
+      now = now.add(const Duration(minutes: 2));
       expect(cache.get('k'), isNull);
       expect(cache.containsKey('k'), isFalse);
     });
@@ -57,16 +64,19 @@ void main() {
       expect(cache.size, equals(2));
     });
 
-    test('purges expired entries before evicting a live one', () async {
+    test('purges expired entries before evicting a live one', () {
+      var now = DateTime.utc(2026, 1, 1, 12);
       final cache = MemoryCache<String>(
-        const CachePolicy(maxSize: 2, ttl: Duration(milliseconds: 40)),
+        const CachePolicy(maxSize: 2, ttl: Duration(minutes: 5)),
+        now: () => now,
       );
       cache.put('a', '1');
-      await Future<void>.delayed(const Duration(milliseconds: 60));
+      now = now.add(const Duration(minutes: 6));
       // 'a' is now expired; inserting two more should reclaim its slot
       // rather than evict a live entry.
       cache.put('b', '2');
       cache.put('c', '3');
+      expect(cache.containsKey('a'), isFalse);
       expect(cache.containsKey('b'), isTrue);
       expect(cache.containsKey('c'), isTrue);
     });

--- a/scripts/utils.dart
+++ b/scripts/utils.dart
@@ -7,6 +7,7 @@ import 'dart:io';
 
 // Package imports:
 import 'package:lexicon/lexicon.dart';
+import 'package:pubspec/pubspec.dart';
 
 /// Root directory containing the synced lexicon definitions.
 const lexiconsPath = 'lexicons';
@@ -14,19 +15,53 @@ const lexiconsPath = 'lexicons';
 /// Root directory containing the workspace packages.
 const packagesPath = 'packages';
 
-/// Returns the names of all workspace packages, sorted alphabetically.
-List<String> get packageNames =>
-    Directory(packagesPath)
-        .listSync()
-        .whereType<Directory>()
-        .map((e) => e.path.split('/').last)
-        .where((name) => !name.startsWith('.'))
-        .toList()
-      ..sort();
+/// Path of the root pubspec, which owns the `workspace:` member list.
+const rootPubspecPath = 'pubspec.yaml';
 
-/// Returns the pubspec file of the given package.
-File getPackagePubspec(String packageName) =>
-    File('$packagesPath/$packageName/pubspec.yaml');
+/// Returns the repo-relative directory of every Dart pub workspace member,
+/// sorted, as declared by the root pubspec's `workspace:` list.
+///
+/// The Dart-side counterpart of `scripts/dart_workspace_dirs.sh`: the
+/// `workspace:` list is the single source of truth for "which packages does
+/// this repo build", and deriving from it is what stops a second, hand-kept
+/// copy from silently dropping a member. Entries are full repo-relative paths,
+/// not bare names, because not every member lives under [packagesPath]
+/// (`templates/feed_generator` does not).
+///
+/// The Flutter package (`packages/bluesky_text_flutter`) is deliberately not a
+/// workspace member, so it never appears here.
+List<String> get workspacePackageDirs {
+  final workspace = loadPubspec(
+    File(rootPubspecPath),
+  ).unParsedYaml?['workspace'];
+
+  if (workspace is! List || workspace.isEmpty) {
+    // A silently empty list would make every workspace-derived check pass by
+    // checking nothing, which is worse than not having the check at all.
+    throw StateError(
+      "Parsed an empty 'workspace:' list from $rootPubspecPath. "
+      'The pubspec layout changed; refusing to continue.',
+    );
+  }
+
+  return workspace.map((e) => e.toString()).toList()..sort();
+}
+
+/// Returns the pubspec file of the workspace member at [packageDir].
+File getWorkspacePubspec(String packageDir) => File('$packageDir/pubspec.yaml');
+
+/// Parses [file] as a pubspec, failing with the offending path in the message.
+PubSpec loadPubspec(File file) {
+  if (!file.existsSync()) {
+    throw StateError('Pubspec file not found: ${file.path}');
+  }
+
+  try {
+    return PubSpec.fromYamlString(file.readAsStringSync());
+  } catch (e) {
+    throw StateError('Failed to parse ${file.path}: $e');
+  }
+}
 
 /// Loads every vendored lexicon document under [lexiconsPath] in
 /// deterministic (lexicon-id-sorted) order. Which lexicons are vendored is

--- a/scripts/validate_dependencies.dart
+++ b/scripts/validate_dependencies.dart
@@ -12,11 +12,11 @@ import 'utils.dart';
 
 /// Packages to exclude from dependency validation.
 ///
-/// `bluesky_text_flutter` lives outside the Dart pub workspace and resolves its
-/// dependencies from pub.dev, so it can only reference *published* workspace
-/// versions; it is bumped/republished after the workspace packages it depends
-/// on are published, not in lockstep.
-const _excludePackages = ['atproto_test', 'did_plc', 'bluesky_text_flutter'];
+/// Note `bluesky_text_flutter` needs no entry here: the package list is derived
+/// from the root pubspec's `workspace:` members, and the Flutter package is not
+/// one. It resolves from pub.dev, so it can only reference *published*
+/// workspace versions and is republished after them, not in lockstep.
+const _excludePackages = ['atproto_test', 'did_plc'];
 
 void main() {
   final errors = <String>[];
@@ -41,13 +41,18 @@ void main() {
 }
 
 /// Loads and parses the pubspec of every package under validation.
+///
+/// The list comes from the root pubspec's `workspace:` members rather than a
+/// listing of `packages/`, so every member is covered wherever it lives.
+/// `templates/feed_generator` used to fall outside a `packages/`-only scan: its
+/// constraints on workspace packages went unchecked and could go stale, and
+/// because a workspace member's constraints must be satisfied by the local
+/// versions, a stale one breaks the root `dart pub get` for the whole repo.
 Map<String, _Package> _loadPackages(List<String> errors) {
   final packages = <String, _Package>{};
 
-  for (final packageName in packageNames) {
-    if (_excludePackages.contains(packageName)) continue;
-
-    final pubspecFile = getPackagePubspec(packageName);
+  for (final packageDir in workspacePackageDirs) {
+    final pubspecFile = getWorkspacePubspec(packageDir);
     if (!pubspecFile.existsSync()) {
       errors.add('Pubspec file not found: ${pubspecFile.path}');
       continue;
@@ -60,6 +65,7 @@ Map<String, _Package> _loadPackages(List<String> errors) {
         errors.add('Package name is null in ${pubspecFile.path}');
         continue;
       }
+      if (_excludePackages.contains(name)) continue;
 
       final dependencies = <String, String>{};
       pubspec.dependencies.forEach((dependency, version) {
@@ -71,7 +77,9 @@ Map<String, _Package> _loadPackages(List<String> errors) {
 
       packages[name] = _Package(
         name: name,
-        version: pubspec.version.toString(),
+        // Null for `publish_to: none` members such as `templates/feed_generator`,
+        // which carry no version because nothing can depend on them.
+        version: pubspec.version?.toString(),
         dependencies: dependencies,
         pubspecPath: pubspecFile.path,
       );
@@ -91,6 +99,7 @@ void _validateDevelopingPackages(
   for (final package in packages.values) {
     package.dependencies.forEach((name, version) {
       final dependencyPackage = packages[name];
+      if (dependencyPackage?.version == null) return;
 
       if (dependencyPackage != null && version != dependencyPackage.version) {
         errors.add(
@@ -139,7 +148,7 @@ class _Package {
   });
 
   final String name;
-  final String version;
+  final String? version;
   final Map<String, String> dependencies;
   final String pubspecPath;
 }

--- a/scripts/validate_website_overrides.dart
+++ b/scripts/validate_website_overrides.dart
@@ -1,0 +1,212 @@
+// Copyright (c) 2023-2025, Shinya Kato.
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+
+// Package imports:
+import 'package:pubspec/pubspec.dart';
+
+// Project imports:
+import 'utils.dart';
+
+/// Asserts that `website/pubspec_overrides.yaml` overrides the FULL transitive
+/// closure of workspace packages reachable from `website/pubspec.yaml`.
+///
+/// Why this exists: `website` is not a pub workspace member. It resolves on its
+/// own, so any workspace package it reaches that is NOT overridden to a local
+/// path is fetched from pub.dev instead — which works only while that exact
+/// version is already published. The moment a release bumps such a package,
+/// `dart pub get` in `website/` fails and takes the `format-analyze` job down
+/// with it. That is exactly what happened in #2519, where `atproto_oauth` and
+/// `atproto_identity` were missing: nothing in the repo imports them, but
+/// `atproto_core` -> `atproto_oauth` -> `atproto_identity` -> `did_plc` pulls
+/// them into the closure.
+///
+/// The override list was hand-maintained, so it could drift back the same way.
+/// This computes the closure from the packages' own pubspecs and compares.
+///
+/// Two traps worth knowing, both of which look like fixes and are not:
+///   * `dependency_overrides:` written into `website/pubspec.yaml` is SILENTLY
+///     IGNORED while `website/pubspec_overrides.yaml` exists. Checked below.
+///   * Adding a transitive workspace package to `dependencies:` as a path dep
+///     does not help either — its dependents still name it as a hosted dep, so
+///     pub reports a path-vs-hosted source conflict. The override file is the
+///     only place these belong.
+///
+/// Usage:
+///   dart run ./scripts/validate_website_overrides.dart
+const _websiteDir = 'website';
+
+void main() {
+  final errors = <String>[];
+
+  // name -> repo-relative dir, e.g. {'xrpc': 'packages/xrpc'}.
+  final workspacePackages = _loadWorkspacePackages();
+
+  final websitePubspec = loadPubspec(File('$_websiteDir/pubspec.yaml'));
+  _validateNoInlineOverrides(websitePubspec, errors);
+
+  final required = _reachableWorkspacePackages(
+    websitePubspec,
+    workspacePackages,
+  );
+  final declared = _loadDeclaredOverrides(workspacePackages, errors);
+
+  _validateClosureIsOverridden(required, declared, workspacePackages, errors);
+
+  if (errors.isEmpty) {
+    logInfo(
+      '✓ $_websiteDir/pubspec_overrides.yaml covers all '
+      '${required.length} reachable workspace packages',
+    );
+    return;
+  }
+
+  logError('✗ Found ${errors.length} validation errors:');
+  for (final error in errors) {
+    logError('  • $error');
+  }
+  exit(1);
+}
+
+/// Maps every workspace member's package name to its repo-relative directory.
+Map<String, String> _loadWorkspacePackages() {
+  final packages = <String, String>{};
+
+  for (final dir in workspacePackageDirs) {
+    final name = loadPubspec(getWorkspacePubspec(dir)).name;
+    if (name == null) {
+      throw StateError('Package name is null in $dir/pubspec.yaml');
+    }
+
+    packages[name] = dir;
+  }
+
+  return packages;
+}
+
+/// Rejects `dependency_overrides:` in `website/pubspec.yaml`, which pub ignores
+/// outright whenever `pubspec_overrides.yaml` sits next to it — so an entry
+/// added there looks correct and does nothing.
+void _validateNoInlineOverrides(PubSpec websitePubspec, List<String> errors) {
+  if (websitePubspec.dependencyOverrides.isNotEmpty) {
+    errors.add(
+      '$_websiteDir/pubspec.yaml declares dependency_overrides, which pub '
+      'silently ignores because $_websiteDir/pubspec_overrides.yaml exists. '
+      'Move those entries into $_websiteDir/pubspec_overrides.yaml.',
+    );
+  }
+}
+
+/// Returns every workspace package pub has to resolve for `website`.
+///
+/// Seeded with the website's own direct dependencies (dev dependencies
+/// included — pub resolves those too), then closed over the *regular*
+/// dependencies of each package reached. Dev dependencies of a dependency are
+/// deliberately not followed: pub does not resolve them either.
+Set<String> _reachableWorkspacePackages(
+  PubSpec websitePubspec,
+  Map<String, String> workspacePackages,
+) {
+  final reachable = <String>{};
+  final queue = <String>[
+    ...websitePubspec.dependencies.keys,
+    ...websitePubspec.devDependencies.keys,
+  ].where(workspacePackages.containsKey).toList();
+
+  while (queue.isNotEmpty) {
+    final name = queue.removeLast();
+    if (!reachable.add(name)) continue;
+
+    final pubspec = loadPubspec(getWorkspacePubspec(workspacePackages[name]!));
+
+    for (final dependency in pubspec.dependencies.keys) {
+      if (workspacePackages.containsKey(dependency) &&
+          !reachable.contains(dependency)) {
+        queue.add(dependency);
+      }
+    }
+  }
+
+  return reachable;
+}
+
+/// Reads the override entries, checking each one is a path pointing at the
+/// workspace package it names.
+Set<String> _loadDeclaredOverrides(
+  Map<String, String> workspacePackages,
+  List<String> errors,
+) {
+  final overridesPath = '$_websiteDir/pubspec_overrides.yaml';
+  final overrides = loadPubspec(File(overridesPath)).dependencyOverrides;
+  final declared = <String>{};
+
+  overrides.forEach((name, reference) {
+    declared.add(name);
+
+    final dir = workspacePackages[name];
+    if (dir == null) {
+      errors.add(
+        '$overridesPath overrides "$name", which is not a workspace package.',
+      );
+      return;
+    }
+
+    if (reference is! PathReference) {
+      errors.add(
+        '$overridesPath overrides "$name" with a ${reference.runtimeType}. '
+        'Overrides must be path references to ../$dir, otherwise the package '
+        'is still resolved from pub.dev.',
+      );
+      return;
+    }
+
+    if (reference.path != '../$dir') {
+      errors.add(
+        '$overridesPath overrides "$name" with path "${reference.path}" '
+        'but the package lives at $dir (expected "../$dir").',
+      );
+    }
+  });
+
+  return declared;
+}
+
+/// Compares the computed closure against the declared overrides, both ways.
+void _validateClosureIsOverridden(
+  Set<String> required,
+  Set<String> declared,
+  Map<String, String> workspacePackages,
+  List<String> errors,
+) {
+  final overridesPath = '$_websiteDir/pubspec_overrides.yaml';
+
+  final missing = required.difference(declared).toList()..sort();
+  for (final name in missing) {
+    errors.add(
+      'Workspace package "$name" is reachable from $_websiteDir/pubspec.yaml '
+      'but is not overridden in $overridesPath, so pub resolves it from '
+      'pub.dev and the next release that bumps it breaks `dart pub get` in '
+      '$_websiteDir/. Add:\n'
+      '      $name:\n'
+      '        path: ../${workspacePackages[name]}',
+    );
+  }
+
+  // The reverse direction keeps the list from accumulating dead entries once a
+  // dependency is dropped, which is what let it drift out of sync to begin
+  // with.
+  final unreachable =
+      declared
+          .difference(required)
+          .where(workspacePackages.containsKey)
+          .toList()
+        ..sort();
+  for (final name in unreachable) {
+    errors.add(
+      '$overridesPath overrides "$name", which is no longer reachable from '
+      '$_websiteDir/pubspec.yaml. Remove it.',
+    );
+  }
+}

--- a/website/pubspec_overrides.yaml
+++ b/website/pubspec_overrides.yaml
@@ -6,6 +6,14 @@
 # `format-analyze` down with it, so keep this list complete: `atproto_core`
 # reaches `atproto_oauth`, which reaches `atproto_identity`, which reaches
 # `did_plc`.
+#
+# `scripts/validate_website_overrides.dart` computes that closure from the
+# packages' own pubspecs and fails when this list drifts from it, so run it
+# rather than tracing the graph by hand. Two things that look like fixes and are
+# not: `dependency_overrides:` in `website/pubspec.yaml` is silently ignored
+# while this file exists, and adding a transitive package to `dependencies:` as
+# a path dep only produces a path-vs-hosted source conflict. Entries belong
+# here.
 dependency_overrides:
   at_primitives:
     path: ../packages/at_primitives


### PR DESCRIPTION
`bluesky_text_flutter` has never published from CI. 0.1.3 and 0.1.4 each reached `Publishing ... to https://pub.dev:`, printed `Pub needs your authorization`, and then sat on a `http://localhost:<port>` redirect until the timeout killed the job — three ten-minute failures.

**That redirect is the tell.** A localhost callback cannot reach a runner, so this was never a flow that could succeed; it is the *unauthenticated interactive* path. pub was not being turned away by pub.dev — it had no credential to present.

`id-token: write` only makes an OIDC token **mintable**. Something still has to mint it and hand it to pub. In the Dart job that something is `dart-lang/setup-dart`, whose [`createPubOIDCToken()`](https://github.com/dart-lang/setup-dart/blob/main/lib/main.dart) does exactly this:

```dart
final token = (await core.getIDToken('https://pub.dev').toDart).toDart;
core.exportVariable('PUB_TOKEN', token);
await exec.exec('dart', ['pub', 'token', 'add', 'https://pub.dev', '--env-var', 'PUB_TOKEN']);
```

The Flutter job only ran `subosito/flutter-action`, which installs Flutter and nothing else. So that step never happened, and pub fell straight through to OAuth.

This adds `dart-lang/setup-dart@v1` to the Flutter job and restores `flutter pub publish`. The credential lands in the shared pub config, so `flutter pub` picks it up.

### On the two wrong turns before this

- #2522 switched the command to `dart pub publish` on the theory that the wrapper was not reaching the OIDC exchange. The retry disproved it by failing identically — the command was never the variable.
- Before that I reported pub.dev's "Automated publishing" as unset, on the strength of the workflow's own error text. That text was the step's guess, not pub.dev's answer. **The pub.dev entry for this package was correct throughout**, and the misleading message is gone.

`bluesky_text_flutter` 0.1.3 is tagged at the previous commit and unpublished (pub.dev is on 0.1.2). After merge the tag needs deleting and re-pushing at the merge commit — a real tag push is the only event pub.dev accepts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)