### PR TITLE
fix(atproto_oauth): validate the authorization-server host against SSRF

### DIFF
--- a/packages/atproto_core/pubspec.yaml
+++ b/packages/atproto_core/pubspec.yaml
@@ -27,7 +27,7 @@ dependencies:
   json_annotation: ^4.9.0
   cbor: ^6.3.7
   multiformats: ^1.4.0
-  atproto_oauth: ^0.6.0
+  atproto_oauth: ^0.7.0
   nanoid: ^1.0.0
   meta: ^1.17.0
 

--- a/packages/atproto_identity/CHANGELOG.md
+++ b/packages/atproto_identity/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Note
 
+## v0.3.0
+
+- **feat**: added `ensureNonReservedHost`, which applies the same SSRF host policy `HttpIdentityResolver` uses for a PDS endpoint — reject `localhost` and IP literals in loopback, private, link-local, CGNAT, unique-local, multicast, unspecified, or reserved ranges (unless `allowPrivateNetwork`), with the same IP-literal-only limitation. Exposed so a caller that derives a further network target from resolver output can hold it to the same bar; `atproto_oauth` uses it to vet the authorization server taken from PDS metadata.
+
 ## v0.2.0
 
 - security: bounded the accepted `publicKeyMultibase` length, closing an unauthenticated quadratic-CPU denial of service. `verifyServiceAuth` decodes the issuer's signing key *before* it verifies the signature, and base58btc decoding is O(n^2), so a DID document declaring a ~512,000-character key (small enough to fit under the resolver's 512 KiB response cap) froze the isolate for minutes on a single unauthenticated request. `signingKeyOf` now throws an `IdentityException` above the new `maxPublicKeyMultibaseLength` (256 characters; a real secp256k1 / P-256 Multikey is 49), and `verifyServiceAuth` re-checks the bound on whatever the `IdentityResolver` returns, since that interface is caller-implementable.

--- a/packages/atproto_identity/lib/src/identity/identity_resolver.dart
+++ b/packages/atproto_identity/lib/src/identity/identity_resolver.dart
@@ -686,6 +686,50 @@ bool _isProhibitedIpv6(final List<int> b) {
       b[0] == 0xff; // ff00::/8 multicast
 }
 
+/// Holds [host] to the same SSRF policy [HttpIdentityResolver] applies to a PDS
+/// endpoint, returning the normalized host on success and throwing an
+/// [IdentityException] otherwise.
+///
+/// Exposed so a caller that derives a *further* network target from resolver
+/// output can hold it to the same bar. The motivating case is OAuth: the PDS a
+/// handle resolves to is host-checked by the resolver, but the authorization
+/// server taken from that PDS's `oauth-protected-resource` metadata (RFC 9728)
+/// is attacker-influenced too, and without this check points the client's
+/// DPoP-signed requests at whatever host the metadata names — a blind SSRF into
+/// internal services.
+///
+/// Rejects `localhost` and IP literals in loopback, private, link-local,
+/// carrier-grade NAT, unique-local, multicast, unspecified, or otherwise
+/// reserved ranges, unless [allowPrivateNetwork] is set. Like the resolver,
+/// only IP *literals* are range-checked — no DNS is resolved (web/WASM
+/// limitation), so pair this with egress controls for defense in depth. [what]
+/// names the host in error messages.
+String ensureNonReservedHost(
+  final String host, {
+  final bool allowPrivateNetwork = false,
+  final String what = 'host',
+}) {
+  final normalized = _normalizeHostname(host, what: what);
+
+  if (allowPrivateNetwork) return normalized;
+
+  if (normalized == 'localhost' || normalized.endsWith('.localhost')) {
+    throw IdentityException(
+      '$what "$normalized" resolves to the local host and is rejected '
+      '(set allowPrivateNetwork: true to permit private-network hosts)',
+    );
+  }
+  if (_isProhibitedIpLiteral(normalized)) {
+    throw IdentityException(
+      '$what "$normalized" is a private, loopback, link-local, multicast, '
+      'or otherwise reserved IP literal and is rejected '
+      '(set allowPrivateNetwork: true to permit private-network hosts)',
+    );
+  }
+
+  return normalized;
+}
+
 /// Parses a user-supplied host or URL into an `https`/`http` [Uri]. A bare
 /// hostname is treated as `https://<host>`.
 Uri _parseHttpOrigin(final String input, {required final String what}) {

--- a/packages/atproto_identity/pubspec.yaml
+++ b/packages/atproto_identity/pubspec.yaml
@@ -1,7 +1,7 @@
 name: atproto_identity
 resolution: workspace
 description: AT Protocol identity resolution (handle/DID) and inbound service-auth JWT verification for Dart/Flutter.
-version: 0.2.0
+version: 0.3.0
 homepage: https://atprotodart.com
 repository: https://github.com/myConsciousness/atproto.dart/tree/main/packages/atproto_identity
 issue_tracker: https://github.com/myConsciousness/atproto.dart/issues

--- a/packages/atproto_identity/test/src/identity/http_identity_resolver_test.dart
+++ b/packages/atproto_identity/test/src/identity/http_identity_resolver_test.dart
@@ -786,4 +786,51 @@ void main() {
       expect(requests, lessThan(10));
     });
   });
