### PR TITLE
fix(website): raise the brace-expansion override past GHSA-mh99-v99m-4gvg

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -8623,9 +8623,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",

--- a/website/package.json
+++ b/website/package.json
@@ -62,7 +62,7 @@
     "the patched version - `npm ls <pkg>` will then show it with no override."
   ],
   "overrides": {
-    "brace-expansion@<1.1.16": "^1.1.16",
+    "brace-expansion": "^1.1.17",
     "postcss": "^8.5.18",
     "fast-uri": "^3.1.4",
     "sharp": "^0.35.0",


### PR DESCRIPTION
Clears Dependabot alert 168 — the one high-severity advisory on the default branch, and the warning `git push` has been printing on every push.

```
brace-expansion  <1.1.17
Severity: high
brace-expansion: DoS via unbounded expansion length causing an out-of-memory
process crash - https://github.com/advisories/GHSA-mh99-v99m-4gvg
```

## Why the existing override did not cover it

`website/package.json` already overrode this package, but at the previous patch level:

```json
"brace-expansion@<1.1.16": "^1.1.16"
```

That resolves to exactly the version the new advisory covers. Raising the bound to `<1.1.17` did **not** move the lockfile: both `npm install --package-lock-only` and `npm update brace-expansion` left it pinned at 1.1.16. The unkeyed form re-resolved to 1.1.18 and cleared the audit, so that is what this uses.

Dropping the version key also matches the convention documented in the file's own comment block — version-keyed entries exist for packages whose tree contains several majors, and only one major of `brace-expansion` is present here. `npm install` re-resolved the whole tree and produced a single `node_modules/brace-expansion` node, so nothing was forced across a major boundary.

## Diff

Two lines of `package.json`/`package-lock.json` between them:

```diff
-      "version": "1.1.16",
+      "version": "1.1.18",
```

## Verification

```
$ npm audit
found 0 vulnerabilities
```

Verified by re-resolving the lockfile against the registry, **not** by a full `npm ci` and site build. Worth stating plainly: no workflow installs the website's npm dependencies, so nothing in CI exercises this change — the same class of gap that #2533 closed for `scripts/`. The bump is patch-level within one major of a small glob-brace utility, and npm accepted the resolution for the whole tree, but it has not been run through a Docusaurus build.

---
_Generated by [Claude Code](https://claude.ai/code/session_016ManHiFgPPPqMpshziygZi)_