### PR TITLE
fix(ci): unbreak Dart publishing and the feed_generator version pin

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -199,7 +199,7 @@ jobs:
           # status with `||` rather than an `if`: a failing `if` condition with
           # no `else` leaves `$?` at 0, which would report the failure as a
           # successful publish.
-          timeout 10m flutter pub publish --force 2>&1 | tee "$log" || status=$?
+          timeout 10m dart pub publish --force 2>&1 | tee "$log" || status=$?
           if [[ "$status" -eq 0 ]]; then
             exit 0
           fi
@@ -207,7 +207,7 @@ jobs:
           if grep -q 'Pub needs your authorization' "$log"; then
             echo "::error::pub fell back to interactive OAuth, so OIDC publishing was rejected. Enable 'Automated publishing' for '$PACKAGE' on pub.dev (Admin tab -> repository myConsciousness/atproto.dart, tag pattern {{package}}-v{{version}})."
           elif [[ "$status" -eq 124 ]]; then
-            echo "::error::'flutter pub publish' did not finish within 10 minutes and was killed."
+            echo "::error::'dart pub publish' did not finish within 10 minutes and was killed."
           fi
           exit "$status"
 

--- a/templates/feed_generator/pubspec.yaml
+++ b/templates/feed_generator/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: ">=3.8.0 <4.0.0"
 
 dependencies:
-  bluesky: ^2.4.0
+  bluesky: ^2.4.1
   atproto_core: ^2.4.0
   atproto_identity: ^0.2.0
   shelf: ^1.4.0


### PR DESCRIPTION
Two one-line fixes for the CI failures on `main`. They are unrelated in mechanism but both are release blockers today.

## 1. `publish-dart` invokes a Flutter SDK it never installs

`4b1ee40` ("mint the pub.dev OIDC token in the Flutter publish job") set out to fix `publish-flutter`, but edited the command inside `publish-dart` instead, swapping `dart pub publish` for `flutter pub publish`. That job only sets up the Dart SDK via `dart-lang/setup-dart`, so every Dart release since then has died immediately:

```
timeout: failed to run command ‘flutter’: No such file or directory
##[error]Process completed with exit code 127.
```

Four packages are currently tagged with nothing published to pub.dev:

| Tag | pub.dev latest | Repo `version:` |
| --- | --- | --- |
| `bluesky-v2.4.1` | 2.4.0 | 2.4.1 |
| `lexicon-v1.2.5` | 1.2.4 | 1.2.5 |
| `lex_gen-v0.4.6` | 0.4.5 | 0.4.6 |
| `bluesky_cli-v0.6.8` | 0.6.7 | 0.6.8 |

This restores `dart pub publish` in the Dart job and aligns the timeout error message with it. `publish-flutter` keeps `flutter pub publish`, which is correct there because that job installs the Flutter SDK via `subosito/flutter-action`.

## 2. `templates/feed_generator` still pins bluesky 2.4.0

The bluesky 2.4.1 release left the template's constraint behind. The template is a `workspace:` member, so `validate_dependencies.dart` requires its constraint to equal the local version exactly, and the check now fails on every pull request:

```
✗ Found 1 validation errors:
  • Invalid version for bluesky in templates/feed_generator/pubspec.yaml. Expected 2.4.1 but found 2.4.0
```

Observed on both `chore-sync-and-generate` (merged red as #2528) and `dependabot/pub/pub-dependencies-050828`. `atproto_core: ^2.4.0` is still correct and is left alone.

## Verification

No Dart SDK is available in the environment where this was prepared, so the CI commands could not be run directly. Instead:

- The `_validateDevelopingPackages` rule was reproduced against the root pubspec's `workspace:` members — 13 packages, zero version mismatches after the change.
- `publish.yml` was parsed as YAML and both publish steps were read back: `publish-dart` runs `dart pub publish`, `publish-flutter` runs `flutter pub publish`. The only remaining `flutter` reference in the Dart job is its `is_flutter == 'false'` gate.

CI on this PR exercises both fixes for real.

## Releasing the four stranded packages

Not part of this diff, and it can only happen after this merges. Per the procedure documented in `publish.yml`, a `workflow_dispatch` cannot publish because pub.dev rejects OIDC from dispatch events — a real tag push is the only accepted trigger. All four tags currently point at `b1ba965`, which still carries the broken workflow, so they must be deleted and re-created against `main` once this lands. The `prepare` job already checks pub.dev for an existing version, so re-pushing a tag is idempotent.

## Not addressed here

`Verify Generated` is also failing on `dependabot/pub/pub-dependencies-050828`, where a `build_runner`/`freezed` bump legitimately changed generated output. That needs `melos gen` committed on the Dependabot branch and is out of scope for this PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_016ManHiFgPPPqMpshziygZi)_