+  group('ensureNonReservedHost (shared SSRF host policy)', () {
+    for (final host in const [
+      'localhost',
+      'sub.localhost',
+      '127.0.0.1',
+      '10.0.0.5',
+      '169.254.169.254',
+      '172.16.0.1',
+      '192.168.1.1',
+      '::1',
+      '[::1]',
+      '::ffff:10.0.0.5',
+      '2130706433',
+      '0177.0.0.1',
+      '127.1',
+    ]) {
+      test('rejects $host', () {
+        expect(
+          () => ensureNonReservedHost(host, what: 'test host'),
+          throwsA(isA<IdentityException>()),
+        );
+      });
+    }
+
+    for (final host in const [
+      'bsky.social',
+      'as.example.com',
+      'public.api.bsky.app',
+      '8.8.8.8',
+      '1.1.1.1',
+    ]) {
+      test('accepts $host', () {
+        expect(ensureNonReservedHost(host), isNotEmpty);
+      });
+    }
+
+    test('normalizes case and a trailing FQDN dot', () {
+      expect(ensureNonReservedHost('AS.Example.COM.'), 'as.example.com');
+    });
+
+    test('allowPrivateNetwork: true permits a private literal', () {
+      expect(
+        ensureNonReservedHost('10.0.0.5', allowPrivateNetwork: true),
+        '10.0.0.5',
+      );
+    });
+  });
 }

--- a/packages/atproto_oauth/CHANGELOG.md
+++ b/packages/atproto_oauth/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release Note
 
+## v0.7.0
+
+- **security**: the authorization server discovered from a PDS's `oauth-protected-resource` metadata (RFC 9728) is now held to the same SSRF host policy the identity resolver applies to the PDS itself. The PDS host was validated, but the `authorization_servers` entry — attacker-influenced, since it comes from a PDS reached via an attacker-supplied handle — was taken verbatim (only `isAbsolute` was checked). An entry such as `https://10.0.0.5:9200` or `https://169.254.169.254` would direct the client's DPoP-signed PAR/token requests at an internal host: a blind SSRF. The AS host is now rejected unless it is an https bare origin on a non-reserved host, mirroring the PDS check.
+- **feat**: `OAuthClient` accepts `allowPrivateNetwork` (default `false`), applied to both the default identity resolver and the authorization-server host check, so a development deployment can opt private-network hosts back in.
+
 ## v0.6.0
 
 - fix: `OAuthSessionManager.refreshOnUnauthorized` accepts the access token the failed request actually carried, and skips the refresh when it has already been rotated past. The single flight only coalesces requests that overlap an in-progress refresh; a request already on the wire with the superseded token 401s afterwards, and each such response used to chain another rotation — spending an unused refresh token and emitting an `onSessionUpdated` the owner has to persist. A stale `401` is now simply retried with the current session.

--- a/packages/atproto_oauth/lib/src/oauth_client.dart
+++ b/packages/atproto_oauth/lib/src/oauth_client.dart
@@ -145,13 +145,19 @@ final class OAuthClient {
     final DPoPNonceCache? nonceCache,
     final DPoPSigner? signer,
     final http.Client? httpClient,
+    final bool allowPrivateNetwork = false,
   }) : _identityResolver =
