### PR TITLE
fix(bluesky): KnownLabelValue was missing `bot`, and says why `gore` stays

### DIFF
--- a/packages/bluesky/CHANGELOG.md
+++ b/packages/bluesky/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Release Note
 
+## v2.8.0
+
+- fix: `KnownLabelValue` was missing `bot`, which `com.atproto.label.defs#labelValue` lists among its `knownValues`. `KnownLabelValue.valueOf('bot')` answered null, so a caller using this enum to tell a global label value from a labeler-defined one got the wrong answer for it. Note that `bot` deliberately gets no entry in `kLabels` or `kLabelDefinitions`: the lexicon declares the value but not how to interpret it, and inventing a severity and a blur here would make this package decide moderation behaviour the protocol does not specify — so a `bot` label still flows through with no interpreted definition, exactly as before. This changes what the enum says, not what the moderation engine does.
+- docs: `gore` is documented as what it is — a value the lexicon has since dropped from `knownValues`, kept because labels already applied to existing content still carry it — rather than as a "deprecated alias".
+- test: the enum is now checked against `lexicons/com/atproto/label/defs.json` directly, so a value added there fails a test naming it instead of drifting unnoticed.
+
+**If you `switch` exhaustively over `KnownLabelValue`,** this release adds a case you will need to handle. Shipped as a minor because that is how lexicon-driven enum additions have shipped here before, not because the risk is zero.
+
 ## v2.7.0
 
 - feat: `Bluesky.fromAtproto` takes `additionalHeaders`, which sends extra headers on this client's `app.bsky.*` calls only and leaves the `ATProto` it was built from alone. `Bluesky.fromSession` has always taken `headers`; `fromAtproto` took none, so a caller who builds the `ATProto` themselves — the entire reason that constructor exists — could either put the header on the shared `ATProto`, where it also went out on `com.atproto.*` calls that were never meant to carry it, or build a second `ATProto` and lose the single-session guarantee. `atproto-accept-labelers` is the obvious case: the AppView only attaches labels from labelers named in that header, and it has no business on `com.atproto.*`.

--- a/packages/bluesky/lib/src/moderation/types/const/labels.dart
+++ b/packages/bluesky/lib/src/moderation/types/const/labels.dart
@@ -7,6 +7,10 @@ import '../interpreted_label_value_definition.dart';
 import '../labels.dart';
 import '../moderation_behavior.dart';
 
