### PR TITLE
fix(scripts): stop every release leaving the feed_generator template stale

### DIFF
--- a/scripts/gen_changelog.dart
+++ b/scripts/gen_changelog.dart
@@ -14,6 +14,7 @@ import 'gen_changelog/package_mapper.dart';
 import 'gen_changelog/semver.dart';
 import 'gen_changelog/version_planner.dart';
 import 'gen_changelog/writer.dart';
+import 'utils.dart';
 
 const _packagesDir = 'packages';
 
@@ -49,20 +50,56 @@ Map<String, PackagePlan> run({
   );
 }
 
-/// Reads `version:` from every workspace package pubspec.
-Map<String, Version> readCurrentVersions() {
-  final versions = <String, Version>{};
-  for (final dir in Directory(_packagesDir).listSync().whereType<Directory>()) {
-    final pubspec = File('${dir.path}/pubspec.yaml');
+/// Maps package name -> repo-relative directory for every package this script
+/// may touch.
+///
+/// The union of two sources, deliberately:
+///
+///   * the root pubspec's `workspace:` list, the source of truth for workspace
+///     membership and the only place `templates/feed_generator` appears. A
+///     `packages/`-only scan is why the template's constraints on workspace
+///     packages went stale on every release, turning `validate_dependencies`
+///     red on the next pull request until someone edited it by hand; and
+///   * the directories under `packages/`, which additionally cover
+///     `bluesky_text_flutter`. That package is deliberately *not* a workspace
+///     member (it resolves from pub.dev rather than from the local workspace),
+///     but it does track `bluesky_text` and has been bumped here all along.
+Map<String, String> readPackageDirs() {
+  final dirs = <String, String>{};
+
+  for (final dir in [
+    ...workspacePackageDirs,
+    ...Directory(_packagesDir)
+        .listSync()
+        .whereType<Directory>()
+        .map((d) => d.path),
+  ]) {
+    final pubspec = getWorkspacePubspec(dir);
     if (!pubspec.existsSync()) continue;
-    final name = dir.path.split(Platform.pathSeparator).last;
+
+    final name = loadPubspec(pubspec).name;
+    if (name == null) continue;
+    dirs[name] = dir;
+  }
+
+  return dirs;
+}
+
+/// Reads `version:` from every package pubspec in [packageDirs].
+///
+/// Members with `publish_to: none` (the template) carry no `version:` and are
+/// absent from the result, which is what marks them as constraint-only for
+/// [applyUnversionedMembers].
+Map<String, Version> readCurrentVersions(Map<String, String> packageDirs) {
+  final versions = <String, Version>{};
+  for (final entry in packageDirs.entries) {
     final match = RegExp(
       r'^version:\s*(\S+)',
       multiLine: true,
-    ).firstMatch(pubspec.readAsStringSync());
+    ).firstMatch(getWorkspacePubspec(entry.value).readAsStringSync());
     if (match != null) {
       try {
-        versions[name] = Version.parse(match.group(1)!);
+        versions[entry.key] = Version.parse(match.group(1)!);
       } catch (_) {
         // Skip packages with non semver versions.
       }
@@ -93,26 +130,63 @@ Set<String> directDependencyNames(String pubspecContent) {
   return names;
 }
 
-/// Builds a `package -> dependents` map among workspace packages only,
-/// considering runtime `dependencies:` (not `dev_dependencies:`).
-Map<String, List<String>> readDependents() {
-  final packages = Directory(_packagesDir)
-      .listSync()
-      .whereType<Directory>()
-      .map((d) => d.path.split(Platform.pathSeparator).last)
-      .toSet();
-
+/// Builds a `package -> dependents` map across [packageDirs], considering
+/// runtime `dependencies:` (not `dev_dependencies:`).
+Map<String, List<String>> readDependents(Map<String, String> packageDirs) {
   final dependents = <String, List<String>>{};
-  for (final pkg in packages) {
-    final pubspec = File('$_packagesDir/$pkg/pubspec.yaml');
-    if (!pubspec.existsSync()) continue;
-    final deps = directDependencyNames(pubspec.readAsStringSync());
+  for (final entry in packageDirs.entries) {
+    final deps = directDependencyNames(
+      getWorkspacePubspec(entry.value).readAsStringSync(),
+    );
     for (final dep in deps) {
-      if (dep == pkg || !packages.contains(dep)) continue;
-      dependents.putIfAbsent(dep, () => []).add(pkg);
+      if (dep == entry.key || !packageDirs.containsKey(dep)) continue;
+      dependents.putIfAbsent(dep, () => []).add(entry.key);
     }
   }
   return dependents;
+}
+
+/// Points the workspace-package constraints of unpublished members at the
+/// versions those packages will carry after [plans] are applied.
+///
+/// A member with `publish_to: none` has no `version:`, so it never gets a
+/// [PackagePlan] and nothing here bumps it -- but `validate_dependencies.dart`
+/// still requires its constraints to equal the current local versions, so a
+/// release that leaves it behind fails every subsequent pull request.
+///
+/// Falls back to [currentVersions] for dependencies this run did not plan, so
+/// drift left by an earlier release is repaired rather than carried forward.
+/// Returns the members it rewrote.
+List<String> applyUnversionedMembers({
+  required Map<String, PackagePlan> plans,
+  required Map<String, String> packageDirs,
+  required Map<String, Version> currentVersions,
+}) {
+  final planned = {
+    for (final plan in plans.values) plan.package: plan.newVersion,
+  };
+
+  final rewritten = <String>[];
+  for (final entry in packageDirs.entries) {
+    if (currentVersions.containsKey(entry.key)) continue;
+
+    final pubspec = getWorkspacePubspec(entry.value);
+    final content = pubspec.readAsStringSync();
+
+    final updates = <String, Version>{};
+    for (final dep in directDependencyNames(content)) {
+      final version = planned[dep] ?? currentVersions[dep];
+      if (version != null) updates[dep] = version;
+    }
+
+    final updated = syncDependencyRanges(content, updates);
+    if (updated == content) continue;
+
+    pubspec.writeAsStringSync(updated);
+    rewritten.add(entry.key);
+  }
+
+  return rewritten;
 }
 
 String? _argValue(List<String> args, String flag) {
@@ -130,23 +204,35 @@ void main(List<String> args) {
   final oldSnap = loadSnapshotFromGit(base);
   final newSnap = loadSnapshotFromDisk();
 
+  final packageDirs = readPackageDirs();
+  final currentVersions = readCurrentVersions(packageDirs);
+
   final plans = run(
     oldSnap: oldSnap,
     newSnap: newSnap,
-    currentVersions: readCurrentVersions(),
-    dependents: readDependents(),
+    currentVersions: currentVersions,
+    dependents: readDependents(packageDirs),
   );
 
   if (plans.isEmpty) {
     stdout.writeln('gen_changelog: no lexicon changes to record.');
-    return;
   }
 
   for (final plan in plans.values) {
-    applyPlan(plan);
+    applyPlan(plan, packageDirs[plan.package]!);
     stdout.writeln(
       'gen_changelog: ${plan.package} ${plan.oldVersion} -> ${plan.newVersion} '
       '(${plan.changelogLines.length} lines)',
     );
+  }
+
+  // Runs even with no plans: an unpublished member can be stale from an
+  // earlier release, and this is what repairs it.
+  for (final member in applyUnversionedMembers(
+    plans: plans,
+    packageDirs: packageDirs,
+    currentVersions: currentVersions,
+  )) {
+    stdout.writeln('gen_changelog: $member workspace constraints synced');
   }
 }

--- a/scripts/gen_changelog/writer.dart
+++ b/scripts/gen_changelog/writer.dart
@@ -8,22 +8,40 @@ import 'dart:io';
 // Project imports:
 import 'models.dart';
 
-/// Rewrites the `version:` line and any bumped dependency ranges.
-String bumpPubspec(String content, PackagePlan plan) {
+/// Rewrites each `^`-ranged dependency named in [updates] to `^<version>`.
+///
+/// Split out of [bumpPubspec] because two callers need exactly this rewrite:
+/// the version bump of a published package, and the constraint-only sync of an
+/// unpublished workspace member (see `applyUnversionedMembers` in
+/// `gen_changelog.dart`). A second copy of the pattern is how the two drift.
+String syncDependencyRanges(String content, Map<String, Version> updates) {
+  if (updates.isEmpty) return content;
+
   final lines = content.split('\n');
   for (var i = 0; i < lines.length; i++) {
-    final line = lines[i];
-    if (RegExp(r'^version:\s').hasMatch(line)) {
-      lines[i] = 'version: ${plan.newVersion}';
-      continue;
-    }
-    for (final dep in plan.depRangeUpdates.entries) {
+    for (final dep in updates.entries) {
       final match = RegExp(
         '^(\\s+)${RegExp.escape(dep.key)}:\\s*\\^',
-      ).firstMatch(line);
+      ).firstMatch(lines[i]);
       if (match != null) {
         lines[i] = '${match.group(1)}${dep.key}: ^${dep.value}';
       }
+    }
+  }
+  return lines.join('\n');
+}
+
+/// Rewrites the `version:` line and any bumped dependency ranges.
+String bumpPubspec(String content, PackagePlan plan) {
+  final lines = syncDependencyRanges(
+    content,
+    plan.depRangeUpdates,
+  ).split('\n');
+
+  for (var i = 0; i < lines.length; i++) {
+    if (RegExp(r'^version:\s').hasMatch(lines[i])) {
+      lines[i] = 'version: ${plan.newVersion}';
+      break;
     }
   }
   return lines.join('\n');
@@ -55,12 +73,21 @@ String insertChangelog(String content, PackagePlan plan) {
       content.substring(insertAt);
 }
 
-/// Applies [plan] to the package's pubspec and changelog on disk.
-void applyPlan(PackagePlan plan) {
-  final pubspec = File('packages/${plan.package}/pubspec.yaml');
+/// Applies [plan] to the pubspec and changelog of the package at [packageDir].
+///
+/// [packageDir] is passed in rather than built as `packages/<name>`: not every
+/// workspace member lives under `packages/` (`templates/feed_generator` does
+/// not), and hardcoding that prefix is what kept this script from ever reaching
+/// the members that do not.
+void applyPlan(PackagePlan plan, String packageDir) {
+  final pubspec = File('$packageDir/pubspec.yaml');
   pubspec.writeAsStringSync(bumpPubspec(pubspec.readAsStringSync(), plan));
 
-  final changelog = File('packages/${plan.package}/CHANGELOG.md');
+  // Members that ship no changelog (the template) still get their pubspec
+  // rewritten; only the changelog step is skipped.
+  final changelog = File('$packageDir/CHANGELOG.md');
+  if (!changelog.existsSync()) return;
+
   changelog.writeAsStringSync(
     insertChangelog(changelog.readAsStringSync(), plan),
   );

--- a/scripts/gen_changelog/writer_test.dart
+++ b/scripts/gen_changelog/writer_test.dart
@@ -28,6 +28,25 @@ void main() {
     expect(out, contains('  http: ^1.4.0'));
   });
 
+  test('syncDependencyRanges rewrites only the named workspace deps', () {
+    const pubspec =
+        'name: feed_generator\npublish_to: none\ndependencies:\n  bluesky: ^2.4.1\n  atproto_core: ^2.4.0\n  shelf: ^1.4.0\n';
+    final out = syncDependencyRanges(pubspec, {
+      'bluesky': Version.parse('2.4.2'),
+    });
+    expect(out, contains('  bluesky: ^2.4.2'));
+    expect(out, contains('  atproto_core: ^2.4.0'));
+    expect(out, contains('  shelf: ^1.4.0'));
+    // A member with `publish_to: none` carries no `version:` to rewrite, and
+    // this must not invent one.
+    expect(out, isNot(contains('version:')));
+  });
+
+  test('syncDependencyRanges leaves content untouched with no updates', () {
+    const pubspec = 'name: feed_generator\ndependencies:\n  bluesky: ^2.4.1\n';
+    expect(syncDependencyRanges(pubspec, const {}), pubspec);
+  });
+
   test('insertChangelog adds a new section after the header', () {
     const changelog = '# Release Note\n\n## v1.7.1\n\n- old entry\n';
     final out = insertChangelog(changelog, _plan());

--- a/templates/feed_generator/pubspec.yaml
+++ b/templates/feed_generator/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: ">=3.8.0 <4.0.0"
 
 dependencies:
-  bluesky: ^2.4.1
+  bluesky: ^2.4.2
   atproto_core: ^2.4.0
   atproto_identity: ^0.2.0
   shelf: ^1.4.0


### PR DESCRIPTION
`validate_dependencies.dart` was widened to check every `workspace:` member, but the script that bumps versions was never widened to match. The checker and the bumper disagree about which packages exist, so every `bluesky` release leaves `templates/feed_generator` behind and turns CI red on the next pull request until someone edits it by hand — `2.4.0` → `2.4.1` yesterday, `2.4.1` → `2.4.2` today:

```
✗ Found 1 validation errors:
  • Invalid version for bluesky in templates/feed_generator/pubspec.yaml. Expected 2.4.2 but found 2.4.1
```

Currently failing on `chore-sync-and-generate` and `dependabot/pub/pub-dependencies-0508285c`.

## Why the bumper could never reach it

Three `packages/`-only assumptions, all in the release tooling:

| Location | Before |
| --- | --- |
| `gen_changelog.dart` `readCurrentVersions()` | scanned `packages/` |
| `gen_changelog.dart` `readDependents()` | scanned `packages/` |
| `writer.dart` `applyPlan()` | wrote to `packages/<name>/pubspec.yaml` |

`templates/feed_generator` is a `workspace:` member that lives outside `packages/`, so it was never seen as a dependent of `bluesky` — and even with a plan in hand, `applyPlan` had no path that could reach it.

## Changes

**The package list is now the root pubspec's `workspace:` list unioned with the `packages/` scan.** The union is deliberate, not belt-and-braces:

- the `workspace:` list is the only place `templates/feed_generator` appears;
- the `packages/` scan is the only place `bluesky_text_flutter` appears. It is intentionally *not* a workspace member — it resolves from pub.dev rather than the local workspace — but it does track `bluesky_text` and has been bumped by this script all along, so dropping it would be a regression.

**`applyPlan` takes the package directory** instead of rebuilding `packages/<name>`, and skips the changelog step for members that ship no `CHANGELOG.md` (the template).

**Members with `publish_to: none` carry no `version:`**, so they get no plan and no changelog. New `applyUnversionedMembers` rewrites only their workspace-package constraints. It falls back to the current local versions for dependencies a run did not plan, so drift left by an earlier release is repaired rather than carried forward, and it runs even when there are no plans at all.

**`syncDependencyRanges` is split out of `bumpPubspec`** so the version-bump path and the constraint-only path share one implementation of the rewrite instead of keeping two copies of the pattern.

The second commit clears the staleness already on `main`.

## Verification

No Dart SDK was available in the environment where this was prepared, so `dart analyze` and the script's own tests could not be run locally — **CI on this PR is the real check.** What was verified was the data flow, replicated against the checked-in pubspecs:

- `readPackageDirs()` → 16 entries; `feed_generator` → `templates/feed_generator`, `bluesky_text_flutter` → `packages/bluesky_text_flutter` (no regression).
- `readCurrentVersions()` → 15 versioned, `feed_generator` the only unversioned member.
- `readDependents()` → `feed_generator` now appears among `bluesky`'s dependents, where it was previously absent; `bluesky_text` → `[bluesky_cli, bluesky_text_flutter]` unchanged.
- `applyUnversionedMembers()` → given the `^2.4.1` state, rewrites to `^2.4.2`, invents no `version:` line, and leaves non-workspace constraints (`shelf`, `shelf_router`) untouched.
- The `_validateDevelopingPackages` rule → 13 packages, zero mismatches.

Two unit tests for `syncDependencyRanges` are added to `writer_test.dart`, including that a `publish_to: none` pubspec gains no `version:` line.

## Not addressed here

`Verify Generated` is still failing on `dependabot/pub/pub-dependencies-0508285c`, where a `build_runner`/`freezed` bump legitimately changed generated output. That needs `melos gen` committed on the Dependabot branch and is unrelated to this change.

---
_Generated by [Claude Code](https://claude.ai/code/session_016ManHiFgPPPqMpshziygZi)_