### PR TITLE
fix(scripts): import semver in writer.dart to unbreak Sync and Generate

### DIFF
--- a/scripts/gen_changelog/writer.dart
+++ b/scripts/gen_changelog/writer.dart
@@ -7,6 +7,7 @@ import 'dart:io';
 
 // Project imports:
 import 'models.dart';
+import 'semver.dart';
 
 /// Rewrites each `^`-ranged dependency named in [updates] to `^<version>`.
 ///


### PR DESCRIPTION
Sync and Generate has failed on `main` every night since #2531 landed — 07-30, 07-31 and 08-01 — so no lexicon sync has reached the repository for three days.

```
scripts/gen_changelog/writer.dart:17:57: Error: Type 'Version' not found.
String syncDependencyRanges(String content, Map<String, Version> updates) {
                                                        ^^^^^^^
##[error]Process completed with exit code 254.
```

`writer.dart` imports `models.dart` but not `semver.dart`. That was survivable while the file never *named* the type: the old `bumpPubspec` reached versions through `plan.depRangeUpdates` and interpolated them into a string, so inference never required `Version` to be in scope. Splitting `syncDependencyRanges` out put the type in a signature and turned a latent missing import into a compile error.

One line. `writer.dart` was the only file under `scripts/gen_changelog/` that referenced `Version` without importing `semver.dart` — the other six that use it all import it.

## Why CI did not catch this

Nothing in CI compiles `scripts/`:

- `format-analyze` runs `dart format`/`dart analyze` against `$DART_DIRS`, derived from the root pubspec's `workspace:` list. `scripts/` is not a workspace member, so it is not in that list.
- the `test` matrix is built from the same list, so the nine test files under `scripts/` have never run. `writer_test.dart` imports `writer.dart` and would have failed to compile.
- `verify-generated` did run on #2531, because its path filter includes `scripts/gen_*.dart`. But that job runs `melos gen`; it never invokes `gen_changelog.dart`, and `scripts/gen_changelog/writer.dart` does not even match the filter. The green check attested to nothing about the changed code.

Closing that gap needs a CI job rather than a source change, so it is deliberately not in this PR — this one is kept to the single line that restores the nightly job. The follow-up adds a `tooling` job that formats, analyzes and tests `scripts/`, and wires it into the `ci-ok` gate.

## Verification

No Dart SDK was available where this was prepared, so the fix could not be compiled locally. What was checked is that the import is the only thing missing: every other file under `scripts/gen_changelog/` that names `Version` already imports `semver.dart`, and `writer.dart` was the sole exception.

---
_Generated by [Claude Code](https://claude.ai/code/session_016ManHiFgPPPqMpshziygZi)_