### PR TITLE
ci: format, analyze and test the release tooling under scripts/

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -306,6 +306,49 @@ jobs:
           fi
 
   # ---------------------------------------------------------------------------
+  # The release tooling under `scripts/` -- version planning, changelog
+  # generation, dependency validation, lexicon sync -- is not a Dart pub
+  # workspace member, so every Dart-only job above skips it by construction:
+  # `format-analyze` takes the workspace dir list, and the `test` matrix is
+  # built from that same list. The nine `*_test.dart` files under `scripts/`
+  # had therefore never run, and nothing compiled the tooling at all.
+  #
+  # What that cost: a plain `Type 'Version' not found` in
+  # `scripts/gen_changelog/writer.dart` reached main and broke the nightly
+  # Sync and Generate job for three nights (#2532). `verify-generated` had gone
+  # green on the pull request that introduced it -- its path filter matches
+  # `scripts/gen_*.dart`, but the job runs `melos gen` and never invokes the
+  # changelog tooling, so that check attested to nothing about the change.
+  #
+  # Deliberately ungated: the suite is small and fast, and a path filter would
+  # rebuild the same "changed but unchecked" hole this job exists to close.
+  # ---------------------------------------------------------------------------
+  tooling:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: ./.github/actions/setup-dart-cached
+
+      # Asserts the `workspace:` list, the pubspec and the packages on disk
+      # still agree. The callers above run these same assertions as a side
+      # effect of asking for the list; running `--check` here gives a drift a
+      # check name of its own instead of surfacing it as an unrelated failure.
+      - name: Check the workspace package list
+        run: ./scripts/dart_workspace_dirs.sh --check
+
+      # `scripts/` resolves against the root pubspec, which already declares
+      # `test` and `pubspec`, so no extra dependency wiring is needed here.
+      - name: Check format
+        run: dart format --output=none --set-exit-if-changed scripts
+
+      - name: Analyze
+        run: dart analyze scripts
+
+      - name: Run the release tooling tests
+        run: dart test scripts
+
+  # ---------------------------------------------------------------------------
   # Single aggregation gate. `test` and `flutter` are conditional / matrix jobs
   # whose individual check names vary, which makes them awkward to require in
   # branch protection. Requiring this one job instead gives a stable required
@@ -313,7 +356,7 @@ jobs:
   # legitimately skipped (a skipped job is not a failure).
   # ---------------------------------------------------------------------------
   ci-ok:
