### PR TITLE
fix(oauth): revoke at the server, bound refreshes, stop spurious logouts

### DIFF
--- a/packages/atproto/CHANGELOG.md
+++ b/packages/atproto/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Note
 
+## v2.4.2
+
+- fix: `ATProto.fromOAuthSession` passes its `timeout` through to the `OAuthSessionManager` it builds, so a hung restore or refresh is bounded by the timeout the caller asked for instead of running unbounded.
+
 ## v2.4.1
 
 - feat: added `com.atproto.server.describeServer.output.blobUploadLimit`

--- a/packages/atproto/lib/src/atproto.dart
+++ b/packages/atproto/lib/src/atproto.dart
@@ -109,9 +109,11 @@ sealed class ATProto {
   /// — and what it gives you instead is worse than two independent clients.
   /// Each manager holds its own copy of [session], and a rotating refresh
   /// token is only honoured once: whichever manager refreshes first spends it,
-  /// and the other's refresh comes back as an `OAuthSessionRevokedException`
-  /// — the signal to send the user back through authorization — for a session
-  /// that was working moments earlier. Build the manager yourself and pass it
+  /// and the other then spends a wasted token request discovering that. It
+  /// recovers — the rejected refresh falls back to whatever the shared
+  /// [oauth.OAuthClient]'s session store now holds — but only because both
+  /// managers happen to read the same store, and each still keeps its own
+  /// in-memory copy in the meantime. Build the manager yourself and pass it
   /// to [ATProto.fromOAuth] when more than one client shares an account.
   factory ATProto.fromOAuthSession(
     final oauth.OAuthSession session, {
@@ -125,7 +127,11 @@ sealed class ATProto {
     final core.GetClient? getClient,
     final core.PostClient? postClient,
   }) => ATProto.fromOAuth(
-    oauth.OAuthSessionManager.fromSession(session, client: oauthClient),
+    oauth.OAuthSessionManager.fromSession(
+      session,
+      client: oauthClient,
+      timeout: timeout,
+    ),
     headers: headers,
     protocol: protocol,
     service: service,

--- a/packages/atproto/pubspec.yaml
+++ b/packages/atproto/pubspec.yaml
@@ -1,7 +1,7 @@
 name: atproto
 resolution: workspace
 description: The most famous and powerful Dart/Flutter library for AT Protocol.
-version: 2.4.1
+version: 2.4.2
 homepage: https://atprotodart.com
 documentation: https://atprotodart.com/docs/packages/atproto
 repository: https://github.com/myConsciousness/atproto.dart/tree/main/packages/atproto
@@ -18,7 +18,7 @@ topics:
   - api
 
 dependencies:
-  atproto_core: ^2.4.0
+  atproto_core: ^2.4.1
   xrpc: ^1.1.3
   freezed_annotation: ^3.1.0
   json_annotation: ^4.9.0

--- a/packages/atproto_core/CHANGELOG.md
+++ b/packages/atproto_core/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Note
 
+## v2.4.1
+
+- chore: bump `atproto_oauth` to `^0.8.0`.
+
 ## v2.4.0
 
 - fix: `decodeCar` validates the CAR header length instead of trusting it. A truncated archive whose header varint claimed more bytes than exist pushed the cursor past the end and decoded to an EMPTY map — a truncated repository export looked like an empty repository, silently losing every block. It now throws `CarException`, the same contract the block-length check already honored.

--- a/packages/atproto_core/pubspec.yaml
+++ b/packages/atproto_core/pubspec.yaml
@@ -1,7 +1,7 @@
 name: atproto_core
 resolution: workspace
 description: Core library for clients and tools. This package is mainly used by https://atprotodart.com packages.
-version: 2.4.0
+version: 2.4.1
 homepage: https://atprotodart.com
 documentation: https://atprotodart.com/docs/intro
 repository: https://github.com/myConsciousness/atproto.dart/tree/main/packages/atproto_core
@@ -27,7 +27,7 @@ dependencies:
   json_annotation: ^4.9.0
   cbor: ^6.3.7
   multiformats: ^1.4.0
-  atproto_oauth: ^0.7.1
+  atproto_oauth: ^0.8.0
   nanoid: ^1.0.0
   meta: ^1.17.0
 

--- a/packages/atproto_oauth/CHANGELOG.md
+++ b/packages/atproto_oauth/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Release Note
 
+## v0.8.0
+
+- **feat**: `revoke` now actually revokes at the authorization server. It was local-only — the session was dropped from the `OAuthSessionStore` and nothing was sent — so after a "log out" the refresh token stayed live at the server for its full lifetime, and anyone holding a copy (a leaked backup, a shared device, a compromised store) could keep minting access tokens. When the server publishes an RFC 7009 `revocation_endpoint`, the refresh token is now POSTed to it with a DPoP proof before the local delete (the refresh token in preference to the access token, since revoking it takes the whole grant down). The call is best-effort: a server that publishes no endpoint is skipped, and a network or server failure never blocks the logout.
+- **feat**: `OAuthServerMetadata` parses `revocation_endpoint`, and it is held to the same `https` + same-origin-as-issuer check already applied to the PAR, authorization and token endpoints.
+- **feat**: `OAuthSessionManager` accepts a `timeout` (default 30s, `defaultOAuthSessionTimeout`) bounding a single restore or refresh round trip. Every request on a manager queues behind the restore/refresh single flight, so an unbounded token call — a hung server, a stalled connection, an injected client whose I/O never completes — held *all* of them indefinitely with no way out. `atproto_core` applies the same bound to the legacy (non-OAuth) refresh callback; the OAuth path now matches. `ATProto.fromOAuthSession`, `Bluesky.fromOAuthSession`, `BlueskyChat.fromOAuthSession` and `OzoneTool.fromOAuthSession` pass their own `timeout` through.
+- **fix**: a refresh that gets `invalid_grant` for a token the store has already rotated past now returns the current stored session instead of throwing `OAuthSessionRevokedException`. v0.5.0 stopped such a stale failure from *deleting* the newer session, but still reported it as revoked — so the caller logged the user out of an account that held a perfectly valid session, undoing the very thing the delete-guard protected. The exception is now raised only when the session that actually failed is the one still stored.
+
 ## v0.7.1
 
 - **security**: the metadata, PAR and token requests no longer follow HTTP redirects. v0.7.0 host-checks the authorization-server origin, but a `3xx` from it would let the server pivot the follow-up (a DPoP-signed PAR/token POST) onto another host, re-opening that SSRF. A `3xx` now surfaces as a response the caller rejects, or — for metadata discovery — falls back from, rather than being chased.

--- a/packages/atproto_oauth/lib/src/oauth_client.dart
+++ b/packages/atproto_oauth/lib/src/oauth_client.dart
@@ -471,7 +471,9 @@ final class OAuthClient {
   /// If the server rejects the refresh token with `invalid_grant`, the
   /// session is deleted from the [OAuthSessionStore] and an
   /// [OAuthSessionRevokedException] is thrown so callers can route the user
-  /// back through [authorize].
+  /// back through [authorize] — unless the store has already rotated past the
+  /// token this call tried, in which case the rejection says only that the
+  /// tried token was spent and the current stored session is returned instead.
   ///
   /// Throws:
   /// - [OAuthException] when no refresh token is available or the request
@@ -531,7 +533,16 @@ final class OAuthClient {
       // session that must not be clobbered by this stale failure.
       if (post.body?['error'] == 'invalid_grant') {
         final current = await _sessionStore.find(session.sub);
-        if (current != null && current.refreshToken == refreshToken) {
+        if (current != null && current.refreshToken != refreshToken) {
+          // The store has already moved past the token this call tried, so
+          // the `invalid_grant` only says "that one was already spent" — it
+          // says nothing about the session that is stored now. Reporting it
+          // as revoked would log out an account that holds a valid session
+          // (the same rotation race the delete-guard above protects against,
+          // which the throw would then undo). Hand back the current session.
+          return current;
+        }
+        if (current != null) {
           await _sessionStore.delete(session.sub);
         }
         throw OAuthSessionRevokedException(
@@ -576,15 +587,62 @@ final class OAuthClient {
     return refreshed;
   }
 
-  /// Best-effort revocation of [session].
+  /// Revokes [session] at the authorization server and removes it locally.
   ///
-  /// The [OAuthServerMetadata] this client parses does not expose a
-  /// revocation endpoint, so no network call is made; the session is always
-  /// removed from the [OAuthSessionStore]. When a revocation endpoint becomes
-  /// available, a token revocation POST would be attempted here (ignoring any
-  /// failure) before the local delete.
+  /// When the server publishes an RFC 7009 `revocation_endpoint`, the refresh
+  /// token is POSTed to it with a DPoP proof so the grant actually dies at the
+  /// server; the refresh token is used in preference to the access token
+  /// because revoking it takes the whole grant down with it, whereas revoking
+  /// an access token leaves the refresh token able to mint new ones. A server
+  /// that publishes no such endpoint (the common case for atproto entryways
+  /// today) is simply skipped.
+  ///
+  /// The network call is **best-effort**: RFC 7009 Section 2.2 already
+  /// requires a `200` for an unknown token, and a logout must not be blocked
+  /// by an unreachable or misbehaving server. Any failure is swallowed and the
+  /// local delete still happens, so this method never throws for a network or
+  /// server-side reason.
   Future<void> revoke(final OAuthSession session) async {
+    try {
+      await _revokeAtServer(session);
+    } on Exception {
+      // Best-effort: a failed server-side revocation must not strand the
+      // session in the local store.
+    }
+
     await _sessionStore.delete(session.sub);
+  }
+
+  /// POSTs an RFC 7009 revocation request for [session], if the authorization
+  /// server publishes a `revocation_endpoint`.
+  Future<void> _revokeAtServer(final OAuthSession session) async {
+    final authority = Uri.parse(session.issuer).authority;
+    if (authority.isEmpty) return;
+
+    final meta = await _discoverServerMetadata(authority);
+    // Unlike the token endpoint, there is no conventional atproto fallback
+    // path for revocation: POSTing to a guessed URL would just 404. Only an
+    // advertised endpoint (already validated https + same-origin by
+    // [_validateEndpointOrigins]) is used.
+    final revocationEndpoint = meta.revocationEndpoint;
+    if (revocationEndpoint == null) return;
+
+    final refreshToken = session.refreshToken;
+
+    await _postWithDPoPProof(
+      endpoint: Uri.parse(revocationEndpoint),
+      keyPair: DPoPKeyPair(
+        publicKey: session.dpopPublicKey,
+        privateKey: session.dpopPrivateKey,
+      ),
+      bodyParams: {
+        'client_id': session.clientId,
+        'token': refreshToken ?? session.accessToken,
+        'token_type_hint': refreshToken == null
+            ? 'access_token'
+            : 'refresh_token',
+      },
+    );
   }
 
   /// Restores a stored session for [sub], refreshing it if it has expired.
@@ -714,6 +772,11 @@ final class OAuthClient {
       'authorization_endpoint',
     );
     _requireSameOriginHttps(metadata.tokenEndpoint, origin, 'token_endpoint');
+    _requireSameOriginHttps(
+      metadata.revocationEndpoint,
+      origin,
+      'revocation_endpoint',
+    );
   }
 
   /// Throws an [OAuthException] unless [endpoint] (when present) is an

--- a/packages/atproto_oauth/lib/src/oauth_session_manager.dart
+++ b/packages/atproto_oauth/lib/src/oauth_session_manager.dart
@@ -12,6 +12,10 @@ import 'stores/dpop_nonce_cache.dart';
 import 'types/dpop_key_pair.dart';
 import 'types/session.dart';
 
+/// Default upper bound on a single restore or refresh round trip performed by
+/// an [OAuthSessionManager], matching `atproto_core`'s `defaultTimeout`.
+const defaultOAuthSessionTimeout = Duration(seconds: 30);
+
 /// Owns an OAuth session's lifecycle for API use: builds DPoP `Authorization`
 /// headers per request (nonce cached per origin) and refreshes the access
 /// token before it expires or on a 401. `atproto_core` delegates to this.
@@ -21,21 +25,25 @@ final class OAuthSessionManager {
     required final String sub,
     final DPoPSigner? signer,
     final DPoPNonceCache? nonceCache,
+    final Duration? timeout,
   }) : _sub = sub,
        _signer = signer ?? const PointyCastleDPoPSigner(),
-       _nonceCache = nonceCache ?? InMemoryDPoPNonceCache();
+       _nonceCache = nonceCache ?? InMemoryDPoPNonceCache(),
+       _timeout = timeout ?? defaultOAuthSessionTimeout;
 
   factory OAuthSessionManager.fromSession(
     final OAuthSession session, {
     final OAuthClient? client,
     final DPoPSigner? signer,
     final DPoPNonceCache? nonceCache,
+    final Duration? timeout,
   }) {
     final mgr = OAuthSessionManager(
       client,
       sub: session.sub,
       signer: signer,
       nonceCache: nonceCache,
+      timeout: timeout,
     ).._session = session;
     return mgr;
   }
@@ -44,6 +52,15 @@ final class OAuthSessionManager {
   final String _sub;
   final DPoPSigner _signer;
   final DPoPNonceCache _nonceCache;
+
+  /// Upper bound on a single restore or refresh round trip. Every request on
+  /// this manager queues behind the [_load] / [_refresh] single flight, so an
+  /// unbounded token call — a hung server, a stalled connection, or an
+  /// injected [OAuthClient] whose I/O never completes — would hold *all* of
+  /// them forever. Bounding it turns that into a failure the caller can see
+  /// and retry, and mirrors the bound `atproto_core` applies to the legacy
+  /// (non-OAuth) refresh callback.
+  final Duration _timeout;
   OAuthSession? _session;
   Future<OAuthSession>? _inflightLoad;
   Future<OAuthSession>? _inflightRefresh;
@@ -123,6 +140,7 @@ final class OAuthSessionManager {
     final client = _client!;
     _inflightRefresh = client
         .refresh(current)
+        .timeout(_timeout)
         .then((refreshed) {
           _session = refreshed;
           _updates.add(refreshed);
@@ -143,6 +161,7 @@ final class OAuthSessionManager {
     if (existing != null) return Future.value(existing);
     if (_inflightLoad != null) return _inflightLoad!;
     _inflightLoad = _loadFromClient()
+        .timeout(_timeout)
         .then((restored) => _session = restored)
         .whenComplete(() => _inflightLoad = null);
     return _inflightLoad!;

--- a/packages/atproto_oauth/lib/src/types/server_metadata.dart
+++ b/packages/atproto_oauth/lib/src/types/server_metadata.dart
@@ -18,6 +18,7 @@ final class OAuthServerMetadata {
     this.pushedAuthorizationRequestEndpoint,
     this.authorizationEndpoint,
     this.tokenEndpoint,
+    this.revocationEndpoint,
     this.scopesSupported,
   });
 
@@ -41,6 +42,7 @@ final class OAuthServerMetadata {
       ),
       authorizationEndpoint: asString('authorization_endpoint'),
       tokenEndpoint: asString('token_endpoint'),
+      revocationEndpoint: asString('revocation_endpoint'),
       scopesSupported: scopes is List
           ? scopes.whereType<String>().toList()
           : null,
@@ -59,6 +61,9 @@ final class OAuthServerMetadata {
   /// The URL of the token endpoint.
   final String? tokenEndpoint;
 
+  /// The URL of the token revocation endpoint (RFC 7009), if published.
+  final String? revocationEndpoint;
+
   /// The OAuth scopes supported by this server, if published.
   final List<String>? scopesSupported;
 
@@ -68,6 +73,7 @@ final class OAuthServerMetadata {
         ?pushedAuthorizationRequestEndpoint,
     'authorization_endpoint': ?authorizationEndpoint,
     'token_endpoint': ?tokenEndpoint,
+    'revocation_endpoint': ?revocationEndpoint,
     'scopes_supported': ?scopesSupported,
   };
 }

--- a/packages/atproto_oauth/pubspec.yaml
+++ b/packages/atproto_oauth/pubspec.yaml
@@ -1,7 +1,7 @@
 name: atproto_oauth
 resolution: workspace
 description: Provides tools to handle OAuth for AT Protocol and Bluesky Social.
-version: 0.7.1
+version: 0.8.0
 homepage: https://atprotodart.com
 repository: https://github.com/myConsciousness/atproto.dart/tree/main/packages/atproto_oauth
 issue_tracker: https://github.com/myConsciousness/atproto.dart/issues

--- a/packages/atproto_oauth/test/src/oauth_client_test.dart
+++ b/packages/atproto_oauth/test/src/oauth_client_test.dart
@@ -126,6 +126,7 @@ bool _isWellKnown(final http.Request r) =>
     r.url.path == '/.well-known/oauth-authorization-server';
 bool _isPar(final http.Request r) => r.url.path == '/oauth/par';
 bool _isToken(final http.Request r) => r.url.path == '/oauth/token';
+bool _isRevoke(final http.Request r) => r.url.path == '/oauth/revoke';
 
 Map<String, dynamic> _tokenBody({
   final String? refreshToken = 'refresh-token-1',
@@ -1153,38 +1154,44 @@ void main() {
       },
     );
 
-    test('invalid_grant does not clobber a newer stored session', () async {
-      final sessionStore = InMemoryOAuthSessionStore();
-      // A newer session (rotated refresh token) is already in the store, e.g.
-      // because a concurrent refresh already rotated it.
-      await sessionStore.set(
-        _sub,
-        _sessionWith(refreshToken: 'refresh-token-2'),
-      );
-      final client = OAuthClient(
-        _metadata(),
-        sessionStore: sessionStore,
-        signer: _StubSigner(),
-        httpClient: MockClient((r) async {
-          if (_isWellKnown(r)) return _json(_serverMetadataDoc());
-          if (_isToken(r)) {
-            return _json({'error': 'invalid_grant'}, status: 400);
-          }
-          return http.Response('unexpected', 500);
-        }),
-      );
+    test(
+      'invalid_grant on a stale token returns the newer stored session',
+      () async {
+        final sessionStore = InMemoryOAuthSessionStore();
+        // A newer session (rotated refresh token) is already in the store, e.g.
+        // because a concurrent refresh already rotated it.
+        await sessionStore.set(
+          _sub,
+          _sessionWith(refreshToken: 'refresh-token-2'),
+        );
+        final client = OAuthClient(
+          _metadata(),
+          sessionStore: sessionStore,
+          signer: _StubSigner(),
+          httpClient: MockClient((r) async {
+            if (_isWellKnown(r)) return _json(_serverMetadataDoc());
+            if (_isToken(r)) {
+              return _json({'error': 'invalid_grant'}, status: 400);
+            }
+            return http.Response('unexpected', 500);
+          }),
+        );
 
-      // Refreshing a STALE session (old refresh token) gets invalid_grant, but
-      // the newer stored session must survive.
-      await expectLater(
-        () => client.refresh(_sessionWith(refreshToken: 'refresh-token-1')),
-        throwsA(isA<OAuthSessionRevokedException>()),
-      );
+        // Refreshing a STALE session (old refresh token) gets invalid_grant.
+        // That only says the token this call tried was already spent; it says
+        // nothing about the session now in the store, so the caller must get
+        // that valid session back rather than a revoked-session error that
+        // would log the account out.
+        final result = await client.refresh(
+          _sessionWith(refreshToken: 'refresh-token-1'),
+        );
+        expect(result.refreshToken, 'refresh-token-2');
 
-      final stored = await sessionStore.find(_sub);
-      expect(stored, isNotNull);
-      expect(stored!.refreshToken, 'refresh-token-2');
-    });
+        final stored = await sessionStore.find(_sub);
+        expect(stored, isNotNull);
+        expect(stored!.refreshToken, 'refresh-token-2');
+      },
+    );
 
     test(
       'invalid_grant deletes the session and throws OAuthSessionRevoked',
@@ -1573,10 +1580,140 @@ void main() {
         _metadata(),
         sessionStore: sessionStore,
         signer: _StubSigner(),
+        httpClient: MockClient((r) async {
+          if (_isWellKnown(r)) return _json(_serverMetadataDoc());
+          return http.Response('unexpected', 500);
+        }),
       );
 
       await client.revoke(_sessionWith());
       expect(await sessionStore.find(_sub), isNull);
+    });
+
+    test('POSTs an RFC 7009 revocation for the refresh token', () async {
+      final recorder = _Recorder();
+      final sessionStore = InMemoryOAuthSessionStore();
+      await sessionStore.set(_sub, _sessionWith());
+      final client = OAuthClient(
+        _metadata(),
+        sessionStore: sessionStore,
+        signer: _StubSigner(),
+        httpClient: recorder.build((r) async {
+          if (_isWellKnown(r)) {
+            return _json({
+              ..._serverMetadataDoc(),
+              'revocation_endpoint': '$_origin/oauth/revoke',
+            });
+          }
+          if (_isRevoke(r)) return http.Response('', 200);
+          return http.Response('unexpected', 500);
+        }),
+      );
+
+      await client.revoke(_sessionWith());
+
+      final revocation = recorder.requests.firstWhere(_isRevoke);
+      final body = Uri.splitQueryString(revocation.body);
+      // The refresh token is revoked in preference to the access token: it
+      // takes the whole grant down, whereas revoking an access token leaves
+      // the refresh token able to mint new ones.
+      expect(body['token'], 'refresh-token-1');
+      expect(body['token_type_hint'], 'refresh_token');
+      expect(body['client_id'], _clientId);
+      expect(revocation.headers['DPoP'], isNotNull);
+
+      expect(await sessionStore.find(_sub), isNull);
+    });
+
+    test(
+      'falls back to the access token when no refresh token is held',
+      () async {
+        final recorder = _Recorder();
+        final client = OAuthClient(
+          _metadata(),
+          signer: _StubSigner(),
+          httpClient: recorder.build((r) async {
+            if (_isWellKnown(r)) {
+              return _json({
+                ..._serverMetadataDoc(),
+                'revocation_endpoint': '$_origin/oauth/revoke',
+              });
+            }
+            if (_isRevoke(r)) return http.Response('', 200);
+            return http.Response('unexpected', 500);
+          }),
+        );
+
+        await client.revoke(_sessionWith(refreshToken: null));
+
+        final body = Uri.splitQueryString(
+          recorder.requests.firstWhere(_isRevoke).body,
+        );
+        expect(body['token'], 'old-access');
+        expect(body['token_type_hint'], 'access_token');
+      },
+    );
+
+    test('skips the network when the server publishes no endpoint', () async {
+      final recorder = _Recorder();
+      final client = OAuthClient(
+        _metadata(),
+        signer: _StubSigner(),
+        httpClient: recorder.build((r) async {
+          if (_isWellKnown(r)) return _json(_serverMetadataDoc());
+          return http.Response('unexpected', 500);
+        }),
+      );
+
+      await client.revoke(_sessionWith());
+
+      // There is no conventional atproto path to guess at, so nothing beyond
+      // discovery is sent.
+      expect(recorder.requests.where(_isRevoke), isEmpty);
+    });
+
+    test(
+      'still deletes locally when the server-side revocation fails',
+      () async {
+        final sessionStore = InMemoryOAuthSessionStore();
+        await sessionStore.set(_sub, _sessionWith());
+        final client = OAuthClient(
+          _metadata(),
+          sessionStore: sessionStore,
+          signer: _StubSigner(),
+          // Every request blows up: a logout must not be blocked by an
+          // unreachable authorization server.
+          httpClient: MockClient(
+            (r) async => throw http.ClientException('down'),
+          ),
+        );
+
+        await client.revoke(_sessionWith());
+        expect(await sessionStore.find(_sub), isNull);
+      },
+    );
+
+    test('rejects an off-origin revocation_endpoint', () async {
+      final client = OAuthClient(
+        _metadata(),
+        signer: _StubSigner(),
+        httpClient: MockClient((r) async {
+          if (_isWellKnown(r)) {
+            return _json({
+              ..._serverMetadataDoc(),
+              'revocation_endpoint': 'https://evil.example/oauth/revoke',
+            });
+          }
+          return http.Response('unexpected', 500);
+        }),
+      );
+
+      // `revoke` swallows it (best-effort), but the same metadata must be
+      // rejected outright on the paths that carry credentials.
+      await expectLater(
+        () => client.refresh(_sessionWith()),
+        throwsA(isA<OAuthException>()),
+      );
     });
   });
 

--- a/packages/atproto_oauth/test/src/oauth_session_manager_test.dart
+++ b/packages/atproto_oauth/test/src/oauth_session_manager_test.dart
@@ -185,6 +185,61 @@ void main() {
     expect(mgr.currentSession?.accessToken, 'access-2');
   });
 
+  group('timeout', () {
+    test('a hung refresh does not hold every caller forever', () async {
+      final client = OAuthClient(
+        _clientMetadata(),
+        signer: _RecordingSigner(),
+        // The token endpoint never answers. Without a bound, the single
+        // flight in _refresh holds every request on this manager behind it
+        // for as long as the server stays silent.
+        httpClient: MockClient((r) async {
+          if (r.url.path == '/.well-known/oauth-authorization-server') {
+            return _json({
+              'issuer': 'https://bsky.social',
+              'token_endpoint': 'https://bsky.social/oauth/token',
+            });
+          }
+          await Completer<void>().future;
+          throw StateError('unreachable');
+        }),
+      );
+
+      final mgr = OAuthSessionManager.fromSession(
+        // Already expired, so getSession() must go through _refresh.
+        _session(
+          expiresAt: DateTime.now().toUtc().subtract(
+            const Duration(minutes: 5),
+          ),
+        ),
+        client: client,
+        timeout: const Duration(milliseconds: 50),
+      );
+
+      await expectLater(mgr.getSession(), throwsA(isA<TimeoutException>()));
+    });
+
+    test('a hung restore does not hold every caller forever', () async {
+      final client = OAuthClient(
+        _clientMetadata(),
+        sessionStore: _HangingSessionStore(),
+        signer: _RecordingSigner(),
+      );
+
+      final mgr = OAuthSessionManager(
+        client,
+        sub: 'did:plc:abc',
+        timeout: const Duration(milliseconds: 50),
+      );
+
+      await expectLater(mgr.getSession(), throwsA(isA<TimeoutException>()));
+    });
+
+    test('defaults to 30s, matching the legacy refresh bound', () {
+      expect(defaultOAuthSessionTimeout, const Duration(seconds: 30));
+    });
+  });
+
   test('buildAuthHeaders strips query/fragment from the DPoP htu', () async {
     final signer = _RecordingSigner();
     final mgr = OAuthSessionManager.fromSession(_session(), signer: signer);
@@ -256,6 +311,20 @@ class _RacingSessionStore implements OAuthSessionStore {
 
   @override
   Future<void> delete(final String sub) async => _store.remove(sub);
+}
+
+/// An [OAuthSessionStore] whose reads never complete, standing in for durable
+/// storage that has wedged (a locked keychain, a stalled platform channel).
+class _HangingSessionStore implements OAuthSessionStore {
+  @override
+  Future<OAuthSession?> find(final String sub) =>
+      Completer<OAuthSession?>().future;
+
+  @override
+  Future<void> set(final String sub, final OAuthSession session) async {}
+
+  @override
+  Future<void> delete(final String sub) async {}
 }
 
 class _RecordingSigner implements DPoPSigner {

--- a/packages/atproto_oauth/test/src/types/server_metadata_test.dart
+++ b/packages/atproto_oauth/test/src/types/server_metadata_test.dart
@@ -17,6 +17,7 @@ void main() {
             'https://bsky.social/oauth/par',
         'authorization_endpoint': 'https://bsky.social/oauth/authorize',
         'token_endpoint': 'https://bsky.social/oauth/token',
+        'revocation_endpoint': 'https://bsky.social/oauth/revoke',
         'scopes_supported': ['atproto', 'transition:generic'],
       });
 
@@ -30,6 +31,7 @@ void main() {
         'https://bsky.social/oauth/authorize',
       );
       expect(metadata.tokenEndpoint, 'https://bsky.social/oauth/token');
+      expect(metadata.revocationEndpoint, 'https://bsky.social/oauth/revoke');
       expect(metadata.scopesSupported, ['atproto', 'transition:generic']);
     });
 
@@ -42,6 +44,7 @@ void main() {
       expect(metadata.pushedAuthorizationRequestEndpoint, isNull);
       expect(metadata.authorizationEndpoint, isNull);
       expect(metadata.tokenEndpoint, isNull);
+      expect(metadata.revocationEndpoint, isNull);
       expect(metadata.scopesSupported, isNull);
     });
 

--- a/packages/bluesky/CHANGELOG.md
+++ b/packages/bluesky/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Note
 
+## v2.4.6
+
+- fix: `Bluesky.fromOAuthSession`, `BlueskyChat.fromOAuthSession` and `OzoneTool.fromOAuthSession` pass their `timeout` through to the `OAuthSessionManager` they build, so a hung restore or refresh is bounded by the timeout the caller asked for instead of running unbounded.
+
 ## v2.4.5
 
 - feat: added `tools.ozone.queue.createQueue.errors.InvalidRecommendedPolicies`

--- a/packages/bluesky/lib/src/bluesky.dart
+++ b/packages/bluesky/lib/src/bluesky.dart
@@ -124,9 +124,11 @@ sealed class Bluesky {
   /// session — and what it gets instead is worse than an independent client.
   /// Each manager holds its own copy of [session], and a rotating refresh
   /// token is only honoured once: whichever manager refreshes first spends it,
-  /// and the other's refresh comes back as an `OAuthSessionRevokedException`
-  /// — the signal to send the user back through authorization — for a session
-  /// that was working moments earlier. Build the manager yourself and pass it
+  /// and the other then spends a wasted token request discovering that. It
+  /// recovers — the rejected refresh falls back to whatever the shared
+  /// [oauth.OAuthClient]'s session store now holds — but only because both
+  /// managers happen to read the same store, and each still keeps its own
+  /// in-memory copy in the meantime. Build the manager yourself and pass it
   /// to [Bluesky.fromOAuth] when more than one client shares an account.
   factory Bluesky.fromOAuthSession(
     final oauth.OAuthSession session, {
@@ -140,7 +142,11 @@ sealed class Bluesky {
     final core.GetClient? getClient,
     final core.PostClient? postClient,
   }) => Bluesky.fromOAuth(
-    oauth.OAuthSessionManager.fromSession(session, client: oauthClient),
+    oauth.OAuthSessionManager.fromSession(
+      session,
+      client: oauthClient,
+      timeout: timeout,
+    ),
     headers: headers,
     protocol: protocol,
     service: service,

--- a/packages/bluesky/lib/src/bluesky_chat.dart
+++ b/packages/bluesky/lib/src/bluesky_chat.dart
@@ -141,9 +141,11 @@ sealed class BlueskyChat {
   /// than two independent clients. Two managers restored from one
   /// [oauth.OAuthSession] each hold their own copy of it, and a rotating
   /// refresh token is only honoured once: whichever refreshes first spends it,
-  /// and the other's refresh comes back as an `OAuthSessionRevokedException`
-  /// — the signal to send the user back through authorization — for a session
-  /// that was working moments earlier. Build the manager yourself and pass it
+  /// and the other then spends a wasted token request discovering that. It
+  /// recovers — the rejected refresh falls back to whatever the shared
+  /// [oauth.OAuthClient]'s session store now holds — but only because both
+  /// managers happen to read the same store, and each still keeps its own
+  /// in-memory copy in the meantime. Build the manager yourself and pass it
   /// to [BlueskyChat.fromOAuth] when more than one client shares an account.
   factory BlueskyChat.fromOAuthSession(
     final oauth.OAuthSession session, {
@@ -157,7 +159,11 @@ sealed class BlueskyChat {
     final core.GetClient? getClient,
     final core.PostClient? postClient,
   }) => BlueskyChat.fromOAuth(
-    oauth.OAuthSessionManager.fromSession(session, client: oauthClient),
+    oauth.OAuthSessionManager.fromSession(
+      session,
+      client: oauthClient,
+      timeout: timeout,
+    ),
     headers: headers,
     protocol: protocol,
     service: service,

--- a/packages/bluesky/lib/src/ozone_tool.dart
+++ b/packages/bluesky/lib/src/ozone_tool.dart
@@ -177,9 +177,11 @@ sealed class OzoneTool {
   /// session — and what it gets instead is worse than an independent client.
   /// Each manager holds its own copy of [session], and a rotating refresh
   /// token is only honoured once: whichever manager refreshes first spends it,
-  /// and the other's refresh comes back as an `OAuthSessionRevokedException`
-  /// — the signal to send the user back through authorization — for a session
-  /// that was working moments earlier. Build the manager yourself and pass it
+  /// and the other then spends a wasted token request discovering that. It
+  /// recovers — the rejected refresh falls back to whatever the shared
+  /// [oauth.OAuthClient]'s session store now holds — but only because both
+  /// managers happen to read the same store, and each still keeps its own
+  /// in-memory copy in the meantime. Build the manager yourself and pass it
   /// to [OzoneTool.fromOAuth] when more than one client shares an account.
   ///
   /// [ozoneDid] names the Ozone instance to route `tools.ozone.*` to, as in
@@ -197,7 +199,11 @@ sealed class OzoneTool {
     final core.GetClient? getClient,
     final core.PostClient? postClient,
   }) => OzoneTool.fromOAuth(
-    oauth.OAuthSessionManager.fromSession(session, client: oauthClient),
+    oauth.OAuthSessionManager.fromSession(
+      session,
+      client: oauthClient,
+      timeout: timeout,
+    ),
     ozoneDid: ozoneDid,
     headers: headers,
     protocol: protocol,

--- a/packages/bluesky/pubspec.yaml
+++ b/packages/bluesky/pubspec.yaml
@@ -1,7 +1,7 @@
 name: bluesky
 resolution: workspace
 description: The most famous and powerful Dart/Flutter library for Bluesky Social.
-version: 2.4.5
+version: 2.4.6
 homepage: https://atprotodart.com
 documentation: https://atprotodart.com/docs/packages/bluesky
 repository: https://github.com/myConsciousness/atproto.dart/tree/main/packages/bluesky
@@ -18,8 +18,8 @@ topics:
   - api
 
 dependencies:
-  atproto_core: ^2.4.0
-  atproto: ^2.4.1
+  atproto_core: ^2.4.1
+  atproto: ^2.4.2
   freezed_annotation: ^3.1.0
   json_annotation: ^4.9.0
   characters: ^1.4.0
@@ -38,6 +38,6 @@ dev_dependencies:
 
   atproto_test:
     path: ../atproto_test
-  atproto_oauth: ^0.7.1
+  atproto_oauth: ^0.8.0
   http: any
   fake_async: ^1.3.3

--- a/packages/bluesky/test/src/oauth_session_sharing_test.dart
+++ b/packages/bluesky/test/src/oauth_session_sharing_test.dart
@@ -322,7 +322,8 @@ void main() {
   });
 
   group('fromOAuthSession does not share', () {
-    test('the second manager replays the spent refresh token', () async {
+    test('the second manager replays the spent refresh token but recovers '
+        'from the shared session store', () async {
       final server = _FakeAuthServer();
       final client = OAuthClient(_clientMetadata(), httpClient: server.client);
       final stale = session(expiresAt: _expired());
@@ -350,13 +351,23 @@ void main() {
       await bsky.feed.getTimeline();
 
       //! The chat manager never saw the rotation, so it presents the refresh
-      //! token the timeline call already spent and the server revokes it. This
-      //! is why `fromOAuth` with a manager the caller owns is the way to share.
-      await expectLater(
-        chat.convo.listConvos(),
-        throwsA(isA<OAuthSessionRevokedException>()),
-      );
+      //! token the timeline call already spent and the server rejects it. That
+      //! `invalid_grant` only means "that token is gone", not "the account is
+      //! gone": both managers share one `OAuthClient`, so its session store
+      //! already holds the rotated session and the call recovers from there
+      //! instead of logging the user out.
+      await chat.convo.listConvos();
       expect(server.tokenPosts, 2);
+
+      //! Recovering is not the same as sharing. The rotation still cost a
+      //! wasted token POST, and the two managers still hold their own copies
+      //! of the session — this one only caught up because it happened to be
+      //! reading the same store. Pass a manager you own to `fromOAuth` when
+      //! more than one client backs the same account.
+      expect(
+        identical(bsky.oAuthSessionManager, chat.oAuthSessionManager),
+        isFalse,
+      );
     });
   });
 }

--- a/templates/feed_generator/pubspec.yaml
+++ b/templates/feed_generator/pubspec.yaml
@@ -7,8 +7,8 @@ environment:
   sdk: ">=3.8.0 <4.0.0"
 
 dependencies:
-  bluesky: ^2.4.5
-  atproto_core: ^2.4.0
+  bluesky: ^2.4.6
+  atproto_core: ^2.4.1
   atproto_identity: ^0.3.0
   shelf: ^1.4.0
   shelf_router: ^1.1.0


### PR DESCRIPTION
Three findings from an audit of the authentication surface and session-management logic.

## 1. `revoke` never revoked anything (medium)

`OAuthClient.revoke` was local-only — it dropped the session from the `OAuthSessionStore` and sent nothing:

```dart
Future<void> revoke(final OAuthSession session) async {
  await _sessionStore.delete(session.sub);
}
```

So after a "log out", the refresh token stayed live at the authorization server for its full lifetime. Anyone holding a copy — a leaked backup, a shared device, a store that was compromised before the logout — could keep minting access tokens against an account the user believes is signed out. Local deletion hides the credential from this client; it does not invalidate it.

When the server publishes an RFC 7009 `revocation_endpoint`, the refresh token is now POSTed to it with a DPoP proof before the local delete. The refresh token is revoked in preference to the access token because revoking it takes the whole grant down, whereas revoking an access token leaves the refresh token able to mint new ones.

The call is best-effort in both directions: a server that publishes no endpoint is skipped entirely (there is no conventional atproto path to guess at, so a POST to a made-up URL would just 404), and a network or server-side failure is swallowed so an unreachable authorization server can never strand a session in the local store. RFC 7009 §2.2 already requires a `200` for an unknown token, so a failure here carries little signal.

`revocation_endpoint` is parsed into `OAuthServerMetadata` and held to the same `https` + same-origin-as-issuer check that `pushed_authorization_request_endpoint`, `authorization_endpoint` and `token_endpoint` already get — a metadata document cannot point the revocation POST at another host.

## 2. The OAuth refresh path had no timeout (medium)

`atproto_core` bounds the legacy (non-OAuth) refresh callback, with the reasoning written out at `service_context.dart:115`:

> Bounded by `timeout`: a user-supplied callback that hangs must not hold every request on this context behind the single flight indefinitely.

The OAuth path had exactly the same structure and none of the bound. Every request on an `OAuthSessionManager` queues behind its restore/refresh single flight, so an unbounded token call — a hung server, a stalled connection, an injected `OAuthClient` whose I/O never completes, a wedged session store — held *all* of them forever with no way out.

`OAuthSessionManager` now takes a `timeout` (default 30s via `defaultOAuthSessionTimeout`, matching `atproto_core`'s `defaultTimeout`), applied to both `_refresh` and `_load`. `ATProto.fromOAuthSession`, `Bluesky.fromOAuthSession`, `BlueskyChat.fromOAuthSession` and `OzoneTool.fromOAuthSession` pass their own `timeout` through, so the bound the caller already asked for now governs the whole path rather than just the XRPC call.

## 3. A stale `invalid_grant` logged the user out of a valid session (low)

v0.5.0 added a guard so a stale refresh failure could not *delete* a newer stored session — but it still threw afterwards:

```dart
final current = await _sessionStore.find(session.sub);
if (current != null && current.refreshToken == refreshToken) {
  await _sessionStore.delete(session.sub);
}
throw OAuthSessionRevokedException(...);   // <- even when the store moved on
```

Under refresh-token rotation, a losing concurrent refresh gets `invalid_grant` for a token that was legitimately spent moments earlier. That says the *tried token* is gone; it says nothing about the session now in the store. Reporting it as revoked sends the caller to re-authorize an account that holds a perfectly valid session — undoing the very thing the delete-guard was added to protect.

The stored session is now returned when it has already rotated past the tried token. `OAuthSessionRevokedException` is raised only when the session that actually failed is still the one stored (or nothing is stored at all).

## Verification

- `dart analyze` across the workspace — clean
- `dart format --set-exit-if-changed` — no changes
- `dart run ./scripts/validate_dependencies.dart` — 14 packages pass
- `atproto_oauth` 120 tests, `atproto_core` 190, `atproto` 389, `bluesky` 976, `scripts` 44 — all pass

New regression coverage: the revocation POST body and DPoP header, the access-token fallback when no refresh token is held, the no-endpoint skip, the local delete surviving a dead server, an off-origin `revocation_endpoint`, a hung refresh, a hung restore, and the stale-`invalid_grant` recovery.

Two existing tests asserted the old behavior and were rewritten rather than deleted. `oauth_session_sharing_test.dart` documented that two managers built from one session end in `OAuthSessionRevokedException`; because they share an `OAuthClient`, and therefore its session store, the loser now recovers from the store instead. The test asserts that recovery and keeps making the original point — the rotation still costs a wasted token POST and the managers still hold divergent copies, so `fromOAuth` with a manager you own is still the way to share an account. The `fromOAuthSession` docstrings were corrected to match.

## Versions

| Package | Version | Why |
| --- | --- | --- |
| `atproto_oauth` | 0.7.1 → 0.8.0 | all three fixes; new public API |
| `atproto_core` | 2.4.0 → 2.4.1 | constraint bump |
| `atproto` | 2.4.1 → 2.4.2 | timeout threading |
| `bluesky` | 2.4.5 → 2.4.6 | timeout threading |

---
_Generated by [Claude Code](https://claude.ai/code/session_016ManHiFgPPPqMpshziygZi)_