+/// The label values `com.atproto.label.defs#labelValue` declares as known.
+///
+/// Kept in step with that lexicon's `knownValues` by hand, so the two can
+/// drift — see [gore], which is here and no longer there.
 enum KnownLabelValue {
   hide('!hide'),
   warn('!warn'),
@@ -16,7 +20,26 @@ enum KnownLabelValue {
   nudity('nudity'),
   graphicMedia('graphic-media'),
 
-  /// Deprecated alias for [graphicMedia].
+  /// Applied to accounts that post automatically.
+  ///
+  /// In the lexicon's `knownValues` and, until now, missing here — so
+  /// [valueOf] answered null for a value the protocol calls known, and a
+  /// caller using this enum to tell a global label from a labeler-defined one
+  /// got the wrong answer.
+  ///
+  /// It has no entry in [kLabels] or [kLabelDefinitions]: the lexicon declares
+  /// the value but not how to interpret it, and inventing a severity and a
+  /// blur here would be this package deciding moderation behaviour the
+  /// protocol does not specify. A `bot` label therefore still flows through
+  /// with no interpreted definition, exactly as before — this changes what the
+  /// enum *says*, not what the moderation engine *does*.
+  bot('bot'),
+
+  /// No longer in the lexicon's `knownValues`, and kept anyway.
+  ///
+  /// It was the earlier spelling of [graphicMedia]. Removing it would drop
+  /// labels that are already applied to existing content on the floor, which
+  /// is worse than carrying a value the protocol has moved past.
   gore('gore');
 
   final String value;

--- a/packages/bluesky/pubspec.yaml
+++ b/packages/bluesky/pubspec.yaml
@@ -1,7 +1,7 @@
 name: bluesky
 resolution: workspace
 description: The most famous and powerful Dart/Flutter library for Bluesky Social.
-version: 2.7.0
+version: 2.8.0
 homepage: https://atprotodart.com
 documentation: https://atprotodart.com/docs/packages/bluesky
 repository: https://github.com/myConsciousness/atproto.dart/tree/main/packages/bluesky

--- a/packages/bluesky/test/src/moderation/known_label_value_test.dart
+++ b/packages/bluesky/test/src/moderation/known_label_value_test.dart
@@ -1,0 +1,79 @@
+// Copyright (c) 2023-2025, Shinya Kato.
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// Dart imports:
+import 'dart:convert';
+import 'dart:io';
+
+// Package imports:
+import 'package:test/test.dart';
+
+// Project imports:
+import 'package:bluesky/src/moderation/types/const/labels.dart';
+
+/// `com.atproto.label.defs#labelValue.knownValues`, read from the lexicon this
+/// package is generated against.
+///
+/// Relative to the package directory, which is where `dart test` runs from —
+/// the same assumption every fixture path in this suite already makes.
+Set<String> _lexiconKnownValues() {
+  final file = File('../../lexicons/com/atproto/label/defs.json');
+  final defs = jsonDecode(file.readAsStringSync()) as Map<String, dynamic>;
+  final labelValue =
+      (defs['defs'] as Map<String, dynamic>)['labelValue']
+          as Map<String, dynamic>;
+
+  return {...(labelValue['knownValues'] as List).cast<String>()};
+}
+
+void main() {
+  group('KnownLabelValue against the lexicon', () {
+    test('every value the lexicon calls known is in the enum', () {
+      // The half that was actually wrong: `bot` is in the lexicon and was not
+      // here, so `valueOf('bot')` answered null for a value the protocol calls
+      // known.
+      final missing = _lexiconKnownValues().difference({
+        for (final value in KnownLabelValue.values) value.value,
+      });
+
+      expect(
+        missing,
+        isEmpty,
+        reason: 'in the lexicon but not in KnownLabelValue: $missing',
+      );
+    });
+
+    test('gore is the only value the enum keeps beyond the lexicon', () {
+      // Not `isEmpty`: `gore` is deliberately retained because labels already
+      // applied to existing content still carry it. Pinning it by name means a
+      // *new* divergence fails this test instead of hiding behind that one.
+      final extra = {
+        for (final value in KnownLabelValue.values) value.value,
+      }.difference(_lexiconKnownValues());
+
+      expect(extra, {'gore'});
+    });
+
+    test('valueOf resolves every lexicon value', () {
+      for (final value in _lexiconKnownValues()) {
+        expect(
+          KnownLabelValue.valueOf(value),
+          isNotNull,
+          reason: 'KnownLabelValue.valueOf($value) returned null',
+        );
+      }
+    });
+
+    test('bot carries no interpreted definition, deliberately', () {
+      // The lexicon declares the value but not how to interpret it. Inventing
+      // a severity and a blur here would make this package decide moderation
+      // behaviour the protocol does not specify — so a `bot` label flows
+      // through undefined, and this test says that is a choice rather than an
+      // oversight.
+      expect(KnownLabelValue.valueOf('bot'), KnownLabelValue.bot);
+      expect(kLabels.containsKey(KnownLabelValue.bot), isFalse);
+      expect(kLabelDefinitions.containsKey('bot'), isFalse);
+    });
+  });
+}

--- a/templates/feed_generator/pubspec.yaml
+++ b/templates/feed_generator/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: ">=3.8.0 <4.0.0"
 
 dependencies:
-  bluesky: ^2.7.0
+  bluesky: ^2.8.0
   atproto_core: ^2.4.1
   atproto_identity: ^0.3.0
   shelf: ^1.4.0


### PR DESCRIPTION
## The drift

`com.atproto.label.defs#labelValue` lists eight `knownValues`:

```
["!hide", "!warn", "!no-unauthenticated", "porn", "sexual", "nudity", "graphic-media", "bot"]
```

`KnownLabelValue` had seven of them, plus one the lexicon does not have. Nothing was checking, so it drifted quietly.

**`bot` was missing.** `KnownLabelValue.valueOf('bot')` answered null, so a caller using this enum to tell a global label value from a labeler-defined one got the wrong answer for a value the protocol calls known.

**`gore` is here and not in the lexicon.** It stays, and its doc now says what it actually is — a value the lexicon has since dropped from `knownValues`, kept because labels already applied to existing content still carry it — instead of calling it a "deprecated alias". Dropping it would put those labels on the floor.

## `bot` gets no interpreted definition, on purpose

It has no entry in `kLabels` or `kLabelDefinitions`, and that is the deliberate part of this change.

The lexicon declares the value but says nothing about how to interpret it — no severity, no blur, no behaviours. Inventing them here would make this package decide moderation behaviour the protocol does not specify, on behalf of every consumer. A `bot` label therefore still flows through with no interpreted definition, exactly as before.

**So this changes what the enum says, not what the moderation engine does.** A test pins that as a choice rather than an oversight, so the next reader does not "fix" it by guessing at a severity.

If `bot` should blur or badge something, that is a separate decision with a source behind it, and it belongs in its own change.

## The check, not just the fix

The enum is now compared against `lexicons/com/atproto/label/defs.json` directly, so this cannot drift silently again. Two guards, and both were exercised rather than assumed:

| guard | how it fails |
|---|---|
| removing an enum member | the test that names `KnownLabelValue.bot` stops compiling |
| adding a value to the lexicon | an assertion fails naming it — verified by temporarily appending `spam` to `knownValues` and watching it report `in the lexicon but not in KnownLabelValue: {spam}` |

The second is the one that matters going forward: no test can name a value that does not exist yet, so the assertion is what catches the next addition.

`gore` is pinned by name rather than the extra set being asserted empty — a *new* divergence fails the test instead of hiding behind the one that is intentional.

## Release

`2.7.0` → `2.8.0`, CHANGELOG entry, and `templates/feed_generator` moved with it as it does on every release.

**If you `switch` exhaustively over `KnownLabelValue`, this adds a case you will need to handle.** Shipped as a minor because that is how lexicon-driven enum additions have shipped here before, not because the risk is zero — say so if you would rather it were a major.

## Checks

`dart format --set-exit-if-changed`: 0 changed · `dart analyze`: clean · `validate_dependencies`: 14 packages · `validate_website_overrides`: 11 packages · `dart test` in `packages/bluesky`: **995 passed**.