### PR TITLE
feat(atproto): persist the firehose cursor across reconnects and restarts

### DIFF
--- a/packages/atproto/CHANGELOG.md
+++ b/packages/atproto/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Release Note
 
+## v2.5.0
+
+- feat: added `Firehose`, a durable `com.atproto.sync.subscribeRepos` consumer. It connects, hands each decoded message to a handler, reconnects with exponential backoff and jitter when the relay drops the connection, and — the part that was missing — persists how far it got so a restart resumes instead of skipping to the live edge. `subscribeReposAsMessages` is unchanged; `Firehose` is a layer on top of it, not a replacement.
+- feat: added `CursorStore` (with an `InMemoryCursorStore` default), the injection point for durable cursor storage, matching the `OAuthStateStore` / `OAuthSessionStore` / `DPoPNonceCache` pattern. `delete()` is part of the interface because a relay answers a cursor that is ahead of its own stream with `FutureCursor` on every reconnect: without a way to discard the cursor, a consumer that has read past its relay never recovers.
+- feat: `Firehose` takes a handler rather than exposing a `Stream`. A stream can only report when a message was *delivered*, never when the consumer finished with it, so advancing the cursor on delivery would lose everything in flight when a process dies — the exact loss a persisted cursor exists to prevent. The completion of the handler's future is the only evidence a message was handled, so delivery is at-least-once and handlers should be idempotent.
+- feat: cursor writes are batched (`flushEveryEvents`, default 100; `flushEveryInterval`, default 5s) because the full-network firehose runs at hundreds to thousands of events per second and a write per message would put the store on the hot path. The replay window after a crash is bounded by those same settings, and a flush is forced before every reconnect and on `stop()`.
+- feat: an `#info` `OutdatedCursor` is surfaced through `onError` as `FirehoseOutdatedCursorException` instead of passing silently. It means the relay no longer holds the requested cursor and resumed from the oldest event it does hold, so events have already been lost — without the signal the caller has no way to notice the gap.
+
 ## v2.4.2
 
 - fix: `ATProto.fromOAuthSession` passes its `timeout` through to the `OAuthSessionManager` it builds, so a hung restore or refresh is bounded by the timeout the caller asked for instead of running unbounded.

--- a/packages/atproto/lib/firehose.dart
+++ b/packages/atproto/lib/firehose.dart
@@ -3,5 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 export 'package:atproto/com_atproto_sync_subscriberepos.dart';
+export 'package:atproto/src/firehose/cursor_store.dart';
+export 'package:atproto/src/firehose/firehose.dart';
 export 'package:atproto/src/firehose/firehose_adaptor.dart';
 export 'package:atproto/src/firehose/sync_subscribe_repos_adaptor.dart';

--- a/packages/atproto/lib/src/firehose/cursor_store.dart
+++ b/packages/atproto/lib/src/firehose/cursor_store.dart
@@ -1,0 +1,53 @@
+// Copyright (c) 2023-2026, Shinya Kato.
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// Persistence for the firehose cursor: the sequence number (`seq`) of the
+/// last message a consumer finished processing.
+///
+/// A firehose consumer that does not persist its cursor restarts from the live
+/// edge of the stream, silently losing every event that occurred while it was
+/// down. Storing the cursor and passing it back on reconnect is what turns a
+/// restart into a gap-free resume.
+///
+/// The implementation is left to the caller — a file, SQLite, Redis, a row in
+/// the same database the consumer already writes to — matching the injection
+/// pattern used by `OAuthStateStore`, `OAuthSessionStore` and `DPoPNonceCache`.
+/// [InMemoryCursorStore] is provided for tests and short-lived processes.
+abstract interface class CursorStore {
+  /// Returns the stored cursor, or `null` when none has been stored yet (a
+  /// first run, or after [delete]).
+  Future<int?> find();
+
+  /// Stores [cursor] as the latest processed sequence number.
+  Future<void> set(final int cursor);
+
+  /// Discards the stored cursor so the next subscription starts from the live
+  /// edge.
+  ///
+  /// This is not merely a convenience: a relay answers a cursor that is ahead
+  /// of its own stream with a `FutureCursor` error, which repeats on every
+  /// reconnect. Without a way to discard the cursor, a consumer that has read
+  /// past its relay — because the relay was rolled back, or because it was
+  /// pointed at a different relay — reconnects forever and never recovers.
+  Future<void> delete();
+}
+
+/// A [CursorStore] that keeps the cursor in memory only.
+///
+/// The default when no store is injected. It makes the cursor survive
+/// reconnects within one process, which is what keeps a relay hiccup from
+/// losing events, but not a restart — for that the caller must supply a
+/// durable implementation.
+final class InMemoryCursorStore implements CursorStore {
+  int? _cursor;
+
+  @override
+  Future<int?> find() async => _cursor;
+
+  @override
+  Future<void> set(final int cursor) async => _cursor = cursor;
+
+  @override
+  Future<void> delete() async => _cursor = null;
+}