-           identityResolver ?? HttpIdentityResolver(httpClient: httpClient),
+           identityResolver ??
+           HttpIdentityResolver(
+             httpClient: httpClient,
+             allowPrivateNetwork: allowPrivateNetwork,
+           ),
        _stateStore = stateStore ?? InMemoryOAuthStateStore(),
        _sessionStore = sessionStore ?? InMemoryOAuthSessionStore(),
        _nonceCache = nonceCache ?? InMemoryDPoPNonceCache(),
        _signer = signer ?? const PointyCastleDPoPSigner(),
-       _httpClient = httpClient;
+       _httpClient = httpClient,
+       _allowPrivateNetwork = allowPrivateNetwork;
 
   /// Client metadata to be used during authentication.
   final OAuthClientMetadata metadata;
@@ -172,6 +178,11 @@ final class OAuthClient {
   ///
   /// When `null`, the default top-level `package:http` functions are used.
   final http.Client? _httpClient;
+
+  /// Whether the client may reach private-network hosts. Applied both to the
+  /// default identity resolver and to the authorization-server host derived
+  /// from PDS metadata; defaults to `false` (blind SSRF protection).
+  final bool _allowPrivateNetwork;
 
   /// Maximum number of `use_dpop_nonce` retries per request (RFC 9449
   /// Section 8). A well-behaved server needs at most one retry; the hard cap
@@ -802,7 +813,7 @@ final class OAuthClient {
   /// (RFC 9728), reads the first entry of `authorization_servers`, and
   /// returns it as an absolute [Uri]. Used by [authorize] to discover the
   /// authorization server (entryway) for a given PDS.
-  static Future<Uri> _resolveAuthorizationServer(
+  Future<Uri> _resolveAuthorizationServer(
     final String pdsOrigin,
     final http.Client? httpClient,
   ) async {
@@ -841,6 +852,39 @@ final class OAuthClient {
       throw OAuthException(
         'Protected resource metadata at "$metadataUri" declares an invalid '
         'authorization server: "$first"',
+      );
+    }
+
+    //* The PDS this metadata came from was host-checked by the identity
+    //* resolver, but its `authorization_servers` entry is attacker-influenced
+    //* and, unchecked, would point the client's DPoP-signed PAR/token requests
+    //* at whatever host it names — a blind SSRF into internal services. Hold
+    //* the AS to the same policy the resolver applies to a PDS: an https bare
+    //* origin whose host is not private/loopback/reserved.
+    if (!serverUri.isScheme('https') && !_allowPrivateNetwork) {
+      throw OAuthException(
+        'Protected resource metadata at "$metadataUri" declares a non-https '
+        'authorization server: "$first"',
+      );
+    }
+    if (serverUri.userInfo.isNotEmpty ||
+        serverUri.hasQuery ||
+        serverUri.hasFragment) {
+      throw OAuthException(
+        'Protected resource metadata at "$metadataUri" declares an '
+        'authorization server that is not a bare origin: "$first"',
+      );
+    }
+    try {
+      ensureNonReservedHost(
+        serverUri.host,
+        allowPrivateNetwork: _allowPrivateNetwork,
+        what: 'authorization server host',
+      );
+    } on IdentityException catch (e) {
+      throw OAuthException(
+        'Protected resource metadata at "$metadataUri" declares an '
+        'authorization server on a rejected host: ${e.message}',
       );
     }
 

--- a/packages/atproto_oauth/pubspec.yaml
+++ b/packages/atproto_oauth/pubspec.yaml
@@ -1,7 +1,7 @@
 name: atproto_oauth
 resolution: workspace
 description: Provides tools to handle OAuth for AT Protocol and Bluesky Social.
-version: 0.6.0
+version: 0.7.0
 homepage: https://atprotodart.com
 repository: https://github.com/myConsciousness/atproto.dart/tree/main/packages/atproto_oauth
 issue_tracker: https://github.com/myConsciousness/atproto.dart/issues
@@ -17,7 +17,7 @@ topics:
   - oauth
 
 dependencies:
-  atproto_identity: ^0.2.0
+  atproto_identity: ^0.3.0
   http: ^1.4.0
   crypto: ^3.0.6
   freezed_annotation: ^3.1.0

--- a/packages/atproto_oauth/test/src/oauth_client_test.dart
+++ b/packages/atproto_oauth/test/src/oauth_client_test.dart
@@ -1312,6 +1312,107 @@ void main() {
     });
   });
 
+  group('authorization-server host SSRF policy', () {
+    // The PDS is host-checked by the resolver, but its `authorization_servers`
+    // entry is attacker-influenced. Point it at hosts a browser would never let
+    // a page reach and assert `authorize` refuses before issuing any AS request.
+    Future<Uri> authorizeWithAsOrigin(
+      final String asOrigin, {
+      final bool allowPrivateNetwork = false,
+    }) async {
+      final client = OAuthClient(
+        _metadata(),
+        signer: _StubSigner(),
+        allowPrivateNetwork: allowPrivateNetwork,
+        httpClient: MockClient((r) async {
+          // Same identity routing as _identityRoute, but the protected-resource
+          // metadata advertises the injected AS origin instead of _origin.
+          if (r.url.host == 'public.api.bsky.app' &&
+              r.url.path == '/xrpc/com.atproto.identity.resolveHandle') {
+            return _json({'did': _sub});
+          }
+          if (r.url.host == 'plc.directory' && r.url.path == '/$_sub') {
+            return _json(_didDoc());
+          }
+          if (r.url.host == 'pds.example' &&
+              r.url.path == '/.well-known/oauth-protected-resource') {
+            return _json({
+              'authorization_servers': [asOrigin],
+            });
+          }
+          // Anything reaching the AS host at all is a policy failure: the guard
+          // must fire before a request leaves for it.
+          return http.Response('unexpected', 500);
+        }),
+      );
+      return client.authorize(_handle);
+    }
+
+    for (final host in const [
+      'http://127.0.0.1', // loopback
+      'https://127.0.0.1', // loopback, https
+      'https://10.0.0.5:9200', // private, the audit's example
+      'https://169.254.169.254', // link-local (cloud metadata)
+      'https://[::1]', // IPv6 loopback
+      'https://[::ffff:10.0.0.5]', // IPv4-mapped private
+      'https://2130706433', // inet_aton loopback spelling
+      'https://localhost:9200', // localhost by name
+    ]) {
+      test('rejects an authorization server at $host', () async {
+        await expectLater(
+          () => authorizeWithAsOrigin(host),
+          throwsA(isA<OAuthException>()),
+        );
+      });
+    }
+
+    test('rejects a non-bare-origin authorization server', () async {
+      await expectLater(
+        () => authorizeWithAsOrigin('https://as.example/path?q=1'),
+        throwsA(isA<OAuthException>()),
+      );
+    });
+
+    test('still accepts a public https authorization server', () async {
+      // Control: a legitimate public AS resolves and reaches PAR.
+      final client = OAuthClient(
+        _metadata(),
+        signer: _StubSigner(),
+        httpClient: MockClient((r) async {
+          final id = _identityRoute(r);
+          if (id != null) return id;
+          if (_isWellKnown(r)) return _json(_serverMetadataDoc());
+          if (_isPar(r)) {
+            return _json({
+              'request_uri': 'urn:ietf:params:oauth:request_uri:xyz',
+            }, status: 201);
+          }
+          return http.Response('unexpected', 500);
+        }),
+      );
+      final url = await client.authorize(_handle);
+      expect(url.path, '/oauth/authorize');
+    });
+
+    test('allowPrivateNetwork: true opts a private AS back in', () async {
+      // With the escape hatch on, a private AS is permitted; it then fails only
+      // because the mock serves no metadata for it, not on the host policy.
+      await expectLater(
+        () => authorizeWithAsOrigin(
+          'https://10.0.0.5:9200',
+          allowPrivateNetwork: true,
+        ),
+        throwsA(
+          isA<OAuthException>().having(
+            (e) => e.message,
+            'message',
+            isNot(contains('rejected host')),
+          ),
+        ),
+      );
+    });
+  });
+
   group('scope validation (atproto profile)', () {
     Future<OAuthSession> exchangeWithScope(final String? scope) async {
       final stateStore = InMemoryOAuthStateStore();

--- a/packages/bluesky/pubspec.yaml
+++ b/packages/bluesky/pubspec.yaml
@@ -38,6 +38,6 @@ dev_dependencies:
 
   atproto_test:
     path: ../atproto_test
-  atproto_oauth: ^0.6.0
+  atproto_oauth: ^0.7.0
   http: any
   fake_async: ^1.3.3

--- a/templates/feed_generator/pubspec.yaml
+++ b/templates/feed_generator/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 dependencies:
   bluesky: ^2.4.5
   atproto_core: ^2.4.0
-  atproto_identity: ^0.2.0
+  atproto_identity: ^0.3.0
   shelf: ^1.4.0
   shelf_router: ^1.1.0
 


### PR DESCRIPTION
Surfaced by a parallel security audit of the OAuth/identity packages. Confirmed by tracing the path end to end and reproduced with the regression tests below.

## The hole

`OAuthClient.authorize(identity)`:

1. resolves the handle to a PDS whose host **is** checked — `HttpIdentityResolver` rejects a PDS on a private/loopback/link-local/reserved range before any request (the ~200-line SSRF defense);
2. GETs that PDS's `/.well-known/oauth-protected-resource` (RFC 9728) and takes `authorization_servers[0]` **verbatim** — the only validation was `isAbsolute`;
3. sends its DPoP-signed PAR and token requests to the authority derived from it.

Step 2's value is attacker-influenced: the PDS was reached via an attacker-supplied handle, so it can return whatever AS it likes.

## The attack

Steer a victim's `authorize` to a PDS that returns:

```json
{"authorization_servers": ["https://10.0.0.5:9200"]}
```

or `https://169.254.169.254` (the cloud metadata address). The client then issues authenticated https requests into internal services — a **blind SSRF**, the exact class the resolver prevents for the PDS, bypassed via the AS one hop later. Medium severity: https-only and the response isn't reflected, so it's an internal-service oracle plus attacker-directed POSTs.

## The fix

Hold the AS host to the same bar as the PDS, reusing the *same* policy rather than a second copy:

- **`atproto_identity`** exposes `ensureNonReservedHost`, factored out of the resolver's own `_checkHost` — it reuses `_normalizeHostname` + `_isProhibitedIpLiteral`, so there is one implementation of the host policy, not two that can drift.
- **`atproto_oauth`** `_resolveAuthorizationServer` now requires the AS to be an https **bare origin** on a **non-reserved host**, and translates a rejection into `OAuthException`.
- **`OAuthClient`** gains `allowPrivateNetwork` (default `false`), applied to both the default resolver and this check, so a development deployment can opt private hosts back in with one knob.

The refresh path reuses the already-validated issuer from the stored session, so it's covered transitively.

## Tests

- **11 authorize-path cases**: loopback (`127.0.0.1`, http and https), private (`10.0.0.5:9200` — the audit's example), link-local (`169.254.169.254`), IPv6 loopback (`[::1]`), IPv4-mapped private (`[::ffff:10.0.0.5]`), inet_aton spelling (`2130706433`), localhost-by-name, and a non-bare-origin — each asserted to throw **before any request reaches the AS host**. Plus a control (a public https AS still resolves and reaches PAR) and the escape hatch (`allowPrivateNetwork: true` lets a private AS through, failing later on metadata, not on host policy).
- **20 `ensureNonReservedHost` unit cases** in the identity package covering the reserved ranges, the inet_aton spellings, normalization, and the opt-in.

## Verification

Run against Dart 3.12.2 (matching CI):

```
dart analyze $DIRS          No issues found!  (whole workspace)
atproto_oauth               All tests passed!  (111, was 100)
atproto_identity            All tests passed!  (120, was 100)
atproto_core (dependent)    All tests passed!  (190)
validate_dependencies       ✓ 14 packages
```

`atproto_identity` 0.2.0 → 0.3.0 (new public API); `atproto_oauth` 0.6.0 → 0.7.0 (security fix + new option). Dependents' constraints follow to `^0.3.0` / `^0.7.0`.

---
_Generated by [Claude Code](https://claude.ai/code/session_016ManHiFgPPPqMpshziygZi)_