### PR TITLE
harden(lex_gen, atproto_oauth): reserved-word enum members and no AS redirects

### DIFF
--- a/packages/atproto_core/pubspec.yaml
+++ b/packages/atproto_core/pubspec.yaml
@@ -27,7 +27,7 @@ dependencies:
   json_annotation: ^4.9.0
   cbor: ^6.3.7
   multiformats: ^1.4.0
-  atproto_oauth: ^0.7.0
+  atproto_oauth: ^0.7.1
   nanoid: ^1.0.0
   meta: ^1.17.0
 

--- a/packages/atproto_oauth/CHANGELOG.md
+++ b/packages/atproto_oauth/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Note
 
+## v0.7.1
+
+- **security**: the metadata, PAR and token requests no longer follow HTTP redirects. v0.7.0 host-checks the authorization-server origin, but a `3xx` from it would let the server pivot the follow-up (a DPoP-signed PAR/token POST) onto another host, re-opening that SSRF. A `3xx` now surfaces as a response the caller rejects, or — for metadata discovery — falls back from, rather than being chased.
+
 ## v0.7.0
 
 - **security**: the authorization server discovered from a PDS's `oauth-protected-resource` metadata (RFC 9728) is now held to the same SSRF host policy the identity resolver applies to the PDS itself. The PDS host was validated, but the `authorization_servers` entry — attacker-influenced, since it comes from a PDS reached via an attacker-supplied handle — was taken verbatim (only `isAbsolute` was checked). An entry such as `https://10.0.0.5:9200` or `https://169.254.169.254` would direct the client's DPoP-signed PAR/token requests at an internal host: a blind SSRF. The AS host is now rejected unless it is an https bare origin on a non-reserved host, mirroring the PDS check.

--- a/packages/atproto_oauth/lib/src/oauth_client.dart
+++ b/packages/atproto_oauth/lib/src/oauth_client.dart
@@ -602,16 +602,39 @@ final class OAuthClient {
     return session;
   }
 
-  Future<http.Response> _get(final Uri url) async =>
-      _httpClient == null ? await http.get(url) : await _httpClient.get(url);
+  /// Sends [request] with redirect-following disabled.
+  ///
+  /// The metadata, PAR and token endpoints are exact URLs, not resources that
+  /// should redirect. The AS origin is host-checked once (see
+  /// `_resolveAuthorizationServer`), but a `3xx` from it would let the server
+  /// pivot the follow-up — a DPoP-signed PAR/token POST — onto another host,
+  /// re-opening the SSRF the host check closes. Following is off, so a `3xx`
+  /// surfaces as a response the caller rejects (or, for metadata discovery,
+  /// falls back from) instead of being chased.
+  Future<http.Response> _send(final http.Request request) async {
+    request.followRedirects = false;
+    final client = _httpClient ?? http.Client();
+    try {
+      return await http.Response.fromStream(await client.send(request));
+    } finally {
+      if (_httpClient == null) client.close();
+    }
+  }
+
+  Future<http.Response> _get(final Uri url) => _send(http.Request('GET', url));
 
   Future<http.Response> _post(
     final Uri url, {
     final Map<String, String>? headers,
-    final Object? body,
-  }) async => _httpClient == null
-      ? await http.post(url, headers: headers, body: body)
-      : await _httpClient.post(url, headers: headers, body: body);
+    final Map<String, String>? body,
+  }) {
+    final request = http.Request('POST', url);
+    if (headers != null) request.headers.addAll(headers);
+    // A map body is `application/x-www-form-urlencoded`, matching what
+    // `http.post` did with a `Map` body (which every caller passes).
+    if (body != null) request.bodyFields = body;
+    return _send(request);
+  }
 
   /// Fetches RFC 8414 metadata from
   /// `https://<authority>/.well-known/oauth-authorization-server`, validating

--- a/packages/atproto_oauth/pubspec.yaml
+++ b/packages/atproto_oauth/pubspec.yaml
@@ -1,7 +1,7 @@
 name: atproto_oauth
 resolution: workspace
 description: Provides tools to handle OAuth for AT Protocol and Bluesky Social.
-version: 0.7.0
+version: 0.7.1
 homepage: https://atprotodart.com
 repository: https://github.com/myConsciousness/atproto.dart/tree/main/packages/atproto_oauth
 issue_tracker: https://github.com/myConsciousness/atproto.dart/issues

--- a/packages/atproto_oauth/test/src/oauth_client_test.dart
+++ b/packages/atproto_oauth/test/src/oauth_client_test.dart
@@ -1413,6 +1413,68 @@ void main() {
     });
   });
 
