### PR TITLE
refactor(scripts): make the release tooling a workspace member

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -306,22 +306,29 @@ jobs:
           fi
 
   # ---------------------------------------------------------------------------
-  # The release tooling under `scripts/` -- version planning, changelog
-  # generation, dependency validation, lexicon sync -- is not a Dart pub
-  # workspace member, so every Dart-only job above skips it by construction:
-  # `format-analyze` takes the workspace dir list, and the `test` matrix is
-  # built from that same list. The nine `*_test.dart` files under `scripts/`
-  # had therefore never run, and nothing compiled the tooling at all.
+  # Guards the list every other Dart job is derived from.
   #
-  # What that cost: a plain `Type 'Version' not found` in
-  # `scripts/gen_changelog/writer.dart` reached main and broke the nightly
-  # Sync and Generate job for three nights (#2532). `verify-generated` had gone
-  # green on the pull request that introduced it -- its path filter matches
-  # `scripts/gen_*.dart`, but the job runs `melos gen` and never invokes the
-  # changelog tooling, so that check attested to nothing about the change.
+  # The release tooling under `scripts/` used to be checked here explicitly,
+  # because it was not a workspace member and so was skipped by construction:
+  # `format-analyze` takes the workspace dir list and the `test` matrix is built
+  # from that same list. That is what let a plain `Type 'Version' not found`
+  # reach main and break Sync and Generate for three nights (#2532).
   #
-  # Deliberately ungated: the suite is small and fast, and a path filter would
-  # rebuild the same "changed but unchecked" hole this job exists to close.
+  # `scripts/` is now a workspace member, so `format-analyze` reaches it the
+  # same way it reaches every other package. Naming it there again would be the
+  # second hardcoded copy `dart_workspace_dirs.sh` exists to prevent, so the
+  # format and analyze steps are gone from here.
+  #
+  # The test step is NOT redundant and must stay. The matrix job runs
+  # `dart test` only `if test -d "test"`, and this package keeps its tests
+  # beside the sources (`gen_changelog/writer_test.dart`, not
+  # `test/writer_test.dart`), so `test (scripts)` skips and all 44 of them
+  # would go unrun again.
+  #
+  # Also keeps the drift assertion. `dart_workspace_dirs.sh` runs it as a side
+  # effect whenever a caller asks for the list; running `--check` on its own
+  # gives a drift its own check name instead of surfacing it inside an
+  # unrelated job.
   # ---------------------------------------------------------------------------
   tooling:
     runs-on: ubuntu-latest
@@ -330,20 +337,8 @@ jobs:
 
       - uses: ./.github/actions/setup-dart-cached
 
-      # Asserts the `workspace:` list, the pubspec and the packages on disk
-      # still agree. The callers above run these same assertions as a side
-      # effect of asking for the list; running `--check` here gives a drift a
-      # check name of its own instead of surfacing it as an unrelated failure.
       - name: Check the workspace package list
         run: ./scripts/dart_workspace_dirs.sh --check
-
-      # `scripts/` resolves against the root pubspec, which already declares
-      # `test` and `pubspec`, so no extra dependency wiring is needed here.
-      - name: Check format
-        run: dart format --output=none --set-exit-if-changed scripts
-
-      - name: Analyze
-        run: dart analyze scripts
 
       - name: Run the release tooling tests
         run: dart test scripts

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,13 +19,12 @@ workspace:
   - packages/lexicon
   - packages/multiformats
   - packages/xrpc
+  # The repository automation. A workspace member like any other, so the
+  # derived package list carries it into format, analyze and test instead of
+  # each job naming it. Its dependencies used to live here, on the root
+  # package, where nothing could see that they belonged to `scripts/`.
+  - scripts
   - templates/feed_generator
-
-dependencies:
-  github: ^9.12.0
-  http: ^1.4.0
-  pubspec: ^2.3.0
-  test: ^1.26.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/scripts/dart_workspace_dirs.sh
+++ b/scripts/dart_workspace_dirs.sh
@@ -15,7 +15,8 @@
 # drift impossible rather than merely detectable.
 #
 # Note the entries are FULL repo-relative paths, not bare package names: not every
-# workspace member lives under `packages/` (`templates/feed_generator` does not).
+# workspace member lives under `packages/` (`templates/feed_generator` and `scripts`
+# do not).
 #
 # The Flutter package (`packages/bluesky_text_flutter`) is deliberately NOT a
 # workspace member — it needs the Flutter SDK and has its own CI job — so it never
