### PR TITLE
feat(bluesky): let Bluesky.fromAtproto set headers on its own calls

### DIFF
--- a/packages/bluesky/CHANGELOG.md
+++ b/packages/bluesky/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release Note
 
+## v2.7.0
+
+- feat: `Bluesky.fromAtproto` takes `additionalHeaders`, which sends extra headers on this client's `app.bsky.*` calls only and leaves the `ATProto` it was built from alone. `Bluesky.fromSession` has always taken `headers`; `fromAtproto` took none, so a caller who builds the `ATProto` themselves — the entire reason that constructor exists — could either put the header on the shared `ATProto`, where it also went out on `com.atproto.*` calls that were never meant to carry it, or build a second `ATProto` and lose the single-session guarantee. `atproto-accept-labelers` is the obvious case: the AppView only attaches labels from labelers named in that header, and it has no business on `com.atproto.*`.
+- chore: the header is merged through `ServiceContext.withAdditionalHeaders` on a *derived* context, matching `BlueskyChat.fromAtproto`. Derived rather than copied, so the session stays shared and only one refresh ever spends the single-use token; merged rather than spread, because header names are case-insensitive and a key-exact spread would leave `Atproto-Proxy` alongside a lowercase one for a custom `getClient` to emit twice. Omitting the parameter passes the original context through untouched, so nothing changes for an existing caller.
+
 ## v2.6.4
 
 - feat: added `app.bsky.feed.defs#knownLikers`