+  group('authorization-server redirects are not followed', () {
+    test('a 3xx from the AS metadata endpoint is not chased off-host', () async {
+      // The metadata endpoint 302s toward an internal host. Following it would
+      // pivot the DPoP-signed follow-ups there; instead the non-200 must make
+      // discovery fall back to the default endpoint layout on the SAME origin,
+      // and nothing must ever reach the redirect target.
+      final recorder = _Recorder();
+      final client = OAuthClient(
+        _metadata(),
+        signer: _StubSigner(),
+        httpClient: recorder.build((r) async {
+          final id = _identityRoute(r);
+          if (id != null) return id;
+          if (_isWellKnown(r)) {
+            return http.Response(
+              '',
+              302,
+              headers: {
+                'location':
+                    'https://169.254.169.254/.well-known/'
+                    'oauth-authorization-server',
+              },
+            );
+          }
+          if (_isPar(r)) {
+            return _json({
+              'request_uri': 'urn:ietf:params:oauth:request_uri:xyz',
+            }, status: 201);
+          }
+          return http.Response('unexpected', 500);
+        }),
+      );
+
+      final url = await client.authorize(_handle);
+
+      // Fell back to the same-origin default layout, and PAR still went to the
+      // validated origin — never to the redirect target.
+      expect(url.toString(), startsWith('$_origin/oauth/authorize'));
+      expect(
+        recorder.requests.any((r) => r.url.host == '169.254.169.254'),
+        isFalse,
+        reason: 'no request may reach the redirect target host',
+      );
+
+      // MockClient never follows redirects on its own, so assert the fix
+      // directly: every request the client issues to the AS carries
+      // followRedirects=false, which is what makes a real IOClient surface a
+      // 3xx instead of chasing it.
+      final asRequests = recorder.requests.where(
+        (r) => _isWellKnown(r) || _isPar(r),
+      );
+      expect(asRequests, isNotEmpty);
+      for (final r in asRequests) {
+        expect(
+          r.followRedirects,
+          isFalse,
+          reason: '${r.url} must be sent with followRedirects=false',
+        );
+      }
+    });
+  });
+
   group('scope validation (atproto profile)', () {
     Future<OAuthSession> exchangeWithScope(final String? scope) async {
       final stateStore = InMemoryOAuthStateStore();

--- a/packages/bluesky/pubspec.yaml
+++ b/packages/bluesky/pubspec.yaml
@@ -38,6 +38,6 @@ dev_dependencies:
 
   atproto_test:
     path: ../atproto_test
-  atproto_oauth: ^0.7.0
+  atproto_oauth: ^0.7.1
   http: any
   fake_async: ^1.3.3

--- a/packages/lex_gen/CHANGELOG.md
+++ b/packages/lex_gen/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Note
 
+## v0.4.11
+
+- **fix**: a `knownValues` entry whose camelCased form is a Dart reserved word (`new`, `in`, `is`, `class`, …) is now suffixed with `Value`, the same escape `default` already received, instead of emitting an uncompilable enum member. Generated output for the current lexicon corpus is unchanged — no value other than `default` triggers it.
+
 ## v0.4.10
 
 - chore: bump `lexicon` to `^1.2.9`

--- a/packages/lex_gen/lib/src/services/rule.dart
+++ b/packages/lex_gen/lib/src/services/rule.dart
@@ -379,8 +379,55 @@ String getLexKnownValuesElementName(
 
   val = toFirstLowerCase(val);
 
-  return val == 'default' ? 'defaultValue' : val;
+  // A knownValue whose camelCased form lands on a Dart reserved word cannot be
+  // emitted as a bare enum member — `default` was special-cased, but `new`,
+  // `in`, `class`, `is`, … would each produce uncompilable output. Suffix any
+  // reserved word with `Value` (which is exactly what `default` already got),
+  // so the whole class is handled instead of the one member that happened to
+  // appear in the corpus. No current knownValue other than `default` hits this,
+  // so generated output is unchanged.
+  return _dartReservedWords.contains(val) ? '${val}Value' : val;
 }
+
+/// Dart reserved words — those that may never be used as a plain identifier, so
+/// a generated enum member named after one would not compile. (Built-in
+/// identifiers like `abstract`/`static`/`dynamic` are legal as enum members and
+/// are deliberately excluded.)
+const _dartReservedWords = <String>{
+  'assert',
+  'break',
+  'case',
+  'catch',
+  'class',
+  'const',
+  'continue',
+  'default',
+  'do',
+  'else',
+  'enum',
+  'extends',
+  'false',
+  'final',
+  'finally',
+  'for',
+  'if',
+  'in',
+  'is',
+  'new',
+  'null',
+  'rethrow',
+  'return',
+  'super',
+  'switch',
+  'this',
+  'throw',
+  'true',
+  'try',
+  'var',
+  'void',
+  'while',
+  'with',
+};
 
 String getNamespaceIdForApi(final String lexiconId) {
   return toFirstLowerCase(Nsid(lexiconId).pascalCase());

--- a/packages/lex_gen/pubspec.yaml
+++ b/packages/lex_gen/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lex_gen
 resolution: workspace
 description: Provides a generator that automatically generates source code from the Lexicon in the AT Protocol.
-version: 0.4.10
+version: 0.4.11
 homepage: https://atprotodart.com
 repository: https://github.com/myConsciousness/atproto.dart/tree/main/packages/lex_gen
 issue_tracker: https://github.com/myConsciousness/atproto.dart/issues

--- a/packages/lex_gen/test/src/services/rule_test.dart
+++ b/packages/lex_gen/test/src/services/rule_test.dart
@@ -144,5 +144,44 @@ void main() {
     test('escapes the reserved "default" identifier', () {
       expect(rule.getLexKnownValuesElementName('default'), 'defaultValue');
     });
+
+    test('escapes every Dart reserved word, not just "default"', () {
+      for (final word in const [
+        'new',
+        'in',
+        'is',
+        'class',
+        'for',
+        'while',
+        'if',
+        'else',
+        'enum',
+        'true',
+        'false',
+        'null',
+        'void',
+        'this',
+        'switch',
+        'return',
+        'const',
+        'final',
+        'with',
+      ]) {
+        expect(
+          rule.getLexKnownValuesElementName(word),
+          '${word}Value',
+          reason: 'reserved word "$word" must be escaped',
+        );
+      }
+    });
+
+    test('leaves a non-reserved identifier untouched', () {
+      // Built-in identifiers (legal as enum members) and ordinary words must
+      // NOT be suffixed.
+      expect(rule.getLexKnownValuesElementName('static'), 'static');
+      expect(rule.getLexKnownValuesElementName('dynamic'), 'dynamic');
+      expect(rule.getLexKnownValuesElementName('spam'), 'spam');
+      expect(rule.getLexKnownValuesElementName('nsfw'), 'nsfw');
+    });
   });
 }

--- a/scripts/pubspec.yaml
+++ b/scripts/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 dependencies:
   github: ^9.12.0
   http: ^1.4.0
-  lex_gen: ^0.4.10
+  lex_gen: ^0.4.11
   lexicon: ^1.2.9
   pubspec: ^2.3.0
   test: ^1.26.2


### PR DESCRIPTION
The two low-priority robustness gaps the audit flagged, done in parallel. Neither is reachable by current inputs; both close a latent hole.

## lex_gen — reserved-word enum members

`getLexKnownValuesElementName` special-cased only `default` when turning a `knownValues` entry into an enum member. A value whose camelCased form is any *other* Dart reserved word — `new`, `in`, `is`, `class`, `for`, `true`, … — would emit an uncompilable member.

Generalized: any Dart reserved word is suffixed with `Value`, which is exactly the escape `default` already got. Built-in identifiers that *are* legal as enum members (`static`, `dynamic`, `abstract`, …) are deliberately left alone.

**Generated output is byte-identical for the current corpus** — no `knownValues` entry other than `default` is a reserved word (or the tree wouldn't compile today), so `verify-generated` sees no diff. The value is future-proofing: when upstream adds such a value, codegen produces correct code instead of a build break someone has to diagnose.

## atproto_oauth — authorization-server redirects

#2554 (v0.7.0) host-checks the authorization-server origin taken from PDS metadata. But `_get`/`_post` used the redirect-following `package:http` convenience methods, so a `3xx` **from the validated AS** could pivot the follow-up — a DPoP-signed PAR or token POST — onto an unvalidated host, e.g. `169.254.169.254`. That re-opens the SSRF the host check closes, one hop later.

Both now send an `http.Request` with `followRedirects = false`. A `3xx` surfaces as a response the caller rejects (metadata discovery falls back to the same-origin default layout; PAR/token treat a non-2xx as failure) instead of being chased. A `Map` body is form-encoded via `bodyFields`, matching what `http.post` did — the one caller passes a `Map<String,String>`. No public API changes.

## Tests

- **lex_gen**: 19 reserved words asserted escaped to `<word>Value`; `static`/`dynamic`/ordinary words asserted untouched.
- **atproto_oauth**: a 302 from the AS metadata endpoint yields no request to the redirect target host, discovery falls back to the same origin, and every AS-directed request is asserted to carry `followRedirects == false` (MockClient never redirects on its own, so this checks the fix, not the mock).

## Verification

Against Dart 3.12.2 (matching CI):

```
dart analyze $DIRS      No issues found!  (whole workspace)
atproto_oauth           All tests passed!  (112)
lex_gen                 All tests passed!
validate_dependencies   ✓ 14 packages
format --set-exit-if-changed   clean
```

Both packages are already published, so this ships as patches: `lex_gen` 0.4.10 → 0.4.11 (no output change), `atproto_oauth` 0.7.0 → 0.7.1 (hardening on top of 0.7.0's host check). Dependent constraints (`scripts` → lex_gen `^0.4.11`; `atproto_core`, `bluesky` → atproto_oauth `^0.7.1`) follow.

---
_Generated by [Claude Code](https://claude.ai/code/session_016ManHiFgPPPqMpshziygZi)_