### PR TITLE
fix(website): raise the dompurify override past GHSA-55q2-fjhq-7xh7

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -12516,9 +12516,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.12",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
-      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
+      "version": "3.4.13",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.13.tgz",
+      "integrity": "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"

--- a/website/package.json
+++ b/website/package.json
@@ -66,7 +66,7 @@
     "fast-uri": "^3.1.5",
     "sharp": "^0.35.0",
     "svgo@3.x": "^3.3.4",
-    "dompurify": "^3.4.12",
+    "dompurify": "^3.4.13",
     "immutable": "^4.3.9",
     "js-yaml@3.x": "^3.15.0",
     "js-yaml@4.x": "^4.3.1",


### PR DESCRIPTION
Found during a full-workspace diagnosis sweep. A moderate advisory published since #2550 merged this morning:

```
dompurify  <=3.4.12
Severity: moderate
DOMPurify: IN_PLACE hook removal leaves a detached subtree executable, causing XSS
https://github.com/advisories/GHSA-55q2-fjhq-7xh7
```

The override sat at `^3.4.12` — the top of the vulnerable range. **Fourth occurrence of this exact shape in three days**, after `brace-expansion` (#2535), `fast-uri` (#2545) and `js-yaml` (#2550). Raised to `^3.4.13`.

## Verification

dompurify is mermaid's runtime sanitizer, so this was verified by rendering, not just building:

| check | result |
| --- | --- |
| `npm ci` / `npm run build` | exit 0 |
| `npm test` | 5 failed / 4179 passed / 4184 — identical to `main` |
| browser, built site | mermaid diagram renders: 1 svg, 14 nodes, no page errors |

## Known and deliberately not fixed here

`image-size` (high, GHSA-w3rx-r6r6-pgpr + GHSA-5p2g-fcmc-qvqq — DoS via crafted ICNS/JXL/HEIF images) flags **every released version including latest 2.0.2**, transitively under `@docusaurus/mdx-loader`. There is no version to override to, so an override entry would be a lie. Build-time only, and the images it sizes are repo-committed rather than user-supplied, so practical exposure is low. Revisit when image-size ships a fix.

---
_Generated by [Claude Code](https://claude.ai/code/session_016ManHiFgPPPqMpshziygZi)_