### PR TITLE
fix(website): raise the fast-uri override past GHSA-7p8r-x3mc-p8w7

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -13036,9 +13036,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",

--- a/website/package.json
+++ b/website/package.json
@@ -64,7 +64,7 @@
   "overrides": {
     "brace-expansion": "^1.1.17",
     "postcss": "^8.5.18",
-    "fast-uri": "^3.1.4",
+    "fast-uri": "^3.1.5",
     "sharp": "^0.35.0",
     "svgo@3.x": "^3.3.4",
     "dompurify": "^3.4.12",


### PR DESCRIPTION
A high-severity advisory published today. `main` is affected right now.

```
fast-uri  3.0.0 - 3.1.4
Severity: high
fast-uri vulnerable to host confusion via backslash authority introducer
https://github.com/advisories/GHSA-7p8r-x3mc-p8w7
```

Same shape as #2535: `website/package.json` already overrode this package, but pinned `^3.1.4` — **exactly the top of the range the advisory covers**. `npm audit` was clean this morning; the advisory landed since.

`fast-uri` is transitive — `@docusaurus/core` → `@docusaurus/bundler` → `babel-loader` → `schema-utils` → `ajv` — so the override is the only way to reach a patched version. `ajv` requires `fast-uri ^3.0.1`, so this stays inside 3.x rather than taking 4.x, and resolves to 3.1.5.

## Verification

```
$ npm audit
found 0 vulnerabilities

$ node -e "…" package-lock.json
[('node_modules/fast-uri', '3.1.5')]
```

Verified by re-resolving the lockfile against the registry. As with #2535 and #2539: no workflow installs the website's npm dependencies, so nothing in CI exercises this change.

## Note on the recurring pattern

This is the second time in one day that an override pinned to `^<latest>` became the vulnerable version when a new advisory landed. A `^` override tracks patches within the minor, so it self-heals *if* the fix ships as a patch above the pin — `^3.1.4` would have picked up 3.1.5 on its own had the lockfile been re-resolved. What actually keeps these stale is that nothing re-resolves the website lockfile on a schedule except Dependabot's weekly npm run, and its pull requests have been blocked on unrelated grounds. Worth considering separately from this fix.

---
_Generated by [Claude Code](https://claude.ai/code/session_016ManHiFgPPPqMpshziygZi)_