--- a/packages/bluesky/lib/src/bluesky.dart
+++ b/packages/bluesky/lib/src/bluesky.dart
@@ -46,7 +46,35 @@ sealed class Bluesky {
   /// Note that headers belong to the context too, so an [atproto] carrying a
   /// service proxy header (`atproto-proxy`) sends every `app.bsky.*` call to
   /// that service as well. Pass a client built for `app.bsky.*` traffic.
-  factory Bluesky.fromAtproto(final atp.ATProto atproto) = _Bluesky.fromAtproto;
+  ///
+  /// [additionalHeaders] sends extra headers on this client's `app.bsky.*`
+  /// calls **only**, leaving [atproto]'s own `com.atproto.*` calls alone. The
+  /// session is still shared — the context is derived, not copied — so all
+  /// three guarantees above continue to hold.
+  ///
+  /// ```dart
+  /// final bluesky = Bluesky.fromAtproto(
+  ///   atproto,
+  ///   additionalHeaders: const {
+  ///     'atproto-accept-labelers': 'did:plc:ar7c4by46qjdydhdevvrndac',
+  ///   },
+  /// );
+  /// ```
+  ///
+  /// This is what [Bluesky.fromSession]'s `headers` gives a caller who lets
+  /// this class build the [atp.ATProto]; without it, a caller who builds one
+  /// themselves — which is the whole point of this constructor — had no way to
+  /// set headers on the Bluesky half at all.
+  ///
+  /// Merged through [core.ServiceContext.withAdditionalHeaders] rather than a
+  /// spread, because a spread is key-exact and header names are not: an
+  /// [atproto] already sending `Atproto-Proxy` would keep it alongside a
+  /// lowercase one passed here, and a custom [core.GetClient] forwarding the
+  /// raw map emits both.
+  factory Bluesky.fromAtproto(
+    final atp.ATProto atproto, {
+    final Map<String, String>? additionalHeaders,
+  }) = _Bluesky.fromAtproto;
 
   /// Returns the new instance of [Bluesky].
   ///
@@ -275,12 +303,26 @@ sealed class Bluesky {
 }
 
 final class _Bluesky implements Bluesky {
-  /// Drives every `app.bsky.*` service from [atproto]'s own context.
+  /// Drives every `app.bsky.*` service from [atproto]'s own context, or —
+  /// when [additionalHeaders] is given — from a context derived from it.
   ///
   /// A second context would carry a second copy of the session, and only one
-  /// of the two would ever be refreshed — see [atp.ATProto.ctx].
-  factory _Bluesky.fromAtproto(final atp.ATProto atproto) =>
-      _Bluesky._(atproto.ctx, atproto);
+  /// of the two would ever be refreshed — see [atp.ATProto.ctx]. Deriving
+  /// shares the session state, so that does not happen either way.
+  ///
+  /// With nothing to add, [atproto]'s context is passed through unchanged
+  /// rather than derived from: an empty merge would produce an equivalent
+  /// context, but not the identical one, and callers that passed no headers
+  /// should get exactly what they got before this parameter existed.
+  factory _Bluesky.fromAtproto(
+    final atp.ATProto atproto, {
+    final Map<String, String>? additionalHeaders,
+  }) => _Bluesky._(
+    additionalHeaders == null || additionalHeaders.isEmpty
+        ? atproto.ctx
+        : atproto.ctx.withAdditionalHeaders(additionalHeaders),
+    atproto,
+  );
 
   _Bluesky._(final core.ServiceContext ctx, this.atproto)
     : actor = ActorService(ctx),

--- a/packages/bluesky/pubspec.yaml
+++ b/packages/bluesky/pubspec.yaml
@@ -1,7 +1,7 @@
 name: bluesky
 resolution: workspace
 description: The most famous and powerful Dart/Flutter library for Bluesky Social.
-version: 2.6.4
+version: 2.7.0
 homepage: https://atprotodart.com
 documentation: https://atprotodart.com/docs/packages/bluesky
 repository: https://github.com/myConsciousness/atproto.dart/tree/main/packages/bluesky

--- a/packages/bluesky/test/src/from_atproto_test.dart
+++ b/packages/bluesky/test/src/from_atproto_test.dart
@@ -33,6 +33,10 @@ final class _FakePds {
   /// request was addressed to. Null where the request carried no such header.
   final Map<String, String?> proxyHeaderByNsid = {};
 
+  /// Every request header seen on a `GET`, keyed by the NSID the request was
+  /// addressed to — for assertions about headers other than the proxy one.
+  final Map<String, Map<String, String>> headersByNsid = {};
+
   /// Every header name spelled `atproto-proxy` in any casing, keyed by the
   /// NSID the request was addressed to.
   ///
@@ -58,6 +62,7 @@ final class _FakePds {
     final Map<String, String>? headers,
   }) async {
     final nsid = url.path.replaceFirst('/xrpc/', '');
+    headersByNsid[nsid] = {...?headers};
     proxyHeaderByNsid[nsid] = headers?['atproto-proxy'];
     proxyHeaderNamesByNsid[nsid] = [
       ...?headers?.keys.where((e) => e.toLowerCase() == 'atproto-proxy'),
@@ -375,6 +380,116 @@ void main() {
         chat.convo.listConvos(),
         throwsA(isA<core.UnauthorizedException>()),
       );
+    });
+  });
+
+  group('Bluesky.fromAtproto additionalHeaders', () {
+    atp.ATProto atproto(
+      final _FakePds pds, {
+      final Map<String, String>? headers,
+    }) => atp.ATProto.fromSession(
+      pds.initialSession,
+      service: 'pds.test',
+      headers: headers,
+      getClient: pds.get,
+      postClient: pds.post,
+    );
+
+    test('sends them on app.bsky.* and nowhere else', () async {
+      final pds = _FakePds();
+      final atp = atproto(pds);
+
+      final bsky = Bluesky.fromAtproto(
+        atp,
+        additionalHeaders: const {'atproto-accept-labelers': 'did:plc:label'},
+      );
+
+      await bsky.feed.getTimeline();
+      await bsky.atproto.server.getSession();
+
+      //! The point of deriving rather than adopting: the caller's own
+      //! `ATProto` keeps sending what it always sent.
+      expect(
+        pds.headersByNsid['app.bsky.feed.getTimeline']?['atproto-accept-labelers'],
+        'did:plc:label',
+      );
+      expect(
+        pds.headersByNsid['com.atproto.server.getSession']?.containsKey(
+          'atproto-accept-labelers',
+        ),
+        isFalse,
+      );
+      expect(identical(bsky.atproto, atp), isTrue);
+    });
+
+    test('shares the session with the context it derived from', () async {
+      final pds = _FakePds();
+      final atp = atproto(pds);
+
+      final bsky = Bluesky.fromAtproto(
+        atp,
+        additionalHeaders: const {'atproto-accept-labelers': 'did:plc:label'},
+      );
+
+      await bsky.feed.getTimeline();
+      final response = await atp.server.getSession();
+
+      //! Derived, not copied. Two copies of one session would each try to
+      //! spend the single-use refresh token and the loser would fail.
+      expect(response.status.code, 200);
+      expect(pds.refreshCalls, 1);
+      expect(identical(bsky.session, atp.session), isTrue);
+    });
+
+    test('merges with a header the context already carries', () async {
+      final pds = _FakePds();
+      final atp = atproto(pds, headers: const {'x-caller': 'kept'});
+
+      final bsky = Bluesky.fromAtproto(
+        atp,
+        additionalHeaders: const {'atproto-accept-labelers': 'did:plc:label'},
+      );
+
+      await bsky.feed.getTimeline();
+
+      //! Both survive: `withAdditionalHeaders` merges rather than replaces.
+      final seen = pds.headersByNsid['app.bsky.feed.getTimeline'];
+      expect(seen?['atproto-accept-labelers'], 'did:plc:label');
+      expect(seen?['x-caller'], 'kept');
+    });
+
+    test('a caller header in another casing does not survive twice', () async {
+      final pds = _FakePds();
+      final atp = atproto(pds, headers: const {'Atproto-Proxy': 'did:web:one'});
+
+      final bsky = Bluesky.fromAtproto(
+        atp,
+        additionalHeaders: const {'atproto-proxy': 'did:web:two'},
+      );
+
+      await bsky.feed.getTimeline();
+
+      //! Header names are case-insensitive, so a key-exact spread would leave
+      //! both spellings in the raw map and a custom `GetClient` would emit
+      //! the header twice. The merge collapses them.
+      expect(
+        pds.proxyHeaderNamesByNsid['app.bsky.feed.getTimeline'],
+        hasLength(1),
+      );
+      expect(pds.proxyHeaderByNsid['app.bsky.feed.getTimeline'], 'did:web:two');
+    });
+
+    test('omitting it changes nothing about the context used', () async {
+      final pds = _FakePds();
+      final atp = atproto(pds);
+
+      final bsky = Bluesky.fromAtproto(atp);
+      final withEmpty = Bluesky.fromAtproto(atp, additionalHeaders: const {});
+
+      //! Passing nothing hands `atproto`'s own context straight through, so
+      //! this parameter cannot change what an existing caller sees.
+      expect(identical(bsky.headers, atp.headers), isTrue);
+      expect(identical(withEmpty.headers, atp.headers), isTrue);
     });
   });
 