--- a/packages/atproto/lib/src/firehose/firehose.dart
+++ b/packages/atproto/lib/src/firehose/firehose.dart
@@ -1,0 +1,520 @@
+// Copyright (c) 2023-2026, Shinya Kato.
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// Dart imports:
+import 'dart:async';
+import 'dart:math';
+
+// Project imports:
+import '../services/codegen/com/atproto/sync/subscribeRepos/info_name.dart';
+import '../services/codegen/com/atproto/sync/subscribeRepos/union_main_message.dart';
+import 'cursor_store.dart';
+import 'firehose_adaptor.dart';
+
+/// An open firehose subscription: the message [stream] plus the [close]
+/// callback that tears the underlying socket down.
+///
+/// [Firehose] closes every connection it opens — after a clean close, after a
+/// stream error and on [Firehose.stop] — so the reconnect loop cannot leak
+/// sockets. [close] must therefore be safe to call more than once.
+final class FirehoseConnection {
+  /// Returns the new instance of [FirehoseConnection].
+  const FirehoseConnection(this.stream, {this.close});
+
+  /// The decoded firehose message stream.
+  final Stream<USyncSubscribeReposMessage> stream;
+
+  /// Tears down the underlying socket, or `null` when there is nothing to tear
+  /// down (an in-memory stream in a test, say).
+  final Future<void> Function()? close;
+}
+
+/// Opens a firehose subscription starting after [cursor], or from the live
+/// edge when it is `null`.
+///
+/// Injectable so tests can drive the reconnect loop, and the cursor handling
+/// that rides on it, without a live socket.
+typedef FirehoseConnector = Future<FirehoseConnection> Function(int? cursor);
+
+/// Handles one firehose message.
+///
+/// The returned future's completion is what advances the cursor, so a handler
+/// that persists must not complete before that write does. Throwing is
+/// tolerated (see [Firehose.start]).
+typedef FirehoseMessageHandler =
+    FutureOr<void> Function(USyncSubscribeReposMessage message);
+
+/// The exponential reconnect delay before connection attempt `failures + 1`,
+/// given `failures` consecutive failures so far (>= 1):
+/// `initial * 2^(failures - 1)`, capped at [max].
+///
+/// This is the deterministic base delay; [Firehose] adds random jitter on top
+/// so a fleet of instances that lost the same relay does not retry in lockstep.
+Duration reconnectBackoff(
+  final int failures, {
+  final Duration initial = const Duration(seconds: 1),
+  final Duration max = const Duration(minutes: 1),
+}) {
+  // Cap the exponent so the shift can never overflow before `max` applies.
+  final exponent = (failures - 1).clamp(0, 30);
+  final delay = initial * (1 << exponent);
+
+  return delay > max ? max : delay;
+}
+
+/// Default number of handled messages between cursor writes.
+const defaultFlushEveryEvents = 100;
+
+/// Default wall-clock interval between cursor writes.
+const defaultFlushEveryInterval = Duration(seconds: 5);
+
+/// A durable firehose consumer: it connects, hands each message to a handler,
+/// reconnects with exponential backoff when the connection drops, and persists
+/// how far it got so a restart resumes instead of skipping ahead to the live
+/// edge.
+///
+/// ## Why a handler and not a `Stream`
+///
+/// Exposing a `Stream` would be the more idiomatic Dart shape, but it cannot
+/// carry the cursor correctly: a stream tells this class when a message was
+/// *delivered*, never when the consumer *finished* with it. Advancing on
+/// delivery loses everything that was in flight when the process died — the
+/// exact loss a persisted cursor exists to prevent. The completion of the
+/// future returned by [FirehoseMessageHandler] is the only evidence that a
+/// message was handled, so [start] takes a handler and the delivery guarantee
+/// is **at-least-once**: after a crash, messages inside the unflushed window
+/// are replayed. Handlers should be idempotent.
+///
+/// Callers who do not care about the cursor can keep using
+/// `atproto.sync.subscribeReposAsMessages()` directly, which is unchanged.
+///
+/// ## Example
+///
+/// ```dart
+/// final firehose = Firehose(
+///   connect: (cursor) async {
+///     final subscription = await atproto.sync.subscribeReposAsMessages(
+///       cursor: cursor,
+///     );
+///
+///     return FirehoseConnection(
+///       subscription.data.stream,
+///       close: subscription.data.close,
+///     );
+///   },
+///   cursorStore: MyCursorStore(),
+/// );
+///
+/// await firehose.start((message) async {
+///   if (message.isCommit) await index(message.commit!);
+/// });
+/// ```
+final class Firehose {
+  /// Returns the new instance of [Firehose].
+  Firehose({
+    required final FirehoseConnector connect,
+    final CursorStore? cursorStore,
+    this.initialBackoff = const Duration(seconds: 1),
+    this.maxBackoff = const Duration(minutes: 1),
+    this.healthyConnectionThreshold = const Duration(seconds: 30),
+    this.jitter = 0.2,
+    this.flushEveryEvents = defaultFlushEveryEvents,
+    this.flushEveryInterval = defaultFlushEveryInterval,
+    final void Function(Object error, StackTrace stackTrace)? onError,
+    final Random? random,
+  }) : _connect = connect,
+       _cursorStore = cursorStore ?? InMemoryCursorStore(),
+       _onError = onError,
+       _random = random ?? Random() {
+    if (jitter < 0 || jitter > 1) {
+      throw ArgumentError.value(jitter, 'jitter', 'must be within 0.0..1.0');
+    }
+    if (flushEveryEvents < 1) {
+      throw ArgumentError.value(
+        flushEveryEvents,
+        'flushEveryEvents',
+        'must be at least 1',
+      );
+    }
+  }
+
+  final FirehoseConnector _connect;
+  final CursorStore _cursorStore;
+  final void Function(Object error, StackTrace stackTrace)? _onError;
+  final Random _random;
+
+  /// The reconnect delay after the first failure; doubles per consecutive
+  /// failure up to [maxBackoff].
+  final Duration initialBackoff;
+  final Duration maxBackoff;
+
+  /// How long a connection must stay up before it counts as healthy and the
+  /// consecutive-failure counter is reset.
+  final Duration healthyConnectionThreshold;
+
+  /// The fraction of the base delay added at random, in `0.0..1.0`. Keeps a
+  /// fleet of instances from reconnecting in lockstep after a shared outage.
+  final double jitter;
+
+  /// How many handled messages may pass between cursor writes.
+  ///
+  /// The full-network firehose runs at hundreds to thousands of events per
+  /// second, so writing the cursor per message would put the store on the hot
+  /// path. Batching bounds the write rate, and the price is bounded too: at
+  /// most this many messages are replayed after a crash.
+  final int flushEveryEvents;
+
+  /// How long may pass between cursor writes.
+  ///
+  /// Needed alongside [flushEveryEvents] because a low-traffic relay — a
+  /// single PDS's firehose, say — would otherwise leave the cursor unwritten
+  /// for minutes at a time.
+  final Duration flushEveryInterval;
+
+  /// Completed by [stop]; also used to interrupt the reconnect sleep.
+  final Completer<void> _stopSignal = Completer<void>();
+
+  FirehoseConnection? _connection;
+  StreamSubscription<USyncSubscribeReposMessage>? _subscription;
+  Completer<void>? _consumed;
+
+  /// The highest handled `seq`, and the bookkeeping that decides when to write
+  /// it.
+  int? _pendingCursor;
+  int _handledSinceFlush = 0;
+  DateTime? _lastFlushAt;
+
+  /// The last value actually written, so a forced flush that has nothing new to
+  /// say writes nothing. Without it a reconnect loop that keeps failing before
+  /// any message arrives would rewrite the same cursor on every attempt.
+  int? _writtenCursor;
+
+  /// Serializes cursor writes. A slow store (a network round trip) could
+  /// otherwise have two flushes in flight and let the older value land last,
+  /// moving the cursor backwards.
+  Future<void>? _inFlightFlush;
+
+  /// Set when the relay rejects the stored cursor as being ahead of its own
+  /// stream, so the next connection is made without one.
+  bool _cursorDiscarded = false;
+
+  bool get _stopped => _stopSignal.isCompleted;
+
+  /// Runs until [stop] is called: connects, hands every message to [onMessage],
+  /// and reconnects with exponential backoff when the connection fails or
+  /// closes.
+  ///
+  /// A handler that throws is reported to `onError` and the message is skipped
+  /// — one bad message must not take the consumer down. Its `seq` is not
+  /// written, but a later successful message will advance the cursor past it,
+  /// so the skipped message is not retried on restart: retry and dead-lettering
+  /// belong to the handler.
+  Future<void> start(final FirehoseMessageHandler onMessage) async {
+    var consecutiveFailures = 0;
+    // Anchor the interval here rather than treating "never flushed" as overdue,
+    // which would make the first message of every run a special case.
+    _lastFlushAt ??= DateTime.now();
+
+    while (!_stopped) {
+      final uptime = Stopwatch()..start();
+      try {
+        final cursor = _cursorDiscarded ? null : await _cursorStore.find();
+        final connection = _connection = await _connect(cursor);
+        try {
+          if (_stopped) break;
+          // Completes when the relay closes the stream; throws on a stream
+          // error. Either way we fall through to the reconnect delay below.
+          await _consume(connection.stream, onMessage);
+        } finally {
+          _connection = null;
+          await _closeQuietly(connection);
+        }
+      } on Object catch (e, st) {
+        // `Object`, not `Exception`: an `Error` escaping here (a `RangeError`
+        // from a decoder edge case, say) would otherwise kill the consumer
+        // permanently after a single attempt.
+        await _handleConnectionFailure(e, st);
+      }
+
+      // The cursor must be durable before the next subscription asks for it,
+      // otherwise the reconnect resumes from a stale position.
+      await _flushCursor(force: true);
+      if (_stopped) break;
+
+      // Only a connection that actually stayed up counts as a success. A
+      // socket that fails immediately must keep growing the delay.
+      if (uptime.elapsed >= healthyConnectionThreshold) {
+        consecutiveFailures = 0;
+      }
+      consecutiveFailures++;
+
+      await _sleep(
+        _withJitter(
+          reconnectBackoff(
+            consecutiveFailures,
+            initial: initialBackoff,
+            max: maxBackoff,
+          ),
+        ),
+      );
+    }
+
+    // `break` can leave a connection open when stop() raced the connect.
+    await _closeQuietly(_connection);
+    _connection = null;
+    await _flushCursor(force: true);
+  }
+
+  /// Stops the consumer, tears the live connection down and writes out the
+  /// pending cursor, after which [start] returns.
+  ///
+  /// A healthy firehose stream never ends, so stopping cannot mean "wait for
+  /// the stream to finish": this cancels the in-flight subscription, closes the
+  /// socket and wakes any pending reconnect sleep. Safe to call more than once,
+  /// and safe to call before or during [start] — a connection that is still
+  /// being established is closed as soon as it opens.
+  Future<void> stop() async {
+    if (!_stopSignal.isCompleted) _stopSignal.complete();
+
+    final subscription = _subscription;
+    _subscription = null;
+    await subscription?.cancel();
+
+    // Cancelling a subscription never delivers a done event, so release
+    // `_consume` explicitly or `start` would wait on it forever.
+    final consumed = _consumed;
+    _consumed = null;
+    if (consumed != null && !consumed.isCompleted) consumed.complete();
+
+    final connection = _connection;
+    _connection = null;
+    await _closeQuietly(connection);
+
+    await _flushCursor(force: true);
+  }
+
+  /// Listens to [messages] until the stream ends, errors, or [stop] cancels it.
+  Future<void> _consume(
+    final Stream<USyncSubscribeReposMessage> messages,
+    final FirehoseMessageHandler onMessage,
+  ) {
+    final completer = Completer<void>();
+    _consumed = completer;
+
+    final subscription = messages.listen(null, cancelOnError: true);
+    _subscription = subscription;
+
+    subscription
+      ..onData((final message) {
+        // Pausing until the message is handled preserves the backpressure an
+        // `await for` gave us: the socket stops being drained while a slow
+        // handler is in flight.
+        subscription.pause(_handleMessage(message, onMessage));
+      })
+      ..onError((final Object error, final StackTrace stackTrace) {
+        if (!completer.isCompleted) completer.completeError(error, stackTrace);
+      })
+      ..onDone(() {
+        if (!completer.isCompleted) completer.complete();
+      });
+
+    return completer.future.whenComplete(() async {
+      if (identical(_consumed, completer)) _consumed = null;
+      if (identical(_subscription, subscription)) _subscription = null;
+      await subscription.cancel();
+    });
+  }
+
+  /// Handles one message and, on success, records its `seq` as processed.
+  ///
+  /// Never throws: a failing handler must not tear the subscription down.
+  Future<void> _handleMessage(
+    final USyncSubscribeReposMessage message,
+    final FirehoseMessageHandler onMessage,
+  ) async {
+    _reportOutdatedCursor(message);
+
+    try {
+      await onMessage(message);
+    } on Object catch (e, st) {
+      _report(e, st);
+
+      return;
+    }
+
+    // `#info` carries no `seq`, so there is nothing to advance to.
+    final seq = _seqOf(message);
+    if (seq == null) return;
+
+    _pendingCursor = seq;
+    _handledSinceFlush++;
+
+    await _flushCursor();
+  }
+
+  /// Writes [_pendingCursor] when the batch thresholds are met, or whenever
+  /// [force] is set (reconnect and shutdown, where the next read must see it).
+  Future<void> _flushCursor({final bool force = false}) async {
+    final cursor = _pendingCursor;
+    if (cursor == null || cursor == _writtenCursor) return;
+
+    if (!force) {
+      final lastFlushAt = _lastFlushAt;
+      final due =
+          _handledSinceFlush >= flushEveryEvents ||
+          lastFlushAt == null ||
+          DateTime.now().difference(lastFlushAt) >= flushEveryInterval;
+      if (!due) return;
+    }
+
+    // Serialize: an older value must never land after a newer one.
+    final previous = _inFlightFlush;
+    if (previous != null) await previous;
+
+    // The wait above may have carried the cursor forward, or written it.
+    final latest = _pendingCursor;
+    if (latest == null || latest == _writtenCursor) return;
+
+    final flush = _writeCursor(latest);
+    _inFlightFlush = flush;
+    try {
+      await flush;
+    } finally {
+      if (identical(_inFlightFlush, flush)) _inFlightFlush = null;
+    }
+  }
+
+  Future<void> _writeCursor(final int cursor) async {
+    try {
+      await _cursorStore.set(cursor);
+      _writtenCursor = cursor;
+      _handledSinceFlush = 0;
+      _lastFlushAt = DateTime.now();
+    } on Object catch (e, st) {
+      // A store that is momentarily unavailable must not stop the consumer;
+      // the cursor stays pending and the next flush retries it.
+      _report(e, st);
+    }
+  }
+
+  /// Reacts to a failed or lost connection.
+  ///
+  /// A `FutureCursor` means the stored cursor is ahead of the relay's own
+  /// stream — the relay was rolled back, or this consumer was pointed at a
+  /// different one. The cursor can only be wrong, and re-sending it would fail
+  /// identically forever, so it is discarded and the next connection starts
+  /// from the live edge. Every other failure (including `ConsumerTooSlow`,
+  /// where the cursor is perfectly good) keeps it.
+  Future<void> _handleConnectionFailure(
+    final Object error,
+    final StackTrace stackTrace,
+  ) async {
+    _report(error, stackTrace);
+
+    if (error is FirehoseErrorException && error.error == 'FutureCursor') {
+      _pendingCursor = null;
+      _writtenCursor = null;
+      _handledSinceFlush = 0;
+      _cursorDiscarded = true;
+      try {
+        await _cursorStore.delete();
+      } on Object catch (e, st) {
+        _report(e, st);
+      }
+    }
+  }
+
+  /// Surfaces an `#info` `OutdatedCursor` to the caller.
+  ///
+  /// It means the relay no longer holds the requested cursor and has started
+  /// from the oldest event it does hold: events have already been lost. Passing
+  /// it silently would leave the caller with no way to notice the gap.
+  void _reportOutdatedCursor(final USyncSubscribeReposMessage message) {
+    final info = message.info;
+    if (info == null) return;
+    if (info.name.knownValue != KnownInfoName.outdatedCursor) return;
+
+    _report(FirehoseOutdatedCursorException(info.message), StackTrace.current);
+  }
+
+  void _report(final Object error, final StackTrace stackTrace) {
+    final onError = _onError;
+    if (onError == null) return;
+
+    try {
+      onError(error, stackTrace);
+    } on Object {
+      // A throwing error handler must not become the failure itself.
+    }
+  }
+
+  /// The sequence number of [message], or `null` for `#info` (which carries
+  /// none) and for a frame this version does not understand.
+  static int? _seqOf(final USyncSubscribeReposMessage message) {
+    if (message.isCommit) return message.commit!.seq;
+    if (message.isSync) return message.sync!.seq;
+    if (message.isIdentity) return message.identity!.seq;
+    if (message.isAccount) return message.account!.seq;
+
+    return null;
+  }
+
+  Duration _withJitter(final Duration delay) {
+    if (jitter <= 0) return delay;
+    final spread = (delay.inMicroseconds * jitter).round();
+    if (spread <= 0) return delay;
+
+    return delay + Duration(microseconds: _random.nextInt(spread + 1));
+  }
+
+  /// Waits [delay], or returns early when [stop] is called.
+  Future<void> _sleep(final Duration delay) {
+    if (_stopped) return Future<void>.value();
+
+    final completer = Completer<void>();
+    final timer = Timer(delay, () {
+      if (!completer.isCompleted) completer.complete();
+    });
+    unawaited(
+      _stopSignal.future.then((_) {
+        timer.cancel();
+        if (!completer.isCompleted) completer.complete();
+      }),
+    );
+
+    return completer.future;
+  }
+
+  Future<void> _closeQuietly(final FirehoseConnection? connection) async {
+    final close = connection?.close;
+    if (close == null) return;
+
+    try {
+      await close();
+    } on Object catch (e, st) {
+      // A failed teardown must never abort the reconnect loop.
+      _report(e, st);
+    }
+  }
+}
+
+/// Reported through `Firehose.onError` when the relay answers with an `#info`
+/// `OutdatedCursor`.
+///
+/// Not thrown: the subscription continues from wherever the relay resumed it.
+/// It is surfaced because it is the only signal that events between the
+/// requested cursor and that point have been lost for good.
+final class FirehoseOutdatedCursorException implements Exception {
+  /// Returns the new instance of [FirehoseOutdatedCursorException].
+  const FirehoseOutdatedCursorException([this.message]);
+
+  /// The optional human readable message sent by the relay.
+  final String? message;
+
+  @override
+  String toString() =>
+      'FirehoseOutdatedCursorException: the requested cursor is older than the '
+      'relay retains, so events before the resumed position were skipped'
+      '${message == null ? '' : ' ($message)'}';
+}