@@ -85,7 +86,8 @@ while IFS= read -r candidate; do
 done < <(
   cd "$REPO_ROOT"
   grep -l '^resolution:[[:space:]]*workspace[[:space:]]*$' \
-    packages/*/pubspec.yaml templates/*/pubspec.yaml 2>/dev/null |
+    packages/*/pubspec.yaml templates/*/pubspec.yaml scripts/pubspec.yaml \
+    2>/dev/null |
     sed 's:/pubspec\.yaml$::' | sort
 )
 

--- a/scripts/pubspec.yaml
+++ b/scripts/pubspec.yaml
@@ -1,0 +1,18 @@
+name: atproto_dart_scripts
+description: Repository automation for atproto.dart - lexicon sync, code generation, changelog and version planning, dependency validation.
+publish_to: none
+resolution: workspace
+
+environment:
+  sdk: ">=3.8.0 <4.0.0"
+
+dependencies:
+  github: ^9.12.0
+  http: ^1.4.0
+  lex_gen: ^0.4.7
+  lexicon: ^1.2.6
+  pubspec: ^2.3.0
+  test: ^1.26.2
+
+dev_dependencies:
+  lints: ^6.0.0


### PR DESCRIPTION
Follow-up to #2533, which gave `scripts/` its missing CI coverage by naming it in a job. That worked, but it is the exact shape `dart_workspace_dirs.sh` was written to eliminate — a second hardcoded package list beside the derived one, free to drift from it. Its own header says so:

> Both copies silently drifted from `pubspec.yaml`'s `workspace:` list, and `atproto_identity` + `templates/feed_generator` ended up never being tested, formatted or analyzed by CI. Deriving the list at runtime makes that class of drift impossible rather than merely detectable.

## Changes

**`scripts/` becomes a workspace member.** New `scripts/pubspec.yaml`, listed in the root `workspace:`. `format-analyze` and the change-detection matrix now reach it the way they reach every other package.

**The dependencies move with it.** `github`, `http`, `pubspec` and `test` sat on the root package — which has no `lib/`, no `test/`, and existed only to host them, so nothing recorded that they belonged to `scripts/`.

**Four lint infos disappear.** Declaring `lexicon` and `lex_gen` clears the `depend_on_referenced_packages` reports: they resolved through the workspace but were never declared by the package importing them. `dart analyze` over the whole workspace goes from 5 issues to 1.

**The `tooling` job loses two steps and keeps two:**

| Step | Fate |
| --- | --- |
| `dart format scripts` | removed — `format-analyze` covers it through the derived list |
| `dart analyze scripts` | removed — same |
| `dart test scripts` | **kept** |
| `dart_workspace_dirs.sh --check` | kept |

The test step is not redundant, and measuring is what showed it. The matrix job runs `dart test` only `if test -d "test"`, and this package keeps its tests beside the sources (`gen_changelog/writer_test.dart`, not `test/writer_test.dart`), so `test (scripts)` skips and all 44 would go unrun again. Removing it on the assumption that membership covered everything would have quietly undone #2533.

**The drift guard now covers the new member.** `dart_workspace_dirs.sh`'s reverse check scans `scripts/pubspec.yaml` as well, so dropping `scripts` from the workspace list is caught rather than silently uncovering it.

## Verification

Run against a real Dart SDK 3.12.2 — the same version CI uses — rather than reasoned about:

```
./scripts/dart_workspace_dirs.sh --check    OK: 16 packages, pubspec.yaml and disk agree
dart format --set-exit-if-changed $DIRS     exit 0
dart analyze $DIRS                          1 issue found (was 5)
dart test scripts                           +44: All tests passed!
dart run ./scripts/validate_dependencies.dart       ✓ 14 packages
dart run ./scripts/validate_website_overrides.dart  ✓ 11 packages
dart run ./scripts/gen_changelog.dart --base <ref>  planned 5 bumps
```

The invocation path was the main risk — every workflow calls these as `dart run ./scripts/*.dart` from the repo root, and membership changes how that resolves. All four still run from the root unchanged.

The remaining analyzer issue is `curly_braces_in_flow_control_structures` in `version_planner.dart:103`, pre-existing and left for a follow-up.

## Why this is safe now and was not before

The scripts package carries no `version:`, so on release `applyUnversionedMembers` from #2531 syncs its `lexicon`/`lex_gen` constraints exactly as it does the feed_generator template. Confirmed in the `gen_changelog` run above:

```
gen_changelog: atproto_dart_scripts workspace constraints synced
gen_changelog: feed_generator workspace constraints synced
```

Without #2531 this change would have created a *new* recurring failure — a workspace member whose constraints go stale on every release and turn `validate_dependencies` red. It is maintenance-free only because that landed first.

---
_Generated by [Claude Code](https://claude.ai/code/session_016ManHiFgPPPqMpshziygZi)_