### PR TITLE
feat(bluesky): build faceted posts from plain text in one call

### DIFF
--- a/packages/bluesky/CHANGELOG.md
+++ b/packages/bluesky/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Release Note
 
+## v2.6.0
+
+- feat: added `feed.buildPostText` and `feed.postText`, which turn plain text into a faceted `app.bsky.feed.post` in one call. Getting this right by hand took three steps the docs had to spell out — format first (markdown links only become link facets after formatting), post the *formatted* text rather than the input (facet ranges are byte offsets into it, so the original string points every link at the wrong characters), and convert `bluesky_text`'s facet maps into `RichtextFacet` models. `buildPostText` returns a `PostText` holding the formatted text and its facets together so the two cannot be separated by accident, and `postText` builds and publishes in one call.
+- fix: mentions are now resolved with `com.atproto.identity.resolveHandle` over this client's transport. `bluesky_text` on its own opens its own HTTP connection to a default host, so an account on a self-hosted PDS resolved its mentions against the wrong server, and none of the client's configuration — service, timeout, retry policy, custom `getClient`, proxy headers — applied to that call.
+- feat: a mention whose handle does not resolve is reported in `PostText.unresolvedHandles` (or through `postText`'s `onUnresolvedHandles`) instead of being silently dropped. It is not an error — the mention just stays plain text — but throwing from the callback aborts before the record is created, for an author who would rather fix a typo than publish a mention that renders as plain text.
+- chore: `bluesky_text` moves from a dev dependency to a runtime dependency. It brings no new transitive packages (`xrpc`, `http` and `characters` are already dependencies) and there is no cycle: `bluesky_text` does not depend on `bluesky`.
+
 ## v2.5.0
 
 - chore: bump `atproto` to `^2.5.0`, which adds `Firehose` and `CursorStore` to `package:bluesky/firehose.dart`.

--- a/packages/bluesky/lib/bluesky.dart
+++ b/packages/bluesky/lib/bluesky.dart
@@ -5,6 +5,7 @@
 export 'package:bluesky/src/bluesky.dart';
 
 export 'package:bluesky/src/services/app/bsky/feed_service.dart';
+export 'package:bluesky/src/services/app/bsky/feed/post_text.dart';
 export 'package:bluesky/src/services/app/bsky/feed/thread.dart';
 export 'package:bluesky/src/services/app/bsky/video_upload_exception.dart';
 

--- a/packages/bluesky/lib/src/services/app/bsky/feed/post_text.dart
+++ b/packages/bluesky/lib/src/services/app/bsky/feed/post_text.dart
@@ -1,0 +1,44 @@
+// Copyright (c) 2023-2026, Shinya Kato.
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// Project imports:
+import '../../../codegen/app/bsky/richtext/facet/main.dart';
+
+/// A piece of post text that has been formatted and had its facets resolved:
+/// exactly the two values `app.bsky.feed.post` needs, in the types the record
+/// API takes.
+///
+/// Produced by `bluesky.feed.buildPostText`. The point of the type is that
+/// [text] and [facets] belong together and must not be separated: facet ranges
+/// are **byte offsets into [text]**, so pairing these facets with the original,
+/// unformatted string produces links that land on the wrong characters.
+final class PostText {
+  /// Returns a new [PostText].
+  const PostText({
+    required this.text,
+    required this.facets,
+    required this.unresolvedHandles,
+  });
+
+  /// The formatted text to post. Not necessarily the string that was passed
+  /// in — markdown links, for one, are rewritten during formatting.
+  final String text;
+
+  /// The facets for [text], as lexicon models.
+  final List<RichtextFacet> facets;
+
+  /// Handles that appear as mentions in [text] but could not be resolved to a
+  /// DID, and therefore carry no facet.
+  ///
+  /// The post is still valid — those mentions simply stay plain text — but a
+  /// silent drop is rarely what the author intended, so a typo'd or deactivated
+  /// handle is reported here rather than swallowed.
+  final List<String> unresolvedHandles;
+
+  /// Whether any mention failed to resolve.
+  bool get hasUnresolvedHandles => unresolvedHandles.isNotEmpty;
+
+  /// Whether every mention resolved.
+  bool get hasNoUnresolvedHandles => unresolvedHandles.isEmpty;
+}

--- a/packages/bluesky/lib/src/services/app/bsky/feed/thread.dart
+++ b/packages/bluesky/lib/src/services/app/bsky/feed/thread.dart
@@ -24,19 +24,17 @@ import '../../../codegen/app/bsky/richtext/facet/main.dart';
 /// freshly generated TID. Letting a caller set any of those would let it
 /// contradict the chain the batch is built to guarantee.
 ///
-/// [facets] are lexicon models, as in `feed.post.create`. `bluesky_text`
-/// emits facet maps, so convert them first:
+/// [facets] are lexicon models, as in `feed.post.create`. Use
+/// `bluesky.feed.buildPostText` to produce both fields from plain text:
 ///
 /// ```dart
-/// final data = await BlueskyText(text).toPostData();
-/// final post = ThreadPost(
-///   text: data.text,
-///   facets: data.facets.map(RichtextFacet.fromJson).toList(),
-/// );
+/// final built = await bluesky.feed.buildPostText(text);
+/// final post = ThreadPost(text: built.text, facets: built.facets);
 /// ```
 ///
-/// Note that `data.text` -- not the original string -- is what must be
-/// posted: facet indices are byte offsets into the formatted text.
+/// Note that `built.text` -- not the original string -- is what must be
+/// posted: facet indices are byte offsets into the formatted text, which is
+/// why [PostText] carries the two together.
 final class ThreadPost {
   /// Returns a new [ThreadPost].
   const ThreadPost({

--- a/packages/bluesky/lib/src/services/app/bsky/feed_service.dart
+++ b/packages/bluesky/lib/src/services/app/bsky/feed_service.dart
@@ -7,16 +7,152 @@ import 'dart:async';
 
 // Package imports:
 import 'package:atproto/com_atproto_repo_applywrites.dart';
+import 'package:atproto/com_atproto_repo_createrecord.dart';
 import 'package:atproto/com_atproto_services.dart';
 import 'package:atproto_core/atproto_core.dart';
+import 'package:bluesky_text/bluesky_text.dart' as text_api;
 
 // Project imports:
 import '../../codegen/app/bsky/feed/post/reply_ref.dart';
+import '../../codegen/app/bsky/feed/post/union_main_embed.dart';
+import '../../codegen/app/bsky/feed/post/union_main_labels.dart';
 import '../../codegen/app/bsky/feed_service.dart';
+import '../../codegen/app/bsky/richtext/facet/main.dart';
+import 'feed/post_text.dart';
 import 'feed/thread.dart';
 
 final class FeedServiceImpl extends FeedService {
   FeedServiceImpl(super.ctx);
+
+  /// Formats [text] and resolves its facets — mentions, links, hashtags —
+  /// returning both in the types `post.create` and [ThreadPost] take.
+  ///
+  /// Getting a faceted post right by hand takes three steps that are easy to
+  /// get subtly wrong, and this does all three:
+  ///
+  /// 1. **Format first, then resolve.** Markdown links only become link facets
+  ///    after formatting, so resolving before formatting silently loses them.
+  /// 2. **Post the formatted text, not the original.** Facet ranges are byte
+  ///    offsets into the formatted string; pairing them with the string that
+  ///    was passed in points every link at the wrong characters. [PostText]
+  ///    keeps the two together so they cannot be separated by accident.
+  /// 3. **Resolve mentions through this client.** Left to itself
+  ///    `bluesky_text` opens its own HTTP connection to a default host, so an
+  ///    account on a self-hosted PDS resolved its mentions against the wrong
+  ///    server — and none of the client's configuration (service, timeout,
+  ///    retry policy, custom `getClient`, proxy headers) applied to that call.
+  ///    Mentions are resolved with `com.atproto.identity.resolveHandle` on
+  ///    this client instead, so they travel the same path as every other
+  ///    request.
+  ///
+  /// A mention whose handle does not resolve carries no facet and is reported
+  /// in [PostText.unresolvedHandles] rather than dropped silently.
+  ///
+  /// Pass [handleResolver] to answer mention DIDs from a cache of your own
+  /// instead of one request per mention.
+  ///
+  /// ```dart
+  /// final built = await bluesky.feed.buildPostText(
+  ///   'hello @alice.bsky.social, see https://atprotodart.com #dart',
+  /// );
+  /// if (built.hasUnresolvedHandles) {
+  ///   print('could not resolve: ${built.unresolvedHandles}');
+  /// }
+  ///
+  /// // Ready for either call, with no conversion at the call site.
+  /// await bluesky.feed.post.create(text: built.text, facets: built.facets);
+  /// final threadPost = ThreadPost(text: built.text, facets: built.facets);
+  /// ```
+  ///
+  /// See [postText] to build and publish in one call.
+  Future<PostText> buildPostText(
+    final String text, {
+    final text_api.HandleResolver? handleResolver,
+  }) async {
+    final data = await text_api.BlueskyText(
+      text,
+    ).toPostData(resolver: handleResolver ?? _resolveHandle);
+
+    return PostText(
+      text: data.text,
+      facets: data.facets.map(RichtextFacet.fromJson).toList(),
+      unresolvedHandles: data.unresolvedHandles,
+    );
+  }
+
+  /// Resolves a mention's handle to a DID over this client's transport.
+  ///
+  /// Returns `null` when the handle does not resolve, which is how
+  /// `bluesky_text` reports it in `unresolvedHandles`. A failure here is not
+  /// fatal to the post: the mention simply stays plain text.
+  Future<String?> _resolveHandle(final String handle) async {
+    try {
+      final response = await comAtprotoIdentityResolveHandle(
+        handle: handle,
+        $ctx: ctx,
+      );
+
+      return response.data.did;
+    } on Exception {
+      return null;
+    }
+  }
+
+  /// Builds [text] with [buildPostText] and publishes it as an
+  /// `app.bsky.feed.post` in one call.
+  ///
+  /// Every other parameter is passed straight through to `post.create`.
+  ///
+  /// ```dart
+  /// await bluesky.feed.postText(
+  ///   'hello @alice.bsky.social, see https://atprotodart.com #dart',
+  /// );
+  /// ```
+  ///
+  /// [onUnresolvedHandles] is invoked, before the post is created, when a
+  /// mention could not be resolved. Throwing from it aborts the post; that is
+  /// the hook for an author who would rather fix a typo than publish a mention
+  /// that renders as plain text. Without it an unresolved mention is not an
+  /// error — the post is still valid — so use [buildPostText] when the
+  /// decision needs to be made somewhere other than a callback.
+  Future<XRPCResponse<RepoCreateRecordOutput>> postText(
+    final String text, {
+    final ReplyRef? reply,
+    final UFeedPostEmbed? embed,
+    final List<String>? langs,
+    final UFeedPostLabels? labels,
+    final List<String>? tags,
+    final DateTime? createdAt,
+    final String? rkey,
+    final bool? validate,
+    final String? swapCommit,
+    final text_api.HandleResolver? handleResolver,
+    final void Function(List<String> handles)? onUnresolvedHandles,
+    final Map<String, String>? $headers,
+    final Map<String, String>? $unknown,
+  }) async {
+    final built = await buildPostText(text, handleResolver: handleResolver);
+
+    if (built.hasUnresolvedHandles) {
+      onUnresolvedHandles?.call(built.unresolvedHandles);
+    }
+
+    return await post.create(
+      text: built.text,
+      facets: built.facets,
+      reply: reply,
+      embed: embed,
+      langs: langs,
+      labels: labels,
+      tags: tags,
+      createdAt: createdAt,
+      rkey: rkey,
+      validate: validate,
+      swapCommit: swapCommit,
+      $headers: $headers,
+      $unknown: $unknown,
+    );
+  }
 
   /// Publishes [posts] as one thread, in a single atomic commit, and returns
   /// each created post's strong ref in order.

--- a/packages/bluesky/pubspec.yaml
+++ b/packages/bluesky/pubspec.yaml
@@ -1,7 +1,7 @@
 name: bluesky
 resolution: workspace
 description: The most famous and powerful Dart/Flutter library for Bluesky Social.
-version: 2.5.0
+version: 2.6.0
 homepage: https://atprotodart.com
 documentation: https://atprotodart.com/docs/packages/bluesky
 repository: https://github.com/myConsciousness/atproto.dart/tree/main/packages/bluesky
@@ -20,6 +20,7 @@ topics:
 dependencies:
   atproto_core: ^2.4.1
   atproto: ^2.5.0
+  bluesky_text: ^1.8.0
   freezed_annotation: ^3.1.0
   json_annotation: ^4.9.0
   characters: ^1.4.0
@@ -34,8 +35,6 @@ dev_dependencies:
     git:
       url: https://github.com/myConsciousness/import_sorter.git
       ref: fix/monorepo-pub-workspaces
-  bluesky_text: ^1.8.0
-
   atproto_test:
     path: ../atproto_test
   atproto_oauth: ^0.8.0

--- a/packages/bluesky/test/src/services/app/bsky/feed_post_text_test.dart
+++ b/packages/bluesky/test/src/services/app/bsky/feed_post_text_test.dart
@@ -1,0 +1,264 @@
+// Copyright (c) 2023-2026, Shinya Kato.
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// Dart imports:
+import 'dart:convert';
+
+// Package imports:
+import 'package:atproto_core/atproto_core.dart' as core;
+import 'package:http/http.dart' as http;
+import 'package:test/test.dart';
+
+// Project imports:
+import 'package:bluesky/app_bsky_richtext_facet.dart';
+import 'package:bluesky/bluesky.dart';
+
+const _did = 'did:plc:abcdefghijklmnopqrstuvwx';
+const _aliceDid = 'did:plc:alicealicealicealicealic';
+
+/// Records every request so the resolution host — the thing only the SDK can
+/// get right — can be asserted on.
+class _Recorder {
+  final List<Uri> gets = [];
+  final List<({Uri url, Object? body})> posts = [];
+
+  Future<http.Response> get(
+    final Uri url, {
+    final Map<String, String>? headers,
+    final Duration? timeout,
+  }) async {
+    gets.add(url);
+
+    final request = http.Request('GET', url);
+
+    if (url.path.endsWith('resolveHandle')) {
+      final handle = url.queryParameters['handle'];
+
+      return handle == 'alice.bsky.social'
+          ? _json({'did': _aliceDid}, request: request)
+          : _json(
+              {
+                'error': 'InvalidRequest',
+                'message': 'Unable to resolve handle',
+              },
+              status: 400,
+              request: request,
+            );
+    }
+
+    return _json({'error': 'unexpected'}, status: 500, request: request);
+  }
+
+  Future<http.Response> post(
+    final Uri url, {
+    final Map<String, String>? headers,
+    final dynamic body,
+    final Encoding? encoding,
+    final Duration? timeout,
+  }) async {
+    posts.add((url: url, body: body));
+
+    return _json({
+      'uri': 'at://$_did/app.bsky.feed.post/abc',
+      'cid': 'bafyreiabc',
+    }, request: http.Request('POST', url));
+  }
+}
+
+/// `request` is required: xrpc's response builder reads `response.request!`,
+/// so a fake response without one fails a null check before the body is even
+/// looked at.
+http.Response _json(
+  final Map<String, dynamic> body, {
+  final int status = 200,
+  required final http.BaseRequest request,
+}) => http.Response(
+  jsonEncode(body),
+  status,
+  headers: {'content-type': 'application/json; charset=utf-8'},
+  request: request,
+);
+
+Bluesky _bluesky(final _Recorder recorder, {final String? service}) =>
+    Bluesky.fromSession(
+      core.Session(
+        did: _did,
+        handle: 'me.example',
+        accessJwt: 'access',
+        refreshJwt: 'refresh',
+      ),
+      service: service,
+      getClient: recorder.get,
+      postClient: recorder.post,
+    );
+
+Map<String, dynamic> _record(final Object? body) =>
+    (jsonDecode(body as String) as Map<String, dynamic>)['record']
+        as Map<String, dynamic>;
+
+void main() {
+  group('buildPostText', () {
+    test('resolves mentions and returns lexicon-model facets', () async {
+      final recorder = _Recorder();
+      final built = await _bluesky(
+        recorder,
+      ).feed.buildPostText('hello @alice.bsky.social');
+
+      expect(built.text, 'hello @alice.bsky.social');
+      expect(built.facets, hasLength(1));
+      expect(built.hasNoUnresolvedHandles, isTrue);
+
+      // The whole point of the conversion: what comes back is already the type
+      // `post.create` and `ThreadPost` accept, with no `fromJson` at the call
+      // site.
+      expect(built.facets.single, isA<RichtextFacet>());
+      expect(built.facets.single.index.byteStart, 6);
+      expect(built.facets.single.index.byteEnd, 24);
+    });
+
+    test('resolves mentions over this client\'s transport, not a connection '
+        'of its own', () async {
+      final recorder = _Recorder();
+      await _bluesky(
+        recorder,
+        service: 'pds.example.com',
+      ).feed.buildPostText('hello @alice.bsky.social');
+
+      final resolve = recorder.gets.firstWhere(
+        (final url) => url.path.endsWith('resolveHandle'),
+      );
+
+      // Left to itself `bluesky_text` opens its own connection to a default
+      // host. Going through the client means the configured service — and its
+      // `getClient`, timeout and retry policy — apply to mention resolution
+      // too. The injected client seeing this request at all is the proof.
+      expect(resolve.host, 'pds.example.com');
+    });
+
+    test(
+      'reports a handle that does not resolve instead of dropping it',
+      () async {
+        final recorder = _Recorder();
+        final built = await _bluesky(
+          recorder,
+        ).feed.buildPostText('hi @ghost.bsky.social');
+
+        expect(built.hasUnresolvedHandles, isTrue);
+        expect(built.unresolvedHandles, ['ghost.bsky.social']);
+        // The post is still valid — the mention just stays plain text.
+        expect(built.text, 'hi @ghost.bsky.social');
+        expect(built.facets, isEmpty);
+      },
+    );
+
+    test('facet byte offsets index the returned text, not the input', () async {
+      final recorder = _Recorder();
+      // A markdown link is rewritten during formatting, so the formatted text
+      // differs from the input and every offset shifts with it. Pairing these
+      // facets with the original string is the trap this type exists to close.
+      final built = await _bluesky(
+        recorder,
+      ).feed.buildPostText('see [the docs](https://atprotodart.com)');
+
+      expect(built.text, isNot('see [the docs](https://atprotodart.com)'));
+      expect(built.facets, hasLength(1));
+
+      final bytes = utf8.encode(built.text);
+      final slice = built.facets.single.index;
+      expect(
+        utf8.decode(bytes.sublist(slice.byteStart, slice.byteEnd)),
+        'the docs',
+      );
+    });
+  });
+
+  group('postText', () {
+    test('publishes the formatted text with its facets', () async {
+      final recorder = _Recorder();
+      await _bluesky(recorder).feed.postText('hello @alice.bsky.social');
+
+      final create = recorder.posts.firstWhere(
+        (final p) => p.url.path.endsWith('createRecord'),
+      );
+      final record = _record(create.body);
+
+      expect(record[r'$type'], 'app.bsky.feed.post');
+      expect(record['text'], 'hello @alice.bsky.social');
+      expect(record['facets'], hasLength(1));
+      expect(
+        (record['facets'] as List).first,
+        containsPair('index', containsPair('byteStart', 6)),
+      );
+    });
+
+    test('passes the other record fields through', () async {
+      final recorder = _Recorder();
+      await _bluesky(
+        recorder,
+      ).feed.postText('hello', langs: ['en'], tags: ['dart']);
+
+      final record = _record(
+        recorder.posts
+            .firstWhere((final p) => p.url.path.endsWith('createRecord'))
+            .body,
+      );
+
+      expect(record['langs'], ['en']);
+      expect(record['tags'], ['dart']);
+    });
+
+    test('reports unresolved handles before creating the record', () async {
+      final recorder = _Recorder();
+      final reported = <List<String>>[];
+
+      await _bluesky(recorder).feed.postText(
+        'hi @ghost.bsky.social',
+        onUnresolvedHandles: reported.add,
+      );
+
+      expect(reported.single, ['ghost.bsky.social']);
+      // Unresolved is not an error: the post still went out.
+      expect(
+        recorder.posts.where((final p) => p.url.path.endsWith('createRecord')),
+        hasLength(1),
+      );
+    });
+
+    test(
+      'a throwing onUnresolvedHandles aborts before the record is created',
+      () async {
+        final recorder = _Recorder();
+
+        await expectLater(
+          () => _bluesky(recorder).feed.postText(
+            'hi @ghost.bsky.social',
+            onUnresolvedHandles: (final handles) =>
+                throw StateError('fix the handle first'),
+          ),
+          throwsA(isA<StateError>()),
+        );
+
+        // Nothing was published — the hook runs before the write.
+        expect(
+          recorder.posts.where(
+            (final p) => p.url.path.endsWith('createRecord'),
+          ),
+          isEmpty,
+        );
+      },
+    );
+
+    test('is not called when every mention resolves', () async {
+      final recorder = _Recorder();
+      var called = false;
+
+      await _bluesky(recorder).feed.postText(
+        'hello @alice.bsky.social',
+        onUnresolvedHandles: (final _) => called = true,
+      );
+
+      expect(called, isFalse);
+    });
+  });
+}

--- a/templates/feed_generator/pubspec.yaml
+++ b/templates/feed_generator/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: ">=3.8.0 <4.0.0"
 
 dependencies:
-  bluesky: ^2.5.0
+  bluesky: ^2.6.0
   atproto_core: ^2.4.1
   atproto_identity: ^0.3.0
   shelf: ^1.4.0


### PR DESCRIPTION
Posting text with working mentions, links and hashtags took three steps the docs had to spell out — **in two separate places**, with the same snippet in both (`ThreadPost`'s docstring at `feed/thread.dart:27`, and `bluesky_text`'s own `split()` / `toPostData()` docs):

```dart
final data = await BlueskyText(text).toPostData();
await bluesky.feed.post.create(
  text: data.text,
  facets: data.facets.map(RichtextFacet.fromJson).toList(),
);
```

When the documentation has to teach the same four lines twice, that is the SDK's work leaking into the call site.

## Why each step is a trap

**Order matters.** A markdown link only becomes a link facet *after* formatting, so resolving before formatting silently loses it.

**The formatted text must be posted, not the input.** Facet ranges are byte offsets into the formatted string. Pass the original and every link lands on the wrong characters — with no error, because the record is perfectly valid. The existing docstring warns about this in prose; a type is a better place for it.

**The facet maps need converting** before `post.create` or `ThreadPost` will take them.

## What this adds

`feed.buildPostText` does all three and returns a `PostText` that holds the formatted text and its facets **together**, so the pair cannot be separated by accident:

```dart
final built = await bluesky.feed.buildPostText(
  'hello @alice.bsky.social, see https://atprotodart.com #dart',
);

await bluesky.feed.post.create(text: built.text, facets: built.facets);
final threadPost = ThreadPost(text: built.text, facets: built.facets);
```

`feed.postText` builds and publishes in one call, passing every other record field straight through:

```dart
await bluesky.feed.postText('hello @alice.bsky.social');
```

Both live on `FeedServiceImpl`, alongside `createThreadAtomic` — the same hand-written-convenience-over-generated-service pattern.

## A defect found on the way

Mentions are now resolved with `com.atproto.identity.resolveHandle` **over this client's transport**. Left to itself, `bluesky_text` opens its own HTTP connection to a default host (`findDID` → `xrpc.query` with `service: null`).

That is not only a testability problem. An account on a self-hosted PDS was resolving its mentions against the wrong server, and none of the client's configuration — service, timeout, retry policy, custom `getClient`, proxy headers — applied to the call. Going through the client fixes all of it at once, and is why the fix is a change of mechanism rather than just threading a `service:` string through.

## Unresolved handles

A handle that does not resolve carries no facet. Today it is dropped silently; `bluesky_text`'s own docs say to "inspect `unresolvedHandles` to warn the user rather than silently posting without those mentions", which only works if the value survives to the caller.

It is reported in `PostText.unresolvedHandles`, and through `postText`'s `onUnresolvedHandles`. It is deliberately **not** an error — the post is still valid, the mention just stays plain text — but the callback runs *before* the record is created, so throwing from it aborts the post. That is the hook for an author who would rather fix a typo than publish a mention that renders as plain text.

## Dependency change

`bluesky_text` moves from a dev dependency to a runtime dependency. It brings **no new transitive packages** — `xrpc`, `http` and `characters` are already dependencies of `bluesky` — and there is no cycle: `bluesky_text` depends only on `xrpc`, `http`, `characters` and the two annotation packages, not on `bluesky`. Version `1.8.0` is published on pub.dev.

## Verification

- `dart analyze` across the workspace — clean
- `dart format --set-exit-if-changed` — no changes
- `dart run ./scripts/validate_dependencies.dart` — 14 packages pass
- `bluesky` 985 tests (9 new), `bluesky_text` 498, `feed_generator` 75 — all pass

The new tests pin the two behaviours that are invisible until they break: that the resolution request actually goes through the injected client (asserted on the recorded request host), and that facet offsets index the *returned* text — the markdown-link case, where the formatted string differs from the input, decoded back out of the UTF-8 bytes to confirm the slice really covers `the docs`.

## Follow-up not included

`bluesky_text`'s own `toPostData()` / `split()` docstrings still show the manual conversion. Updating them needs a `bluesky_text` release, so it is left out of this PR rather than bundled in.

## Versions

| Package | Version | Why |
| --- | --- | --- |
| `bluesky` | 2.5.0 → 2.6.0 | new public API, new runtime dependency |

---
_Generated by [Claude Code](https://claude.ai/code/session_016ManHiFgPPPqMpshziygZi)_