--- a/packages/atproto/pubspec.yaml
+++ b/packages/atproto/pubspec.yaml
@@ -1,7 +1,7 @@
 name: atproto
 resolution: workspace
 description: The most famous and powerful Dart/Flutter library for AT Protocol.
-version: 2.4.2
+version: 2.5.0
 homepage: https://atprotodart.com
 documentation: https://atprotodart.com/docs/packages/atproto
 repository: https://github.com/myConsciousness/atproto.dart/tree/main/packages/atproto

--- a/packages/atproto/test/src/firehose/firehose_test.dart
+++ b/packages/atproto/test/src/firehose/firehose_test.dart
@@ -1,0 +1,529 @@
+// Copyright (c) 2023-2026, Shinya Kato.
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// Dart imports:
+import 'dart:async';
+import 'dart:math';
+
+// Package imports:
+import 'package:test/test.dart';
+
+// Project imports:
+import 'package:atproto/firehose.dart';
+
+const _did = 'did:plc:abcdefghijklmnopqrstuvwx';
+
+USyncSubscribeReposMessage _commit(final int seq) =>
+    USyncSubscribeReposMessage.commit(
+      data: Commit(
+        seq: seq,
+        repo: _did,
+        commit: 'bafyreiabc',
+        rev: '3kaa',
+        since: null,
+        blocks: const {},
+        ops: const [],
+        time: DateTime.utc(2026),
+      ),
+    );
+
+USyncSubscribeReposMessage _identity(final int seq) =>
+    USyncSubscribeReposMessage.identity(
+      data: Identity(seq: seq, did: _did, time: DateTime.utc(2026)),
+    );
+
+USyncSubscribeReposMessage _info({
+  final String name = 'OutdatedCursor',
+  final String? message,
+}) => USyncSubscribeReposMessage.info(
+  data: Info(name: InfoName.valueOf(name)!, message: message),
+);
+
+/// A [CursorStore] that records every write, so batching can be asserted on
+/// call count rather than on the final value alone.
+class _RecordingCursorStore implements CursorStore {
+  _RecordingCursorStore({this.initial, this.writeDelay});
+
+  int? initial;
+  final Duration? writeDelay;
+
+  final List<int> writes = [];
+  int deleteCalls = 0;
+
+  @override
+  Future<int?> find() async => initial;
+
+  @override
+  Future<void> set(final int cursor) async {
+    if (writeDelay != null) await Future<void>.delayed(writeDelay!);
+    writes.add(cursor);
+    initial = cursor;
+  }
+
+  @override
+  Future<void> delete() async {
+    deleteCalls++;
+    initial = null;
+  }
+}
+
+/// Drives the reconnect loop without a socket. Each connection replays one
+/// scripted batch of messages, then ends (or errors) so the loop reconnects.
+class _ScriptedRelay {
+  _ScriptedRelay(this.batches);
+
+  /// One entry per connection: the messages to deliver, or an error to raise.
+  final List<Object> batches;
+
+  /// The cursor each connection was opened with, in order.
+  final List<int?> requestedCursors = [];
+
+  int _attempt = 0;
+
+  FirehoseConnector get connect => (final cursor) async {
+    requestedCursors.add(cursor);
+    final batch = _attempt < batches.length
+        ? batches[_attempt]
+        : const <USyncSubscribeReposMessage>[];
+    _attempt++;
+
+    if (batch is! List) {
+      return FirehoseConnection(
+        Stream<USyncSubscribeReposMessage>.error(batch),
+      );
+    }
+
+    return FirehoseConnection(
+      Stream<USyncSubscribeReposMessage>.fromIterable(
+        batch.cast<USyncSubscribeReposMessage>(),
+      ),
+    );
+  };
+}
+
+/// Runs [firehose] until [until] returns true, then stops it. Keeps the tests
+/// from depending on wall-clock sleeps in the reconnect loop.
+Future<void> _runUntil(
+  final Firehose firehose,
+  final FirehoseMessageHandler onMessage,
+  final bool Function() until,
+) async {
+  final run = firehose.start(onMessage);
+
+  final deadline = DateTime.now().add(const Duration(seconds: 5));
+  while (!until() && DateTime.now().isBefore(deadline)) {
+    await Future<void>.delayed(const Duration(milliseconds: 1));
+  }
+
+  await firehose.stop();
+  await run;
+}
+
+Firehose _firehose({
+  required final FirehoseConnector connect,
+  final CursorStore? cursorStore,
+  final int flushEveryEvents = defaultFlushEveryEvents,
+  final Duration flushEveryInterval = const Duration(hours: 1),
+  final void Function(Object error, StackTrace stackTrace)? onError,
+}) => Firehose(
+  connect: connect,
+  cursorStore: cursorStore,
+  flushEveryEvents: flushEveryEvents,
+  flushEveryInterval: flushEveryInterval,
+  onError: onError,
+  // Keep the reconnect loop from actually sleeping between attempts.
+  initialBackoff: Duration.zero,
+  maxBackoff: Duration.zero,
+  jitter: 0,
+  random: Random(0),
+);
+
+void main() {
+  group('cursor advancement', () {
+    test('records the seq of every handled message', () async {
+      final store = _RecordingCursorStore();
+      final relay = _ScriptedRelay([
+        [_commit(1), _identity(2), _commit(3)],
+      ]);
+      final handled = <int>[];
+
+      await _runUntil(
+        _firehose(
+          connect: relay.connect,
+          cursorStore: store,
+          flushEveryEvents: 1,
+        ),
+        (message) async => handled.add(message.commit?.seq ?? -1),
+        () => handled.length >= 3,
+      );
+
+      expect(store.writes, [1, 2, 3]);
+    });
+
+    test('does not advance past a message whose handler threw', () async {
+      final store = _RecordingCursorStore();
+      final relay = _ScriptedRelay([
+        [_commit(1), _commit(2)],
+      ]);
+      final errors = <Object>[];
+      var seen = 0;
+
+      await _runUntil(
+        _firehose(
+          connect: relay.connect,
+          cursorStore: store,
+          flushEveryEvents: 1,
+          onError: (e, _) => errors.add(e),
+        ),
+        (message) async {
+          seen++;
+          if (message.commit!.seq == 2) throw StateError('boom');
+        },
+        () => seen >= 2,
+      );
+
+      // seq 2 threw, so only seq 1 was ever recorded as processed.
+      expect(store.writes, [1]);
+      expect(errors.single, isA<StateError>());
+    });
+
+    test('#info carries no seq, so it never moves the cursor', () async {
+      final store = _RecordingCursorStore();
+      final relay = _ScriptedRelay([
+        [_commit(7), _info()],
+      ]);
+      var seen = 0;
+
+      await _runUntil(
+        _firehose(
+          connect: relay.connect,
+          cursorStore: store,
+          flushEveryEvents: 1,
+        ),
+        (_) async => seen++,
+        () => seen >= 2,
+      );
+
+      expect(store.writes, [7]);
+    });
+
+    test('a handler that throws does not tear the subscription down', () async {
+      final relay = _ScriptedRelay([
+        [_commit(1), _commit(2), _commit(3)],
+      ]);
+      final seen = <int>[];
+
+      await _runUntil(_firehose(connect: relay.connect, onError: (_, _) {}), (
+        message,
+      ) async {
+        seen.add(message.commit!.seq);
+        throw StateError('every message fails');
+      }, () => seen.length >= 3);
+
+      expect(seen, [1, 2, 3]);
+    });
+  });
+
+  group('resume', () {
+    test('the stored cursor is passed to the next connection', () async {
+      final store = _RecordingCursorStore(initial: 41);
+      final relay = _ScriptedRelay([
+        [_commit(42)],
+        [_commit(43)],
+      ]);
+      final seen = <int>[];
+
+      await _runUntil(
+        _firehose(
+          connect: relay.connect,
+          cursorStore: store,
+          flushEveryEvents: 1,
+        ),
+        (message) async => seen.add(message.commit!.seq),
+        () => seen.length >= 2,
+      );
+
+      // First connection resumes from what was stored; the second resumes from
+      // where the first one got to.
+      expect(relay.requestedCursors.take(2), [41, 42]);
+    });
+
+    test('a pending cursor is flushed before reconnecting', () async {
+      // flushEveryEvents is high enough that nothing would be written by the
+      // batching rules alone: only the forced flush on reconnect can write.
+      final store = _RecordingCursorStore();
+      final relay = _ScriptedRelay([
+        [_commit(5)],
+        [_commit(6)],
+      ]);
+      var seen = 0;
+
+      await _runUntil(
+        _firehose(
+          connect: relay.connect,
+          cursorStore: store,
+          flushEveryEvents: 1000,
+        ),
+        (_) async => seen++,
+        () => seen >= 2,
+      );
+
+      expect(store.writes.first, 5);
+      expect(relay.requestedCursors[1], 5);
+    });
+  });
+
+  group('FutureCursor', () {
+    test('discards the stored cursor and reconnects without one', () async {
+      final store = _RecordingCursorStore(initial: 99);
+      final relay = _ScriptedRelay([
+        const FirehoseErrorException(error: 'FutureCursor'),
+        [_commit(1)],
+      ]);
+      var seen = 0;
+
+      await _runUntil(
+        _firehose(
+          connect: relay.connect,
+          cursorStore: store,
+          flushEveryEvents: 1,
+          onError: (_, _) {},
+        ),
+        (_) async => seen++,
+        () => seen >= 1,
+      );
+
+      expect(store.deleteCalls, 1);
+      // The first attempt carried the bad cursor; the retry carries none.
+      expect(relay.requestedCursors[0], 99);
+      expect(relay.requestedCursors[1], isNull);
+    });
+
+    test('ConsumerTooSlow keeps the cursor', () async {
+      final store = _RecordingCursorStore(initial: 12);
+      final relay = _ScriptedRelay([
+        const FirehoseErrorException(error: 'ConsumerTooSlow'),
+        [_commit(13)],
+      ]);
+      var seen = 0;
+
+      await _runUntil(
+        _firehose(
+          connect: relay.connect,
+          cursorStore: store,
+          flushEveryEvents: 1,
+          onError: (_, _) {},
+        ),
+        (_) async => seen++,
+        () => seen >= 1,
+      );
+
+      expect(store.deleteCalls, 0);
+      expect(relay.requestedCursors[1], 12);
+    });
+  });
+
+  group('OutdatedCursor', () {
+    test('is surfaced through onError, and the stream continues', () async {
+      final relay = _ScriptedRelay([
+        [_info(message: 'cursor too old'), _commit(1)],
+      ]);
+      final errors = <Object>[];
+      var seen = 0;
+
+      await _runUntil(
+        _firehose(connect: relay.connect, onError: (e, _) => errors.add(e)),
+        (_) async => seen++,
+        () => seen >= 2,
+      );
+
+      // Losing events silently would leave the caller no way to notice a gap.
+      final outdated = errors.whereType<FirehoseOutdatedCursorException>();
+      expect(outdated, hasLength(1));
+      expect(outdated.single.message, 'cursor too old');
+      expect(seen, 2);
+    });
+
+    test('an #info that is not OutdatedCursor is not reported', () async {
+      final relay = _ScriptedRelay([
+        [_info(name: 'SomethingElse'), _commit(1)],
+      ]);
+      final errors = <Object>[];
+      var seen = 0;
+
+      await _runUntil(
+        _firehose(connect: relay.connect, onError: (e, _) => errors.add(e)),
+        (_) async => seen++,
+        () => seen >= 2,
+      );
+
+      expect(errors.whereType<FirehoseOutdatedCursorException>(), isEmpty);
+    });
+  });
+
+  group('write batching', () {
+    test('writes once per flushEveryEvents messages', () async {
+      final store = _RecordingCursorStore();
+      final relay = _ScriptedRelay([
+        List.generate(10, (final i) => _commit(i + 1)),
+      ]);
+      var seen = 0;
+
+      await _runUntil(
+        _firehose(
+          connect: relay.connect,
+          cursorStore: store,
+          flushEveryEvents: 5,
+        ),
+        (_) async => seen++,
+        () => seen >= 10,
+      );
+
+      // Two batched writes during the run; `stop()` force-flushes the last
+      // value, which is already stored, so it is written again at most once.
+      expect(store.writes.take(2), [5, 10]);
+      expect(store.writes.length, lessThanOrEqualTo(3));
+      expect(store.writes.last, 10);
+    });
+
+    test('stop() flushes the pending cursor', () async {
+      final store = _RecordingCursorStore();
+      final relay = _ScriptedRelay([
+        [_commit(1), _commit(2), _commit(3)],
+      ]);
+      var seen = 0;
+
+      await _runUntil(
+        _firehose(
+          connect: relay.connect,
+          cursorStore: store,
+          // Nothing would be written by the batching rules alone.
+          flushEveryEvents: 1000,
+        ),
+        (_) async => seen++,
+        () => seen >= 3,
+      );
+
+      expect(store.writes, isNotEmpty);
+      expect(store.writes.last, 3);
+    });
+
+    test('a slow store never lets an older value land last', () async {
+      final store = _RecordingCursorStore(
+        writeDelay: const Duration(milliseconds: 5),
+      );
+      final relay = _ScriptedRelay([
+        List.generate(6, (final i) => _commit(i + 1)),
+      ]);
+      var seen = 0;
+
+      await _runUntil(
+        _firehose(
+          connect: relay.connect,
+          cursorStore: store,
+          flushEveryEvents: 1,
+        ),
+        (_) async => seen++,
+        () => seen >= 6,
+      );
+
+      expect(store.writes, isNotEmpty);
+      expect(store.writes, orderedEquals(store.writes.toList()..sort()));
+      expect(store.writes.last, 6);
+    });
+
+    test('a store that throws does not stop the consumer', () async {
+      final relay = _ScriptedRelay([
+        [_commit(1), _commit(2)],
+      ]);
+      final errors = <Object>[];
+      var seen = 0;
+
+      await _runUntil(
+        _firehose(
+          connect: relay.connect,
+          cursorStore: _ThrowingCursorStore(),
+          flushEveryEvents: 1,
+          onError: (e, _) => errors.add(e),
+        ),
+        (_) async => seen++,
+        () => seen >= 2,
+      );
+
+      expect(seen, 2);
+      expect(errors, isNotEmpty);
+    });
+  });
+
+  group('construction', () {
+    test('rejects an out-of-range jitter', () {
+      expect(
+        () => Firehose(
+          connect: (_) async => const FirehoseConnection(
+            Stream<USyncSubscribeReposMessage>.empty(),
+          ),
+          jitter: 1.5,
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('rejects a flushEveryEvents below 1', () {
+      expect(
+        () => Firehose(
+          connect: (_) async => const FirehoseConnection(
+            Stream<USyncSubscribeReposMessage>.empty(),
+          ),
+          flushEveryEvents: 0,
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+  });
+
+  group('InMemoryCursorStore', () {
+    test('round-trips and clears', () async {
+      final store = InMemoryCursorStore();
+      expect(await store.find(), isNull);
+
+      await store.set(7);
+      expect(await store.find(), 7);
+
+      await store.delete();
+      expect(await store.find(), isNull);
+    });
+  });
+
+  group('reconnectBackoff', () {
+    test('doubles per failure and caps at max', () {
+      expect(
+        reconnectBackoff(1, initial: const Duration(seconds: 1)),
+        const Duration(seconds: 1),
+      );
+      expect(
+        reconnectBackoff(3, initial: const Duration(seconds: 1)),
+        const Duration(seconds: 4),
+      );
+      expect(
+        reconnectBackoff(
+          99,
+          initial: const Duration(seconds: 1),
+          max: const Duration(minutes: 1),
+        ),
+        const Duration(minutes: 1),
+      );
+    });
+  });
+}
+
+class _ThrowingCursorStore implements CursorStore {
+  @override
+  Future<int?> find() async => null;
+
+  @override
+  Future<void> set(final int cursor) async => throw StateError('store is down');
+
+  @override
+  Future<void> delete() async {}
+}

--- a/packages/bluesky/CHANGELOG.md
+++ b/packages/bluesky/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Note
 
+## v2.5.0
+
+- chore: bump `atproto` to `^2.5.0`, which adds `Firehose` and `CursorStore` to `package:bluesky/firehose.dart`.
+
 ## v2.4.6
 
 - fix: `Bluesky.fromOAuthSession`, `BlueskyChat.fromOAuthSession` and `OzoneTool.fromOAuthSession` pass their `timeout` through to the `OAuthSessionManager` they build, so a hung restore or refresh is bounded by the timeout the caller asked for instead of running unbounded.

--- a/packages/bluesky/pubspec.yaml
+++ b/packages/bluesky/pubspec.yaml
@@ -1,7 +1,7 @@
 name: bluesky
 resolution: workspace
 description: The most famous and powerful Dart/Flutter library for Bluesky Social.
-version: 2.4.6
+version: 2.5.0
 homepage: https://atprotodart.com
 documentation: https://atprotodart.com/docs/packages/bluesky
 repository: https://github.com/myConsciousness/atproto.dart/tree/main/packages/bluesky
@@ -19,7 +19,7 @@ topics:
 
 dependencies:
   atproto_core: ^2.4.1
-  atproto: ^2.4.2
+  atproto: ^2.5.0
   freezed_annotation: ^3.1.0
   json_annotation: ^4.9.0
   characters: ^1.4.0

--- a/templates/feed_generator/bin/server.dart
+++ b/templates/feed_generator/bin/server.dart
@@ -9,6 +9,7 @@ import 'package:atproto_identity/atproto_identity.dart';
 import 'package:feed_generator/src/algorithm/whats_hot_algorithm.dart';
 import 'package:feed_generator/src/config.dart';
 import 'package:feed_generator/src/identity/caching_identity_resolver.dart';
+import 'package:feed_generator/src/indexer/file_cursor_store.dart';
 import 'package:feed_generator/src/indexer/firehose_indexer.dart';
 import 'package:feed_generator/src/server/feed_generator_service.dart';
 import 'package:feed_generator/src/server/middleware.dart';
@@ -55,7 +56,15 @@ Future<void> main() async {
   // catchError guard only exists so an unexpected error escaping the loop is
   // logged instead of becoming an unhandled async error — the server keeps
   // serving whatever is already in the store either way.
-  final indexer = FirehoseIndexer(store);
+  //
+  // The cursor is persisted so a restart resumes where this process stopped
+  // rather than skipping to the live edge and losing everything that happened
+  // while it was down. A file is the simplest durable store; put the cursor in
+  // your database alongside the indexed data if you have one.
+  final indexer = FirehoseIndexer(
+    store,
+    cursorStore: FileCursorStore.at(config.cursorPath),
+  );
   unawaited(
     indexer.start().catchError(
       (Object e) => stderr.writeln('firehose indexer stopped unexpectedly: $e'),

--- a/templates/feed_generator/lib/src/config.dart
+++ b/templates/feed_generator/lib/src/config.dart
@@ -15,6 +15,7 @@ final class FeedGeneratorConfig {
     this.feedDescription,
     this.port = 3000,
     this.storeCapacity = 10000,
+    this.cursorPath = 'firehose.cursor',
     required this.publisherHandle,
     this.publisherPassword,
   });
@@ -28,6 +29,7 @@ final class FeedGeneratorConfig {
   /// - `FEEDGEN_DISPLAY_NAME`     (default `What's Hot`)
   /// - `FEEDGEN_DESCRIPTION`      (optional)
   /// - `FEEDGEN_PORT`             (default `3000`)
+  /// - `FEEDGEN_CURSOR_PATH`      (default `firehose.cursor`)
   /// - `FEEDGEN_STORE_CAPACITY`   (default `10000`)
   ///
   /// `FEEDGEN_PUBLISHER_PASSWORD` is deliberately **not** read here: only
@@ -78,6 +80,11 @@ final class FeedGeneratorConfig {
       );
     }
 
+    final cursorPathRaw = env['FEEDGEN_CURSOR_PATH'];
+    final cursorPath = (cursorPathRaw == null || cursorPathRaw.isEmpty)
+        ? 'firehose.cursor'
+        : cursorPathRaw;
+
     final password = withPassword ? env['FEEDGEN_PUBLISHER_PASSWORD'] : null;
 
     return FeedGeneratorConfig(
@@ -87,6 +94,7 @@ final class FeedGeneratorConfig {
       feedDescription: env['FEEDGEN_DESCRIPTION'],
       port: port,
       storeCapacity: capacity,
+      cursorPath: cursorPath,
       publisherHandle: require('FEEDGEN_PUBLISHER_HANDLE'),
       publisherPassword: (password == null || password.isEmpty)
           ? null
@@ -151,6 +159,11 @@ final class FeedGeneratorConfig {
   /// [DateTime] per post) but not indexing throughput — the store evicts in
   /// O(1).
   final int storeCapacity;
+
+  /// Where the firehose cursor is persisted, so a restart resumes instead of
+  /// skipping to the live edge. Must survive the process — a path inside a
+  /// container's writable layer is lost on redeploy.
+  final String cursorPath;
 
   /// The handle of the account that publishes the feed generator record.
   final String publisherHandle;

--- a/templates/feed_generator/lib/src/indexer/file_cursor_store.dart
+++ b/templates/feed_generator/lib/src/indexer/file_cursor_store.dart
@@ -1,0 +1,52 @@
+// Copyright (c) 2023-2026, Shinya Kato.
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:bluesky/firehose.dart' as firehose;
+
+/// A [firehose.CursorStore] backed by a single file holding the sequence
+/// number as text.
+///
+/// The simplest durable store there is, and enough to make a redeploy resume
+/// where the previous process stopped instead of skipping to the live edge.
+/// A production deployment that already has a database should put the cursor
+/// in the same transaction as whatever the handler writes — then the cursor
+/// and the indexed data can never disagree, which no separate store can
+/// promise.
+///
+/// The write is atomic: it goes to a temporary file that is then renamed over
+/// the target. A process killed mid-write would otherwise leave a truncated
+/// number behind, and the next start would resume from a position that was
+/// never reached.
+final class FileCursorStore implements firehose.CursorStore {
+  FileCursorStore(this._file);
+
+  /// Opens a store at [path].
+  factory FileCursorStore.at(final String path) => FileCursorStore(File(path));
+
+  final File _file;
+
+  @override
+  Future<int?> find() async {
+    if (!_file.existsSync()) return null;
+
+    // A corrupt file must not stop the consumer from starting: fall back to
+    // the live edge, which is exactly where a consumer with no cursor begins.
+    return int.tryParse((await _file.readAsString()).trim());
+  }
+
+  @override
+  Future<void> set(final int cursor) async {
+    final temporary = File('${_file.path}.tmp');
+    await temporary.parent.create(recursive: true);
+    await temporary.writeAsString('$cursor', flush: true);
+    await temporary.rename(_file.path);
+  }
+
+  @override
+  Future<void> delete() async {
+    if (_file.existsSync()) await _file.delete();
+  }
+}

--- a/templates/feed_generator/lib/src/indexer/firehose_indexer.dart
+++ b/templates/feed_generator/lib/src/indexer/firehose_indexer.dart
@@ -2,36 +2,13 @@
 // All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
 import 'dart:io';
-import 'dart:math';
 
 import 'package:atproto_core/atproto_core.dart' show AtUri;
 import 'package:bluesky/bluesky.dart';
 import 'package:bluesky/firehose.dart' as firehose;
 
 import '../store/feed_store.dart';
-
-/// An open firehose connection: the event [stream] plus the [close] callback
-/// that tears the underlying socket down.
-///
-/// [FirehoseIndexer] closes every connection it opens — after a clean close,
-/// after a stream error and on [FirehoseIndexer.stop] — so the reconnect loop
-/// cannot leak sockets. [close] must therefore be safe to call more than once.
-final class FirehoseConnection {
-  const FirehoseConnection(this.stream, {this.close});
-
-  /// The raw firehose event stream.
-  final Stream<dynamic> stream;
-
-  /// Tears down the underlying socket, or `null` when there is nothing to
-  /// tear down (an in-memory stream in a test, say).
-  final Future<void> Function()? close;
-}
-
-/// Opens a firehose connection. Injectable so tests can drive the reconnect
-/// loop without a live socket.
-typedef FirehoseConnector = Future<FirehoseConnection> Function();
 
 /// Pure mapping from a created post URI to an [IndexedPost]. Extracted so it
 /// can be unit-tested without a live firehose socket.
@@ -41,257 +18,69 @@ IndexedPost indexedPostFrom(final AtUri uri, {final DateTime? now}) =>
       indexedAt: (now ?? DateTime.now()).toUtc(),
     );
 
-/// The exponential reconnect delay before connection attempt
-/// `failures + 1`, given `failures` consecutive failures so far (>= 1):
-/// `initial * 2^(failures - 1)`, capped at [max].
-///
-/// This is the deterministic base delay; [FirehoseIndexer] adds random jitter
-/// on top so a fleet of instances that lost the same relay does not retry in
-/// lockstep.
-Duration reconnectBackoff(
-  final int failures, {
-  final Duration initial = const Duration(seconds: 1),
-  final Duration max = const Duration(minutes: 1),
-}) {
-  // Cap the exponent so the shift can never overflow before `max` applies.
-  final exponent = (failures - 1).clamp(0, 30);
-  final delay = initial * (1 << exponent);
-  return delay > max ? max : delay;
-}
-
 /// Subscribes to the public firehose and indexes every newly created post.
-/// Replace the filter/mapping to index only what your feed needs.
+/// Replace the filter/mapping in [_onMessage] to index only what your feed
+/// needs.
 ///
-/// When the relay closes the connection or the stream errors, [start]
-/// reconnects with exponential backoff plus jitter, so a relay hiccup does not
-/// silently stop indexing — and a relay *outage* does not turn this service
-/// into a reconnect flood. A production indexer should additionally persist
-/// the firehose cursor (`seq`) and resume from it on reconnect so no events
-/// are lost across the gap — out of scope for this template.
-///
-/// The backoff counter is reset only once a connection has stayed up for
-/// [healthyConnectionThreshold]. Resetting it on connect instead would defeat
-/// the backoff entirely: `xrpc.subscribe` opens its socket lazily and reports
-/// connection failures as *stream* errors, so every failed attempt would look
-/// like a fresh success followed by a first failure and the delay would never
-/// grow past [initialBackoff].
+/// Reconnection, backoff and cursor persistence all live in
+/// [firehose.Firehose]; this class is only the part that is specific to *this*
+/// feed. Pass a durable [firehose.CursorStore] — the default keeps the cursor
+/// in memory, which survives a relay hiccup but not a restart, so a redeploy
+/// loses every event that happened while the process was down.
 final class FirehoseIndexer {
   FirehoseIndexer(
     this._store, {
-    final FirehoseConnector? connect,
+    final firehose.CursorStore? cursorStore,
+    final firehose.FirehoseConnector? connect,
     final void Function(String message)? log,
-    this.initialBackoff = const Duration(seconds: 1),
-    this.maxBackoff = const Duration(minutes: 1),
-    this.healthyConnectionThreshold = const Duration(seconds: 30),
-    this.jitter = 0.2,
-    final Random? random,
-  }) : _connect = connect ?? _publicFirehoseConnector(),
-       _log = log ?? stderr.writeln,
-       _random = random ?? Random() {
-    if (jitter < 0 || jitter > 1) {
-      throw ArgumentError.value(jitter, 'jitter', 'must be within 0.0..1.0');
-    }
+  }) : _log = log ?? stderr.writeln {
+    _firehose = firehose.Firehose(
+      connect: connect ?? _publicFirehoseConnector(),
+      cursorStore: cursorStore,
+      onError: (final error, final _) => _log('firehose: $error'),
+    );
   }
 
   final FeedStore _store;
-  final FirehoseConnector _connect;
   final void Function(String message) _log;
-  final Random _random;
-
-  /// The reconnect delay after the first failure; doubles per consecutive
-  /// failure up to [maxBackoff].
-  final Duration initialBackoff;
-  final Duration maxBackoff;
-
-  /// How long a connection must stay up before it counts as healthy and the
-  /// consecutive-failure counter is reset.
-  final Duration healthyConnectionThreshold;
-
-  /// The fraction of the base delay added at random, in `0.0..1.0`. Keeps a
-  /// fleet of instances from reconnecting in lockstep after a shared outage.
-  final double jitter;
-
-  /// Completed by [stop]; also used to interrupt the reconnect sleep.
-  final Completer<void> _stopSignal = Completer<void>();
-
-  FirehoseConnection? _connection;
-  StreamSubscription<dynamic>? _subscription;
-  Completer<void>? _consumed;
-
-  bool get _stopped => _stopSignal.isCompleted;
-
-  /// Stops the indexer and tears the live connection down, after which [start]
-  /// returns.
-  ///
-  /// A healthy firehose stream never ends, so stopping cannot mean "wait for
-  /// the stream to finish": this cancels the in-flight subscription, closes
-  /// the socket and wakes any pending reconnect sleep. Safe to call more than
-  /// once, and safe to call before or during [start] — a connection that is
-  /// still being established is closed as soon as it opens.
-  Future<void> stop() async {
-    if (!_stopSignal.isCompleted) _stopSignal.complete();
-
-    final subscription = _subscription;
-    _subscription = null;
-    await subscription?.cancel();
-
-    // Cancelling a subscription never delivers a done event, so release
-    // `_consume` explicitly or `start` would wait on it forever.
-    final consumed = _consumed;
-    _consumed = null;
-    if (consumed != null && !consumed.isCompleted) consumed.complete();
-
-    final connection = _connection;
-    _connection = null;
-    await _closeQuietly(connection);
-  }
+  late final firehose.Firehose _firehose;
 
   /// The default connector: one anonymous client, reused across reconnects,
-  /// and a [FirehoseConnection.close] that tears the WebSocket down.
-  static FirehoseConnector _publicFirehoseConnector() {
+  /// resuming from [cursor] when the store has one.
+  static firehose.FirehoseConnector _publicFirehoseConnector() {
     Bluesky? bsky;
-    return () async {
-      final subscription = await (bsky ??= Bluesky.anonymous()).atproto.sync
-          .subscribeRepos();
 
-      return FirehoseConnection(
+    return (final cursor) async {
+      final subscription = await (bsky ??= Bluesky.anonymous()).atproto.sync
+          .subscribeReposAsMessages(cursor: cursor);
+
+      return firehose.FirehoseConnection(
         subscription.data.stream,
         close: subscription.data.close,
       );
     };
   }
 
-  /// Runs until [stop] is called: connects, consumes events, and reconnects
-  /// with exponential backoff when the connection fails or closes.
-  Future<void> start() async {
-    var consecutiveFailures = 0;
+  /// Runs until [stop] is called.
+  Future<void> start() => _firehose.start(_onMessage);
 
-    while (!_stopped) {
-      final uptime = Stopwatch()..start();
-      try {
-        final connection = _connection = await _connect();
-        try {
-          if (_stopped) break;
-          // Completes when the relay closes the stream; throws on a stream
-          // error. Either way we fall through to the reconnect delay below.
-          await _consume(connection.stream);
-          if (!_stopped) _log('firehose stream closed by the relay');
-        } finally {
-          _connection = null;
-          await _closeQuietly(connection);
-        }
-      } on Object catch (e) {
-        // `Object`, not `Exception`: an `Error` escaping here (a `RangeError`
-        // from a decoder edge case, say) would otherwise kill the indexer
-        // permanently after a single attempt and leave the server serving a
-        // frozen feed forever.
-        _log('firehose connection error: $e');
-      }
-      if (_stopped) break;
+  /// Stops indexing and writes out the pending cursor.
+  Future<void> stop() => _firehose.stop();
 
-      // Only a connection that actually stayed up counts as a success. A
-      // socket that fails immediately must keep growing the delay.
-      if (uptime.elapsed >= healthyConnectionThreshold) {
-        consecutiveFailures = 0;
-      }
-      consecutiveFailures++;
+  /// Indexes one firehose message.
+  ///
+  /// Throwing here tells [firehose.Firehose] this message was not processed, so
+  /// its `seq` is not recorded — which is why the store write is awaited rather
+  /// than fired and forgotten.
+  Future<void> _onMessage(
+    final firehose.USyncSubscribeReposMessage message,
+  ) async {
+    if (message.isNotCommit) return;
 
-      final delay = _withJitter(
-        reconnectBackoff(
-          consecutiveFailures,
-          initial: initialBackoff,
-          max: maxBackoff,
-        ),
-      );
-      _log('reconnecting to the firehose in ${delay.inMilliseconds}ms');
-      await _sleep(delay);
-    }
-
-    // `break` can leave a connection open when stop() raced the connect.
-    await _closeQuietly(_connection);
-    _connection = null;
-  }
-
-  /// Listens to [events] until the stream ends, errors, or [stop] cancels it.
-  Future<void> _consume(final Stream<dynamic> events) {
-    final completer = Completer<void>();
-    _consumed = completer;
-
-    final subscription = events.listen(null, cancelOnError: true);
-    _subscription = subscription;
-
-    subscription
-      ..onData((final event) {
-        // Pausing until the event is handled preserves the backpressure an
-        // `await for` gave us: the socket stops being drained while a slow
-        // store write is in flight.
-        subscription.pause(_handleEvent(event));
-      })
-      ..onError((final Object error, final StackTrace stackTrace) {
-        if (!completer.isCompleted) completer.completeError(error, stackTrace);
-      })
-      ..onDone(() {
-        if (!completer.isCompleted) completer.complete();
-      });
-
-    return completer.future.whenComplete(() async {
-      if (identical(_consumed, completer)) _consumed = null;
-      if (identical(_subscription, subscription)) _subscription = null;
-      await subscription.cancel();
-    });
-  }
-
-  /// Handles one raw firehose frame. Never throws: a single malformed frame or
-  /// a failed store write must not bring the whole indexer down. (Stream-level
-  /// errors, by contrast, end [_consume] and trigger a reconnect in [start].)
-  Future<void> _handleEvent(final dynamic event) async {
-    try {
-      final repos = const firehose.SyncSubscribeReposAdaptor().execute(event);
-      if (!repos.isCommit) return;
-      await firehose.RepoCommitHandler(
-        onCreateFeedPost: (data) async {
-          await _store.index(indexedPostFrom(data.uri));
-        },
-      ).execute(repos.commit!);
-    } catch (e) {
-      _log('skipped a firehose frame: $e');
-    }
-  }
-
-  Duration _withJitter(final Duration delay) {
-    if (jitter <= 0) return delay;
-    final spread = (delay.inMicroseconds * jitter).round();
-    if (spread <= 0) return delay;
-
-    return delay + Duration(microseconds: _random.nextInt(spread + 1));
-  }
-
-  /// Waits [delay], or returns early when [stop] is called.
-  Future<void> _sleep(final Duration delay) {
-    if (_stopped) return Future<void>.value();
-
-    final completer = Completer<void>();
-    final timer = Timer(delay, () {
-      if (!completer.isCompleted) completer.complete();
-    });
-    unawaited(
-      _stopSignal.future.then((_) {
-        timer.cancel();
-        if (!completer.isCompleted) completer.complete();
-      }),
-    );
-
-    return completer.future;
-  }
-
-  Future<void> _closeQuietly(final FirehoseConnection? connection) async {
-    final close = connection?.close;
-    if (close == null) return;
-    try {
-      await close();
-    } catch (e) {
-      // A failed teardown must never abort the reconnect loop.
-      _log('failed to close the firehose connection: $e');
-    }
+    await firehose.RepoCommitHandler(
+      onCreateFeedPost: (final data) async {
+        await _store.index(indexedPostFrom(data.uri));
+      },
+    ).execute(message.commit!);
   }
 }

--- a/templates/feed_generator/pubspec.yaml
+++ b/templates/feed_generator/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: ">=3.8.0 <4.0.0"
 
 dependencies:
-  bluesky: ^2.4.6
+  bluesky: ^2.5.0
   atproto_core: ^2.4.1
   atproto_identity: ^0.3.0
   shelf: ^1.4.0

--- a/templates/feed_generator/test/config_test.dart
+++ b/templates/feed_generator/test/config_test.dart
@@ -108,6 +108,29 @@ void main() {
       }
     });
 
+    test('defaults FEEDGEN_CURSOR_PATH and honours an override', () {
+      expect(
+        FeedGeneratorConfig.fromEnvironment(_baseEnv).cursorPath,
+        'firehose.cursor',
+      );
+      expect(
+        FeedGeneratorConfig.fromEnvironment({
+          ..._baseEnv,
+          'FEEDGEN_CURSOR_PATH': '/var/lib/feedgen/cursor',
+        }).cursorPath,
+        '/var/lib/feedgen/cursor',
+      );
+      // An empty value is the same as not setting it at all, so a blank
+      // variable cannot silently point the cursor file at the CWD root.
+      expect(
+        FeedGeneratorConfig.fromEnvironment({
+          ..._baseEnv,
+          'FEEDGEN_CURSOR_PATH': '',
+        }).cursorPath,
+        'firehose.cursor',
+      );
+    });
+
     test('defaults and validates FEEDGEN_STORE_CAPACITY', () {
       expect(
         FeedGeneratorConfig.fromEnvironment(_baseEnv).storeCapacity,

--- a/templates/feed_generator/test/indexer/file_cursor_store_test.dart
+++ b/templates/feed_generator/test/indexer/file_cursor_store_test.dart
@@ -1,0 +1,70 @@
+// Copyright (c) 2023-2026, Shinya Kato.
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:feed_generator/src/indexer/file_cursor_store.dart';
+import 'package:test/test.dart';
+
+void main() {
+  late Directory dir;
+
+  setUp(() => dir = Directory.systemTemp.createTempSync('cursor_store_test'));
+  tearDown(() => dir.deleteSync(recursive: true));
+
+  String path([final String name = 'firehose.cursor']) => '${dir.path}/$name';
+
+  test('returns null before anything is stored', () async {
+    expect(await FileCursorStore.at(path()).find(), isNull);
+  });
+
+  test('round-trips a cursor across instances', () async {
+    await FileCursorStore.at(path()).set(4242);
+
+    // A fresh instance stands in for a restarted process.
+    expect(await FileCursorStore.at(path()).find(), 4242);
+  });
+
+  test('overwrites the previous value', () async {
+    final store = FileCursorStore.at(path());
+    await store.set(1);
+    await store.set(2);
+
+    expect(await store.find(), 2);
+  });
+
+  test('delete clears the stored cursor', () async {
+    final store = FileCursorStore.at(path());
+    await store.set(7);
+    await store.delete();
+
+    expect(await store.find(), isNull);
+  });
+
+  test('delete on a missing file is a no-op', () async {
+    await FileCursorStore.at(path('never-written')).delete();
+  });
+
+  test('a corrupt file reads as no cursor rather than throwing', () async {
+    // A process killed mid-write is the realistic source of this. Starting
+    // from the live edge is the same place a first run starts.
+    File(path()).writeAsStringSync('not-a-number');
+
+    expect(await FileCursorStore.at(path()).find(), isNull);
+  });
+
+  test('creates missing parent directories', () async {
+    final nested = '${dir.path}/state/firehose.cursor';
+    await FileCursorStore.at(nested).set(9);
+
+    expect(await FileCursorStore.at(nested).find(), 9);
+  });
+
+  test('leaves no temporary file behind', () async {
+    final store = FileCursorStore.at(path());
+    await store.set(5);
+
+    expect(File('${path()}.tmp').existsSync(), isFalse);
+  });
+}

--- a/templates/feed_generator/test/indexer/firehose_indexer_test.dart
+++ b/templates/feed_generator/test/indexer/firehose_indexer_test.dart
@@ -3,22 +3,45 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:io';
-import 'dart:math';
 
 import 'package:atproto_core/atproto_core.dart' show AtUri;
+import 'package:bluesky/firehose.dart' as firehose;
 import 'package:feed_generator/src/indexer/firehose_indexer.dart';
 import 'package:feed_generator/src/store/in_memory_feed_store.dart';
 import 'package:test/test.dart';
 
-/// A `log` callback that records the delay from every reconnect log line.
-void Function(String) _collectReconnectDelays(final List<int> delays) {
-  final pattern = RegExp(r'reconnecting to the firehose in (\d+)ms');
-  return (final message) {
-    final match = pattern.firstMatch(message);
-    if (match != null) delays.add(int.parse(match.group(1)!));
-  };
-}
+/// A `#commit` carrying a single created `app.bsky.feed.post`.
+///
+/// The blocks map is keyed by CID exactly as `SyncSubscribeReposAdaptor`
+/// produces it, so `RepoCommitHandler` resolves the op to its record.
+firehose.USyncSubscribeReposMessage _createPostCommit({
+  final String did = 'did:plc:testaccount',
+  final String rkey = 'abc',
+  final String cid = 'bafyreiabc',
+}) => firehose.USyncSubscribeReposMessage.commit(
+  data: firehose.Commit(
+    seq: 1,
+    repo: did,
+    commit: 'bafyreicommit',
+    rev: '3kaa',
+    since: null,
+    blocks: {
+      cid: {
+        r'$type': 'app.bsky.feed.post',
+        'text': 'hello',
+        'createdAt': '2026-01-01T00:00:00.000Z',
+      },
+    },
+    ops: [
+      firehose.RepoOp(
+        action: firehose.RepoOpAction.valueOf('create')!,
+        path: 'app.bsky.feed.post/$rkey',
+        cid: cid,
+      ),
+    ],
+    time: DateTime.utc(2026),
+  ),
+);
 
 void main() {
   test('maps a created feed post URI to an IndexedPost', () {
@@ -45,272 +68,62 @@ void main() {
     );
   });
 
-  group('reconnectBackoff', () {
-    test('grows exponentially from the initial delay', () {
-      expect(reconnectBackoff(1), const Duration(seconds: 1));
-      expect(reconnectBackoff(2), const Duration(seconds: 2));
-      expect(reconnectBackoff(3), const Duration(seconds: 4));
-      expect(reconnectBackoff(4), const Duration(seconds: 8));
-    });
-
-    test('is capped at the maximum delay', () {
-      expect(reconnectBackoff(7), const Duration(minutes: 1));
-      expect(reconnectBackoff(100), const Duration(minutes: 1));
-    });
-  });
-
   group('start', () {
-    test('reconnects after the firehose stream closes', () async {
-      var connects = 0;
-      late FirehoseIndexer indexer;
-      indexer = FirehoseIndexer(
-        InMemoryFeedStore(),
-        initialBackoff: const Duration(milliseconds: 1),
+    // Reconnection, backoff and cursor handling now live in
+    // `firehose.Firehose` and are covered by the `atproto` package's tests.
+    // What is left here is the part this template actually owns: which
+    // messages become indexed posts.
+    test('indexes a created feed post', () async {
+      final store = InMemoryFeedStore();
+      final indexer = FirehoseIndexer(
+        store,
         log: (_) {},
-        connect: () async {
-          connects++;
-          if (connects >= 3) unawaited(indexer.stop());
-          // A stream that immediately closes simulates the relay dropping
-          // the connection.
-          return const FirehoseConnection(Stream<dynamic>.empty());
-        },
-      );
-
-      await indexer.start();
-      expect(connects, 3);
-    });
-
-    test('retries with backoff when connecting fails', () async {
-      var connects = 0;
-      late FirehoseIndexer indexer;
-      indexer = FirehoseIndexer(
-        InMemoryFeedStore(),
-        initialBackoff: const Duration(milliseconds: 1),
-        log: (_) {},
-        connect: () async {
-          connects++;
-          if (connects >= 3) {
-            unawaited(indexer.stop());
-            return const FirehoseConnection(Stream<dynamic>.empty());
-          }
-          throw const SocketException('connection refused');
-        },
-      );
-
-      await indexer.start();
-      expect(connects, 3);
-    });
-
-    test('backs off exponentially when the relay fails at the STREAM '
-        'level, not only when connect() throws', () async {
-      // `xrpc.subscribe` never throws on a failed connection: the socket is
-      // opened lazily and `channel.ready` errors are swallowed, so a refused
-      // or dropped connection surfaces as a stream error. This is the real
-      // production failure mode, and the one the backoff must handle.
-      final delays = <int>[];
-      var connects = 0;
-      late FirehoseIndexer indexer;
-      indexer = FirehoseIndexer(
-        InMemoryFeedStore(),
-        initialBackoff: const Duration(milliseconds: 1),
-        jitter: 0,
-        log: _collectReconnectDelays(delays),
-        connect: () async {
-          connects++;
-          if (connects >= 5) unawaited(indexer.stop());
-          return FirehoseConnection(
-            Stream<dynamic>.error(const SocketException('reset by peer')),
-          );
-        },
-      );
-
-      await indexer.start();
-      expect(delays, [1, 2, 4, 8]);
-    });
-
-    test('does not reset the backoff for a connection that dies '
-        'immediately', () async {
-      final delays = <int>[];
-      var connects = 0;
-      late FirehoseIndexer indexer;
-      indexer = FirehoseIndexer(
-        InMemoryFeedStore(),
-        initialBackoff: const Duration(milliseconds: 1),
-        jitter: 0,
-        // Nothing in this test stays up this long, so no reset may happen.
-        healthyConnectionThreshold: const Duration(hours: 1),
-        log: _collectReconnectDelays(delays),
-        connect: () async {
-          connects++;
-          if (connects >= 4) unawaited(indexer.stop());
-          return const FirehoseConnection(Stream<dynamic>.empty());
-        },
-      );
-
-      await indexer.start();
-      expect(delays, [1, 2, 4]);
-    });
-
-    test('resets the backoff once a connection has stayed healthy', () async {
-      final delays = <int>[];
-      var connects = 0;
-      late FirehoseIndexer indexer;
-      indexer = FirehoseIndexer(
-        InMemoryFeedStore(),
-        initialBackoff: const Duration(milliseconds: 1),
-        jitter: 0,
-        // Every connection counts as healthy, so the delay never grows.
-        healthyConnectionThreshold: Duration.zero,
-        log: _collectReconnectDelays(delays),
-        connect: () async {
-          connects++;
-          if (connects >= 4) unawaited(indexer.stop());
-          return const FirehoseConnection(Stream<dynamic>.empty());
-        },
-      );
-
-      await indexer.start();
-      expect(delays, [1, 1, 1]);
-    });
-
-    test('adds jitter on top of the base delay', () async {
-      final delays = <int>[];
-      var connects = 0;
-      late FirehoseIndexer indexer;
-      indexer = FirehoseIndexer(
-        InMemoryFeedStore(),
-        initialBackoff: const Duration(milliseconds: 100),
-        jitter: 0.5,
-        random: Random(7),
-        log: _collectReconnectDelays(delays),
-        connect: () async {
-          connects++;
-          if (connects >= 6) unawaited(indexer.stop());
-          return const FirehoseConnection(Stream<dynamic>.empty());
-        },
-      );
-
-      // Keep the wall-clock cost down: stop before the delays are actually
-      // slept through, and only assert on what was computed.
-      unawaited(
-        Future<void>.delayed(
-          const Duration(milliseconds: 120),
-          () => indexer.stop(),
+        connect: (final cursor) async => firehose.FirehoseConnection(
+          Stream.value(_createPostCommit(rkey: 'first')),
         ),
       );
-      await indexer.start();
 
-      expect(delays, isNotEmpty);
-      for (var i = 0; i < delays.length; i++) {
-        final base = 100 * (1 << i);
-        expect(delays[i], inInclusiveRange(base, (base * 1.5).round()));
+      final run = indexer.start();
+      final deadline = DateTime.now().add(const Duration(seconds: 5));
+      while ((await store.recent(limit: 10)).isEmpty &&
+          DateTime.now().isBefore(deadline)) {
+        await Future<void>.delayed(const Duration(milliseconds: 1));
       }
-      // Jitter must actually vary the delay, not be a constant offset.
-      expect(delays.any((d) => d != 100 * (1 << delays.indexOf(d))), isTrue);
+      await indexer.stop();
+      await run;
+
+      final indexed = await store.recent(limit: 10);
+      expect(indexed, hasLength(1));
+      expect(
+        indexed.single.uri,
+        'at://did:plc:testaccount/app.bsky.feed.post/first',
+      );
     });
 
-    test('stop() ends a live connection instead of blocking forever', () async {
-      // A healthy firehose never closes its stream, so a `stop()` that only
-      // flips a flag can never interrupt it.
-      final controller = StreamController<dynamic>();
-      addTearDown(controller.close);
-      var closed = 0;
-
+    test('ignores messages that are not commits', () async {
+      final store = InMemoryFeedStore();
       final indexer = FirehoseIndexer(
-        InMemoryFeedStore(),
-        initialBackoff: const Duration(milliseconds: 1),
+        store,
         log: (_) {},
-        connect: () async =>
-            FirehoseConnection(controller.stream, close: () async => closed++),
+        connect: (final cursor) async => firehose.FirehoseConnection(
+          Stream.value(
+            firehose.USyncSubscribeReposMessage.identity(
+              data: firehose.Identity(
+                seq: 1,
+                did: 'did:plc:testaccount',
+                time: DateTime.utc(2026),
+              ),
+            ),
+          ),
+        ),
       );
 
-      final started = indexer.start();
+      final run = indexer.start();
       await Future<void>.delayed(const Duration(milliseconds: 20));
       await indexer.stop();
+      await run;
 
-      await started.timeout(const Duration(seconds: 2));
-      expect(closed, greaterThanOrEqualTo(1));
-    });
-
-    test('closes every connection it opens, including failed ones', () async {
-      var closed = 0;
-      var connects = 0;
-      late FirehoseIndexer indexer;
-      indexer = FirehoseIndexer(
-        InMemoryFeedStore(),
-        initialBackoff: const Duration(milliseconds: 1),
-        jitter: 0,
-        log: (_) {},
-        connect: () async {
-          connects++;
-          if (connects >= 3) unawaited(indexer.stop());
-          return FirehoseConnection(
-            Stream<dynamic>.error(const SocketException('reset by peer')),
-            close: () async => closed++,
-          );
-        },
-      );
-
-      await indexer.start();
-      expect(connects, 3);
-      expect(closed, 3, reason: 'every attempt must tear its socket down');
-    });
-
-    test(
-      'survives an Error (not just an Exception) from the connector',
-      () async {
-        var connects = 0;
-        late FirehoseIndexer indexer;
-        indexer = FirehoseIndexer(
-          InMemoryFeedStore(),
-          initialBackoff: const Duration(milliseconds: 1),
-          jitter: 0,
-          log: (_) {},
-          connect: () async {
-            connects++;
-            if (connects >= 3) {
-              unawaited(indexer.stop());
-              return const FirehoseConnection(Stream<dynamic>.empty());
-            }
-            // An `Error`, not an `Exception`: `on Exception` would let this
-            // escape and kill the indexer permanently.
-            throw RangeError('index out of range');
-          },
-        );
-
-        await indexer.start();
-        expect(connects, 3);
-      },
-    );
-
-    test('skips malformed frames without dying', () async {
-      final logs = <String>[];
-      var connects = 0;
-      late FirehoseIndexer indexer;
-      indexer = FirehoseIndexer(
-        InMemoryFeedStore(),
-        initialBackoff: const Duration(milliseconds: 1),
-        log: logs.add,
-        connect: () async {
-          connects++;
-          if (connects >= 2) {
-            // stop() now tears the live connection down immediately, so it
-            // must be requested after the frames have been delivered.
-            unawaited(indexer.stop());
-            return const FirehoseConnection(Stream<dynamic>.empty());
-          }
-          return FirehoseConnection(
-            Stream<dynamic>.fromIterable(['not-a-frame', 42]),
-          );
-        },
-      );
-
-      // Must complete normally: malformed frames are logged and skipped.
-      await indexer.start();
-      expect(
-        logs.where((m) => m.contains('skipped a firehose frame')),
-        hasLength(2),
-      );
+      expect(await store.recent(limit: 10), isEmpty);
     });
   });
 }


### PR DESCRIPTION
A gap analysis against the upstream TypeScript implementation turned up four missing areas. Three were declined on demand grounds (zero issues ever filed for repo/MST verification, `getRepo` enumeration, or lexicon runtime validation — and this SDK's users are overwhelmingly Flutter client apps, which never see an MST). This is the one that survived, and the repository had already named it itself.

## What was missing

The reconnect loop a firehose consumer needs already existed — exponential backoff, jitter, a healthy-connection threshold before resetting the failure counter — but it lived in `templates/feed_generator`, and it explicitly left out the one piece that makes a consumer durable:

> A production indexer should additionally persist the firehose cursor (`seq`) and resume from it on reconnect so no events are lost across the gap — **out of scope for this template**.
>
> — `firehose_indexer.dart:68`

Without it, a restart resumes at the live edge and silently drops everything that happened while the process was down. And because the loop lived in a *template*, every feed generator author copied 297 lines and re-implemented the missing part themselves. That is the signal that it belongs in the library.

## `Firehose`

Promoted to `packages/atproto`, exported from `package:atproto/firehose.dart` (and therefore `package:bluesky/firehose.dart`). No new package: the audience already depends on these.

**It takes a handler, not a `Stream`.** A stream would be the more idiomatic Dart shape, and it cannot carry the cursor correctly — it reports when a message was *delivered*, never when the consumer *finished* with it. Advancing on delivery loses exactly what was in flight when a process died, which is the loss a persisted cursor exists to prevent. The completion of the handler's future is the only evidence a message was handled, so delivery is **at-least-once** and handlers should be idempotent. `subscribeReposAsMessages` is untouched for callers who don't want a cursor.

```dart
final firehose = Firehose(
  connect: (cursor) async {
    final subscription =
        await atproto.sync.subscribeReposAsMessages(cursor: cursor);

    return FirehoseConnection(
      subscription.data.stream,
      close: subscription.data.close,
    );
  },
  cursorStore: FileCursorStore.at('firehose.cursor'),
);

await firehose.start((message) async {
  if (message.isCommit) await index(message.commit!);
});
```

## `CursorStore`

Injected, matching the `OAuthStateStore` / `OAuthSessionStore` / `DPoPNonceCache` pattern, with an `InMemoryCursorStore` default.

`delete()` is part of the interface rather than a convenience. A relay answers a cursor that is ahead of its own stream with `FutureCursor` on *every* attempt, so a consumer that has read past its relay — because the relay was rolled back, or because it was repointed at a different one — reconnects forever unless the cursor can be discarded.

## Cursor advancement

`seq` exists on `#commit`, `#sync`, `#identity` and `#account`, but **not on `#info`**, which decides most of the rules:

| Situation | Advances | Why |
| --- | --- | --- |
| Handler returns normally | yes | The only evidence the message was handled. |
| `#info` frame | no | Carries no `seq`. |
| Handler throws | skipped | Reported and skipped so one bad message can't take the consumer down. A later success advances past it, so retry belongs to the handler — documented, not silent. |
| Reconnect / `stop()` | forced flush | The next subscription must see it, or the resume position is stale. |

Writes are batched — `flushEveryEvents` (100) or `flushEveryInterval` (5s), whichever comes first — because the full-network firehose runs at hundreds to thousands of events per second and a write per message would put the store on the hot path. The replay window after a crash is bounded by the same settings. Flushes are skipped when the value hasn't changed (otherwise a reconnect loop failing before any message arrives rewrites the same cursor every attempt — caught by the tests) and serialized so a slow store can't land an older value after a newer one.

## Relay-side failures

| Input | Handling |
| --- | --- |
| `FutureCursor` | Discard the stored cursor, reconnect from the live edge. |
| `ConsumerTooSlow` | Keep the cursor; it is correct. Normal backoff. |
| `#info` `OutdatedCursor` | Surfaced through `onError` as `FirehoseOutdatedCursorException`. Events are already lost; passing it silently would leave the caller no way to notice the gap. |

## The template

**297 lines → 86**, keeping only what is specific to this feed. That shrink was the criterion for whether the promotion was worth doing. Its test file drops the reconnect-loop coverage that moved into the library and gains end-to-end coverage that a created post still reaches the store. A `FileCursorStore` is added as the durable example (atomic write via temp-file rename, corrupt file reads as "no cursor" rather than throwing), wired into `bin/server.dart` behind a new `FEEDGEN_CURSOR_PATH`.

## Verification

- `dart analyze` across the workspace — clean
- `dart format --set-exit-if-changed` — no changes
- `dart run ./scripts/validate_dependencies.dart` — 14 packages pass
- `atproto` 407 tests (18 new for `Firehose`), `bluesky` 976, `feed_generator` 75, `scripts` 44 — all pass

## Versions

| Package | Version | Why |
| --- | --- | --- |
| `atproto` | 2.4.2 → 2.5.0 | new public API |
| `bluesky` | 2.4.6 → 2.5.0 | re-exports it via `package:bluesky/firehose.dart` |

---
_Generated by [Claude Code](https://claude.ai/code/session_016ManHiFgPPPqMpshziygZi)_