-    needs: [format-analyze, test, flutter]
+    needs: [format-analyze, tooling, test, flutter]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/scripts/gen_changelog.dart
+++ b/scripts/gen_changelog.dart
@@ -69,10 +69,9 @@ Map<String, String> readPackageDirs() {
 
   for (final dir in [
     ...workspacePackageDirs,
-    ...Directory(_packagesDir)
-        .listSync()
-        .whereType<Directory>()
-        .map((d) => d.path),
+    ...Directory(
+      _packagesDir,
+    ).listSync().whereType<Directory>().map((d) => d.path),
   ]) {
     final pubspec = getWorkspacePubspec(dir);
     if (!pubspec.existsSync()) continue;

--- a/scripts/gen_changelog/writer.dart
+++ b/scripts/gen_changelog/writer.dart
@@ -34,10 +34,7 @@ String syncDependencyRanges(String content, Map<String, Version> updates) {
 
 /// Rewrites the `version:` line and any bumped dependency ranges.
 String bumpPubspec(String content, PackagePlan plan) {
-  final lines = syncDependencyRanges(
-    content,
-    plan.depRangeUpdates,
-  ).split('\n');
+  final lines = syncDependencyRanges(content, plan.depRangeUpdates).split('\n');
 
   for (var i = 0; i < lines.length; i++) {
     if (RegExp(r'^version:\s').hasMatch(lines[i])) {

--- a/scripts/gen_doc_snippets.dart
+++ b/scripts/gen_doc_snippets.dart
@@ -44,12 +44,13 @@ final _openMarker = RegExp(
 void main() {
   final stopwatch = Stopwatch()..start();
 
-  final docs = Directory(_docsRoot)
-      .listSync(recursive: true)
-      .whereType<File>()
-      .where((file) => file.path.endsWith('.md'))
-      .toList()
-    ..sort((a, b) => a.path.compareTo(b.path));
+  final docs =
+      Directory(_docsRoot)
+          .listSync(recursive: true)
+          .whereType<File>()
+          .where((file) => file.path.endsWith('.md'))
+          .toList()
+        ..sort((a, b) => a.path.compareTo(b.path));
 
   final missing = <String>[];
   var injectedCount = 0;


### PR DESCRIPTION
Follow-up to #2532, which fixed a missing import that nothing in CI could have caught. This adds the coverage that was missing.

## The gap

`scripts/` is not a Dart pub workspace member, so every Dart-only job skips it *by construction*:

| Job | How its target is chosen | Covers `scripts/`? |
| --- | --- | --- |
| `format-analyze` | `$DART_DIRS` from `scripts/dart_workspace_dirs.sh`, i.e. the root pubspec's `workspace:` list | no |
| `test` | matrix built from the same list | no |
| `verify-generated` | runs `melos gen` | never invokes the tooling |

Nothing compiled the release tooling — version planning, changelog generation, dependency validation, lexicon sync — and its nine `*_test.dart` files had never run.

## What it cost

A plain compile error reached `main` and broke the nightly Sync and Generate job for three nights:

```
scripts/gen_changelog/writer.dart:17:57: Error: Type 'Version' not found.
```

The absence of a signal would have been bad enough, but the pull request that introduced it went **green**. `verify-generated` triggered because its path filter matches `scripts/gen_*.dart`, yet that job runs `melos gen` and never touches the changelog tooling — and the broken file, `scripts/gen_changelog/writer.dart`, does not even match the filter. The check attested to nothing about the changed code.

#2532 shows the same shape from the other side: `test` and `flutter` both skipped, `verify-generated` did not trigger at all, and `format-analyze` — which does not read `scripts/` — was the only substantive check on a change that lived entirely inside it.

## The change

A `tooling` job that checks the workspace list, then formats, analyzes and tests `scripts/`, required through the existing `ci-ok` gate.

**Ungated on purpose.** The suite is small and fast, and a path filter would rebuild the same "changed but unchecked" hole the job exists to close. This matches `format-analyze`, which is also unconditional.

**No dependency wiring needed.** `scripts/` resolves against the root pubspec, which already declares `test: ^1.26.2` and `pubspec: ^2.3.0`.

**`dart_workspace_dirs.sh --check` gets a home.** Its assertions already run as a side effect whenever a caller asks for the list; invoking `--check` explicitly gives a drift its own check name instead of surfacing it inside an unrelated job.

## Why not make `scripts/` a workspace member

That would fold it into the derived list rather than naming it in the workflow, which fits this repo's "derive, never hardcode" approach better — it is the structurally cleaner answer and worth revisiting. It is not done here because it means adding a pubspec, splitting the dependencies out of the root, and re-resolving how `dart run ./scripts/*.dart` finds its packages. That is not a risk worth taking inside the change that restores the missing coverage in the first place.

## Verification

**This pull request is itself the measurement.** No Dart SDK was available where it was prepared, so whether `scripts/` currently passes `dart format --set-exit-if-changed`, `dart analyze` and `dart test` is genuinely unknown — the code has never been checked by anything. Pre-existing violations are plausible, and if the new job goes red, the fixes belong in this pull request before it merges, not on `main`.

The workflow itself was parsed as YAML and asserted: `tooling` is present with the four expected steps, carries no `needs`/`if` gate, and `ci-ok` now requires `[format-analyze, tooling, test, flutter]`.

---
_Generated by [Claude Code](https://claude.ai/code/session_016ManHiFgPPPqMpshziygZi)_