--- a/templates/feed_generator/pubspec.yaml
+++ b/templates/feed_generator/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: ">=3.8.0 <4.0.0"
 
 dependencies:
-  bluesky: ^2.6.4
+  bluesky: ^2.7.0
   atproto_core: ^2.4.1
   atproto_identity: ^0.3.0
   shelf: ^1.4.0


### PR DESCRIPTION
## The gap

`Bluesky.fromSession` takes `headers` and passes them to the `ATProto` it builds. `Bluesky.fromAtproto` took none.

So a caller who builds the `ATProto` themselves — which is the entire reason that constructor exists — had no way to put a header on the Bluesky half. The two workarounds are both bad:

- Set the header on the shared `ATProto`, and it goes out on `com.atproto.*` calls that were never meant to carry it.
- Build a second `ATProto`, and lose the single-session guarantee `fromAtproto` exists to provide — two copies of one session, each trying to spend a single-use refresh token.

`app.bsky.*`-scoped request headers are a real need (`atproto-accept-labelers` is the obvious one: the AppView only attaches labels from labelers named in that header, and it has no business on `com.atproto.*`).

## The change

```dart
final bluesky = Bluesky.fromAtproto(
  atproto,
  additionalHeaders: const {
    'atproto-accept-labelers': 'did:plc:ar7c4by46qjdydhdevvrndac',
  },
);
```

Additive and optional — no existing caller changes.

It follows `BlueskyChat.fromAtproto`, which already derives a context for the `atproto-proxy` header, and for the same two reasons its doc gives:

**Derived, not copied.** A second context carries a second copy of the session and only one of the two is ever refreshed; the loser then presents a spent refresh token. `withAdditionalHeaders` shares the session state, so `fromAtproto`'s three documented guarantees — one session, one refresh, one `onSessionUpdated` — continue to hold.

**Merged, not spread.** A spread is key-exact and header names are not: an `ATProto` already sending `Atproto-Proxy` would keep it alongside a lowercase one passed here, and a custom `GetClient` forwarding the raw map emits the header twice.

**Passing nothing hands `atproto.ctx` straight through** rather than deriving from it with an empty merge. The two behave identically but are not the same object, and a caller who omits the parameter should get exactly what they got before it existed.

## Tests

Five, in `packages/bluesky/test/src/from_atproto_test.dart` beside the `BlueskyChat.fromAtproto` group they mirror:

| | |
|---|---|
| sends them on `app.bsky.*` and nowhere else | the caller's own `ATProto` keeps sending what it always sent |
| shares the session with the context it derived from | one refresh, `identical(bsky.session, atp.session)` |
| merges with a header the context already carries | both survive |
| a caller header in another casing does not survive twice | the raw map carries one `atproto-proxy`, not two |
| omitting it changes nothing about the context used | `identical(bsky.headers, atp.headers)` |

The fake PDS in that file gains a `headersByNsid` map so a test can assert on headers other than the proxy one.

Mutation-checked rather than assumed: swapping `withAdditionalHeaders` for `withHeaders` (merge → replace) fails the third test.

`dart test` in `packages/bluesky`: **991 passed.** `dart analyze`: clean.