### PR TITLE
style(scripts): brace the changelog-line refresh in version_planner

### DIFF
--- a/scripts/gen_changelog/version_planner.dart
+++ b/scripts/gen_changelog/version_planner.dart
@@ -99,9 +99,10 @@ Map<String, PackagePlan> planVersions({
           final idx = draft.lines.indexWhere(
             (l) => l.startsWith('chore: bump `$pkg` to '),
           );
-          if (idx >= 0)
+          if (idx >= 0) {
             draft.lines[idx] =
                 'chore: bump `$pkg` to `^${producer.newVersion}`';
+          }
         }
       }
     }


### PR DESCRIPTION
The last analyzer report left in the workspace:

```
info - scripts/gen_changelog/version_planner.dart:103:13
       Statements in an if should be enclosed in a block.
       Try wrapping the statement in a block.
       - curly_braces_in_flow_control_structures
```

It survived because nothing analyzed `scripts/` until #2533. The four `depend_on_referenced_packages` reports beside it went away in #2536, when the package started declaring `lexicon` and `lex_gen` instead of reaching them through the workspace. This is the remainder of that set of five.

Braces only — the guarded statement is unchanged.

## Verification

Run against Dart SDK 3.12.2, the version CI uses, over the full derived package list:

```
$ dart analyze $(./scripts/dart_workspace_dirs.sh)
Analyzing at_primitives, atproto, atproto_core, atproto_identity, atproto_oauth,
atproto_test, bluesky, bluesky_cli, bluesky_text, did_plc, lex_gen, lexicon,
multiformats, xrpc, scripts, feed_generator...
No issues found!

$ dart format --output=none --set-exit-if-changed $(./scripts/dart_workspace_dirs.sh)
exit 0

$ dart test scripts
+44: All tests passed!
```

## Follow-up this makes possible

With the workspace at zero analyzer reports, `dart analyze --fatal-infos` becomes viable — today infos are non-fatal, which is how this one sat unnoticed. That is a policy change affecting every future pull request (a new lint from an SDK upgrade would turn CI red on unrelated work), so it is left as a separate decision rather than folded in here.

---
_Generated by [Claude Code](https://claude.ai/code/session_016ManHiFgPPPqMpshziygZi)_