### PR TITLE
feat(atproto_identity): allow access to raw DID documents

### DIFF
--- a/.github/actions/setup-dart-cached/action.yml
+++ b/.github/actions/setup-dart-cached/action.yml
@@ -17,6 +17,13 @@ runs:
       uses: dart-lang/setup-dart@v1
       with:
         sdk: ${{ inputs.sdk }}
+        # setup-dart v1.8.1 resolves its `dart analyze` problem-matcher JSON
+        # against the calling action's directory, which for this composite
+        # action is `.github/actions/setup-dart-cached/` rather than its own.
+        # The file is not there, `::add-matcher::` fails, and the whole step
+        # fails -- skipping `dart pub get` and every job that follows it.
+        # Disable the matcher until upstream resolves the path correctly.
+        problem-matcher: false
 
     - name: Cache pub-cache
       uses: actions/cache@v4

--- a/packages/atproto_core/pubspec.yaml
+++ b/packages/atproto_core/pubspec.yaml
@@ -27,7 +27,7 @@ dependencies:
   json_annotation: ^4.9.0
   cbor: ^6.3.7
   multiformats: ^1.4.0
-  atproto_oauth: ^0.8.0
+  atproto_oauth: ^0.8.1
   nanoid: ^1.0.0
   meta: ^1.17.0
 

--- a/packages/atproto_identity/CHANGELOG.md
+++ b/packages/atproto_identity/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release Note
 
+## v0.4.0
+
+- **feat**: added `HttpIdentityResolver.resolveDidDocument`, which fetches a DID document and returns it verbatim as a `Map<String, dynamic>`. `resolve` interprets a document as an atproto identity and therefore rejects anything without an `#atproto_pds` service, so a document that is not an account's — a feed generator's `did:web` document, which declares only a `#bsky_fg` service — was unreachable through this package even though the resolver already fetched, size-capped, redirect-checked, and `id`-bound it. The new method reuses that same fetch; only the atproto-specific interpretation is skipped.
+- **feat**: added `serviceEndpointOf`, which reads a service entry out of a raw DID document (matching both the `#bsky_fg` and `<did>#bsky_fg` spellings, optionally on `type`) and returns its `serviceEndpoint` held to the same bar the resolver applies to a PDS endpoint: https-only, no credentials/query/fragment, and no `localhost` or reserved IP literal. Without it, reading a raw document would hand every caller an unvalidated attacker-controlled URL — the gap `ensureNonReservedHost` was added in v0.3.0 to close. Unlike the PDS endpoint the result keeps its path, since DID Core allows one.
+- **security**: the strict DID grammar that `verifyServiceAuth` applies to a JWT's `iss` now also guards every DID document fetch, including one whose DID came back from handle resolution — which validated only the `did:` prefix before the DID was interpolated into the PLC directory URL. A hostile or compromised handle resolver could return `did:plc:x/../../admin` and change the URL the request reached. `resolve` is correspondingly stricter: a DID carrying a path, query, fragment, or whitespace now fails before any request is issued.
+
 ## v0.3.0
 
 - **feat**: added `ensureNonReservedHost`, which applies the same SSRF host policy `HttpIdentityResolver` uses for a PDS endpoint — reject `localhost` and IP literals in loopback, private, link-local, CGNAT, unique-local, multicast, unspecified, or reserved ranges (unless `allowPrivateNetwork`), with the same IP-literal-only limitation. Exposed so a caller that derives a further network target from resolver output can hold it to the same bar; `atproto_oauth` uses it to vet the authorization server taken from PDS metadata.

--- a/packages/atproto_identity/README.md
+++ b/packages/atproto_identity/README.md
@@ -127,18 +127,19 @@ document describes an account: a feed generator publishes a `did:web` document
 whose only service is `#bsky_fg`, and `resolve(...)` throws on it.
 
 `resolveDidDocument(did)` returns such a document verbatim, as decoded JSON,
-using the same hardened fetch — the host policy, the timeout, the size cap, the
-redirect rules, and, for `did:web`, the binding of the document's `id` to the
-DID you asked for. Only the atproto-specific interpretation is skipped, so no
-`#atproto_pds` service is required:
+using the same hardened fetch — the timeout, the size cap and the redirect cap
+on every fetch, plus, for `did:web`, the host policy above and the binding of
+the document's `id` to the DID you asked for. Only the atproto-specific
+interpretation is skipped, so no `#atproto_pds` service is required:
 
 ```dart
 final document = await resolver.resolveDidDocument('did:web:foryou.club');
 ```
 
-The values inside the document are *not* validated. A `serviceEndpoint` other
-than the PDS one is attacker-controlled text that has passed no scheme or host
-policy, so read one with `serviceEndpointOf` rather than by hand:
+The values inside the document are *not* validated. Every `serviceEndpoint` in
+it — the `#atproto_pds` entry included, since that one is checked only on the
+`resolve(...)` path — is attacker-controlled text that has passed no scheme or
+host policy, so read one with `serviceEndpointOf` rather than by hand:
 
 ```dart
 final endpoint = serviceEndpointOf(
@@ -146,7 +147,7 @@ final endpoint = serviceEndpointOf(
   'did:web:foryou.club',
   id: '#bsky_fg',                // matches `#bsky_fg` and `<did>#bsky_fg`
   type: 'BskyFeedGenerator',     // optional; the entry's type must equal it
-); // https origin (path preserved), or null when no such service is declared
+); // validated https URL, or null when no such service is declared
 ```
 
 `serviceEndpointOf` holds the endpoint to the same bar the resolver applies to a

--- a/packages/atproto_identity/README.md
+++ b/packages/atproto_identity/README.md
@@ -14,6 +14,8 @@ generation, and it depends only on [`http`](https://pub.dev/packages/http) and
 Use it to:
 
 - **Resolve** a handle or DID to its DID, PDS origin, and `#atproto` signing key.
+- **Read** a raw DID document, for identities the atproto model does not
+  describe — a feed generator's `did:web` document, for instance.
 - **Verify** an inbound AppView service-auth JWT (e.g. in a custom feed
   generator or other AppView) and recover the viewer's DID.
 
@@ -21,7 +23,7 @@ Use it to:
 
 ```yaml
 dependencies:
-  atproto_identity: ^0.1.1 # Replace with the actual version
+  atproto_identity: ^0.4.0 # Replace with the actual version
 ```
 
 ## Resolving an identity
@@ -116,6 +118,42 @@ final key = signingKeyOf(didDocument, 'did:plc:...'); // multibase String, or nu
 
 `resolve(...)` already populates `ResolvedIdentity.signingKey` with this value;
 `signingKeyOf` is exported for when you hold a DID document directly.
+
+### Reading a raw DID document
+
+`resolve(...)` interprets a DID document as an atproto identity, so it requires
+an `#atproto_pds` service and rejects any document without one. Not every DID
+document describes an account: a feed generator publishes a `did:web` document
+whose only service is `#bsky_fg`, and `resolve(...)` throws on it.
+
+`resolveDidDocument(did)` returns such a document verbatim, as decoded JSON,
+using the same hardened fetch — the host policy, the timeout, the size cap, the
+redirect rules, and, for `did:web`, the binding of the document's `id` to the
+DID you asked for. Only the atproto-specific interpretation is skipped, so no
+`#atproto_pds` service is required:
+
+```dart
+final document = await resolver.resolveDidDocument('did:web:foryou.club');
+```
+
+The values inside the document are *not* validated. A `serviceEndpoint` other
+than the PDS one is attacker-controlled text that has passed no scheme or host
+policy, so read one with `serviceEndpointOf` rather than by hand:
+
+```dart
+final endpoint = serviceEndpointOf(
+  document,
+  'did:web:foryou.club',
+  id: '#bsky_fg',                // matches `#bsky_fg` and `<did>#bsky_fg`
+  type: 'BskyFeedGenerator',     // optional; the entry's type must equal it
+); // https origin (path preserved), or null when no such service is declared
+```
+
+`serviceEndpointOf` holds the endpoint to the same bar the resolver applies to a
+PDS endpoint — https only, no credentials, query, or fragment, and no
+`localhost` or reserved IP literal — and throws an `IdentityException` when a
+matching service declares an endpoint that fails those checks. If you derive a
+host some other way, vet it with `ensureNonReservedHost` before connecting.
 
 ## Verifying an inbound service-auth JWT
 

--- a/packages/atproto_identity/example/example.dart
+++ b/packages/atproto_identity/example/example.dart
@@ -8,12 +8,14 @@ import 'package:atproto_identity/atproto_identity.dart';
 ///
 /// This example shows how to:
 /// - Resolve a handle or DID to its DID, PDS origin, and `#atproto` signing key
+/// - Read a raw DID document that the atproto identity model does not describe
 /// - Verify an inbound AppView service-auth JWT and recover the viewer's DID
 /// - Handle [IdentityException] failures
 Future<void> main(List<String> args) async {
   final resolver = HttpIdentityResolver();
 
   await demonstrateIdentityResolution(resolver);
+  await demonstrateRawDidDocument(resolver);
   demonstrateServiceAuthVerification(resolver);
 }
 
@@ -36,6 +38,43 @@ Future<void> demonstrateIdentityResolution(IdentityResolver resolver) async {
     // Thrown on a malformed identity, a failed lookup, or when bidirectional
     // handle verification does not hold.
     print('Failed to resolve identity: ${e.message}');
+  }
+}
+
+/// Demonstrates reading a DID document that is not an account's.
+///
+/// [demonstrateIdentityResolution] fails on a feed generator: its `did:web`
+/// document declares a `#bsky_fg` service and no PDS, so it cannot become a
+/// [ResolvedIdentity]. [HttpIdentityResolver.resolveDidDocument] returns that
+/// document verbatim through the same hardened fetch, and `serviceEndpointOf`
+/// reads the endpoint out of it — validated, because a `serviceEndpoint` is
+/// attacker-controlled text and this is a host you are about to connect to.
+///
+/// It takes the concrete resolver rather than [IdentityResolver], because
+/// document access is not part of that interface.
+Future<void> demonstrateRawDidDocument(HttpIdentityResolver resolver) async {
+  print('\n=== Raw DID Document ===\n');
+
+  const did = 'did:web:foryou.club';
+
+  try {
+    final document = await resolver.resolveDidDocument(did);
+    final endpoint = serviceEndpointOf(
+      document,
+      did,
+      // Matches both `#bsky_fg` and `<did>#bsky_fg`.
+      id: '#bsky_fg',
+      // Optional; when given, the entry's type must equal it.
+      type: 'BskyFeedGenerator',
+    );
+
+    print('Document id:   ${document['id']}'); // did:web:foryou.club
+    print('Feed endpoint: $endpoint'); // https://... , or null
+  } on IdentityException catch (e) {
+    // Thrown on a malformed DID, an unsupported DID method, a transport or
+    // host-policy failure, a did:web document whose `id` does not match, or a
+    // matching service whose endpoint fails the host policy.
+    print('Failed to read the DID document: ${e.message}');
   }
 }
 

--- a/packages/atproto_identity/lib/src/did_syntax.dart
+++ b/packages/atproto_identity/lib/src/did_syntax.dart
@@ -1,0 +1,16 @@
+// Copyright (c) 2023-2026, Shinya Kato.
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// Strict DID grammar (per the DID Core `did:method:id` syntax): rejects
+/// fragments, queries, paths, whitespace, and a trailing `:`/`%`.
+final _didPattern = RegExp(r'^did:[a-z]+:[a-zA-Z0-9._:%-]*[a-zA-Z0-9._-]$');
+
+/// Whether [value] is a syntactically valid DID.
+///
+/// Applied wherever an attacker-controlled DID drives network resolution: the
+/// `iss` of an inbound service-auth JWT, and every DID the resolver fetches a
+/// document for — whose `did:plc` branch interpolates it into the PLC
+/// directory URL, so a DID carrying a delimiter would change the URL that
+/// request reaches.
+bool isValidDid(final String value) => _didPattern.hasMatch(value);

--- a/packages/atproto_identity/lib/src/identity/identity_resolver.dart
+++ b/packages/atproto_identity/lib/src/identity/identity_resolver.dart
@@ -438,10 +438,12 @@ final class HttpIdentityResolver implements IdentityResolver {
   /// The returned map is a fresh decode owned by the caller: it is mutable,
   /// and it is not cached.
   ///
-  /// **The values inside it are not validated.** A `serviceEndpoint` other
-  /// than the PDS one is attacker-controlled text that has passed no scheme or
-  /// host policy. Read one with [serviceEndpointOf], or vet a host you derive
-  /// yourself with [ensureNonReservedHost], before connecting to it.
+  /// **The values inside it are not validated.** Every `serviceEndpoint` in it
+  /// is attacker-controlled text that has passed no scheme or host policy —
+  /// the `#atproto_pds` entry included, since the PDS endpoint is checked only
+  /// on the [resolve] path, where it becomes [ResolvedIdentity.pds]. Read one
+  /// with [serviceEndpointOf], or vet a host you derive yourself with
+  /// [ensureNonReservedHost], before connecting to it.
   ///
   /// Throws an [IdentityException] on a malformed DID, an unsupported DID
   /// method, a transport or host-policy failure, a non-200 response, a body

--- a/packages/atproto_identity/lib/src/identity/identity_resolver.dart
+++ b/packages/atproto_identity/lib/src/identity/identity_resolver.dart
@@ -11,6 +11,7 @@ import 'dart:typed_data';
 import 'package:http/http.dart' as http;
 
 // Project imports:
+import '../did_syntax.dart';
 import '../identity_exception.dart';
 import '../signing_key.dart';
 import '../types/resolved_identity.dart';
@@ -354,23 +355,13 @@ final class HttpIdentityResolver implements IdentityResolver {
         if (service['type'] != 'AtprotoPersonalDataServer') continue;
         final endpoint = service['serviceEndpoint'];
         if (endpoint is String && endpoint.isNotEmpty) {
-          const what = 'PDS serviceEndpoint';
-          final uri = _parseHttpOrigin(endpoint, what: what);
-          if (uri.userInfo.isNotEmpty || uri.hasQuery || uri.hasFragment) {
-            throw IdentityException(
-              'Invalid $what: "$endpoint" must be a bare origin, without '
-              'credentials, a query, or a fragment',
-            );
-          }
-          if (!uri.isScheme('https') && !allowPrivateNetwork) {
-            throw IdentityException(
-              'Invalid $what: "$endpoint" must use https '
-              '(set allowPrivateNetwork: true to permit plain http)',
-            );
-          }
-          _checkHost(uri.host, what: '$what host', applyAllowlist: false);
-
-          return uri.origin;
+          // Reduced to a bare origin: the atproto spec defines the PDS
+          // endpoint as one, and `ResolvedIdentity.pds` is documented as one.
+          return _validateServiceEndpoint(
+            endpoint,
+            what: 'PDS serviceEndpoint',
+            allowPrivateNetwork: allowPrivateNetwork,
+          ).origin;
         }
       }
     }
@@ -382,14 +373,7 @@ final class HttpIdentityResolver implements IdentityResolver {
 
   @override
   Future<ResolvedIdentity> resolve(final String identity) async {
-    var normalized = identity.trim();
-    if (normalized.startsWith('at://')) {
-      normalized = normalized.substring('at://'.length);
-    }
-    if (normalized.startsWith('@')) normalized = normalized.substring(1);
-    if (normalized.isEmpty) {
-      throw ArgumentError.value(identity, 'identity', 'must not be empty');
-    }
+    final normalized = _normalizeIdentity(identity, name: 'identity');
 
     final String did;
     final String? handle;
@@ -426,6 +410,47 @@ final class HttpIdentityResolver implements IdentityResolver {
     );
   }
 
+  /// Fetches the DID document for [did] and returns it verbatim, as decoded
+  /// JSON.
+  ///
+  /// [did] must be a `did:plc:` or `did:web:` DID (optionally `at://`-prefixed
+  /// and surrounded by whitespace); a handle is not accepted, because
+  /// verifying that a handle and a document claim each other is what [resolve]
+  /// is for, and there is no [ResolvedIdentity] here to carry the result.
+  ///
+  /// Unlike [resolve] this applies no atproto-specific interpretation: no
+  /// `#atproto_pds` service is required and no signing key is extracted, so it
+  /// serves documents that cannot become a [ResolvedIdentity] at all. A feed
+  /// generator's `did:web` document, for instance, declares a `#bsky_fg`
+  /// service and no PDS, and [resolve] rejects it outright.
+  ///
+  /// The transport controls [resolve] uses still apply: [timeout],
+  /// [maxResponseBytes], and the redirect cap for every fetch, plus — for
+  /// `did:web` only — [allowedHosts], [allowPrivateNetwork], https-only
+  /// redirects, and the binding of the document's `id` to [did]. A `did:plc`
+  /// document is fetched from the operator-configured [plcDirectory], which is
+  /// trusted by construction and therefore exempt from the host policy, and is
+  /// not `id`-bound because it is content-addressed. As in [resolve], the
+  /// redirect validation only takes effect on platforms whose HTTP client
+  /// honors `followRedirects = false`; on the web the browser follows
+  /// redirects transparently.
+  ///
+  /// The returned map is a fresh decode owned by the caller: it is mutable,
+  /// and it is not cached.
+  ///
+  /// **The values inside it are not validated.** A `serviceEndpoint` other
+  /// than the PDS one is attacker-controlled text that has passed no scheme or
+  /// host policy. Read one with [serviceEndpointOf], or vet a host you derive
+  /// yourself with [ensureNonReservedHost], before connecting to it.
+  ///
+  /// Throws an [IdentityException] on a malformed DID, an unsupported DID
+  /// method, a transport or host-policy failure, a non-200 response, a body
+  /// that is not a JSON object, or a `did:web` document whose `id` does not
+  /// match [did]; and an [ArgumentError] when [did] is blank.
+  Future<Map<String, dynamic>> resolveDidDocument(final String did) async {
+    return _resolveDidDocument(_normalizeIdentity(did, name: 'did'));
+  }
+
   Future<String> _resolveHandle(final String handle) async {
     final origin = _normalizeHttpOrigin(
       handleResolver,
@@ -452,6 +477,15 @@ final class HttpIdentityResolver implements IdentityResolver {
   }
 
   Future<Map<String, dynamic>> _resolveDidDocument(final String did) async {
+    // The DID arrives either straight from a caller or from `_resolveHandle`,
+    // which checks only the `did:` prefix — and the did:plc branch below
+    // interpolates it into the directory URL. Enforce the DID grammar here, so
+    // that neither path can smuggle a delimiter into the URL a request
+    // actually reaches.
+    if (!isValidDid(did)) {
+      throw IdentityException('Not a syntactically valid DID: "$did"');
+    }
+
     final Uri uri;
     final bool isDidWeb;
     if (did.startsWith('did:plc:')) {
@@ -539,6 +573,23 @@ final class HttpIdentityResolver implements IdentityResolver {
           : [...path, 'did.json'],
     );
   }
+}
+
+/// Trims [identity] and strips a leading `at://` or `@`, so that the same
+/// spellings [HttpIdentityResolver.resolve] accepts also reach
+/// [HttpIdentityResolver.resolveDidDocument]. [name] names the argument in the
+/// [ArgumentError] thrown when nothing is left.
+String _normalizeIdentity(final String identity, {required final String name}) {
+  var normalized = identity.trim();
+  if (normalized.startsWith('at://')) {
+    normalized = normalized.substring('at://'.length);
+  }
+  if (normalized.startsWith('@')) normalized = normalized.substring(1);
+  if (normalized.isEmpty) {
+    throw ArgumentError.value(identity, name, 'must not be empty');
+  }
+
+  return normalized;
 }
 
 /// Parses a port string, returning `null` when it is not a plain decimal
@@ -730,6 +781,86 @@ String ensureNonReservedHost(
   return normalized;
 }
 
+/// Returns the `serviceEndpoint` of the service entry [id] declares in
+/// [didDocument] — validated for use as a network target — or `null` when the
+/// document declares no such service.
+///
+/// Pair it with [HttpIdentityResolver.resolveDidDocument] to reach a service
+/// the atproto identity model does not carry. A feed generator, for instance,
+/// publishes its endpoint as a `#bsky_fg` service and no PDS:
+///
+/// ```dart
+/// final document = await resolver.resolveDidDocument('did:web:foryou.club');
+/// final endpoint = serviceEndpointOf(
+///   document,
+///   'did:web:foryou.club',
+///   id: '#bsky_fg',
+///   type: 'BskyFeedGenerator',
+/// );
+/// ```
+///
+/// [id] is matched against both spellings the atproto DID spec accepts — the
+/// relative fragment (`#bsky_fg`) and the fully qualified form
+/// (`<did>#bsky_fg`) — so pass the fragment together with the [did] the
+/// document describes and either spelling matches. When [type] is given, the
+/// entry's `type` must equal it as well; that is what stops a document from
+/// parking an unrelated service under a well-known fragment.
+///
+/// The endpoint is held to the same bar [HttpIdentityResolver] applies to a
+/// PDS endpoint, because it is attacker-controlled and the caller is about to
+/// connect to it: https only (plain `http` needs [allowPrivateNetwork]), no
+/// credentials, query, or fragment, and a host that is neither `localhost` nor
+/// a reserved IP literal. As everywhere in this package, only IP *literals*
+/// are range-checked — see [ensureNonReservedHost] for that limitation.
+///
+/// Unlike the PDS endpoint, which the spec defines as a bare origin and which
+/// [HttpIdentityResolver] reduces to one, the returned endpoint keeps its path
+/// (minus a trailing `/`): DID Core allows one, and a service that publishes
+/// `https://example.com/fg` means it.
+///
+/// Throws an [IdentityException] when a matching entry declares an endpoint
+/// that is absent, not a string, or fails any of those checks — a service that
+/// matches but cannot be used is a failure, not an absence.
+String? serviceEndpointOf(
+  final Map<String, dynamic> didDocument,
+  final String did, {
+  required final String id,
+  final String? type,
+  final bool allowPrivateNetwork = false,
+}) {
+  final services = didDocument['service'];
+  if (services is! List) return null;
+
+  final qualified = id.startsWith('#') ? '$did$id' : id;
+  for (final service in services) {
+    if (service is! Map) continue;
+    final serviceId = service['id'];
+    if (serviceId != id && serviceId != qualified) continue;
+    if (type != null && service['type'] != type) continue;
+
+    final endpoint = service['serviceEndpoint'];
+    if (endpoint is! String || endpoint.isEmpty) {
+      throw IdentityException(
+        'The "$id" service in the DID document for "$did" declares no usable '
+        '"serviceEndpoint"',
+      );
+    }
+
+    final uri = _validateServiceEndpoint(
+      endpoint,
+      what: '"$id" serviceEndpoint',
+      allowPrivateNetwork: allowPrivateNetwork,
+    );
+    final normalized = uri.toString();
+
+    return normalized.endsWith('/')
+        ? normalized.substring(0, normalized.length - 1)
+        : normalized;
+  }
+
+  return null;
+}
+
 /// Parses a user-supplied host or URL into an `https`/`http` [Uri]. A bare
 /// hostname is treated as `https://<host>`.
 Uri _parseHttpOrigin(final String input, {required final String what}) {
@@ -748,6 +879,46 @@ Uri _parseHttpOrigin(final String input, {required final String what}) {
       uri.host.isEmpty) {
     throw IdentityException('Invalid $what: "$input"');
   }
+
+  return uri;
+}
+
+/// Validates a `serviceEndpoint` taken from a DID document and returns it
+/// parsed.
+///
+/// A `serviceEndpoint` is attacker-controlled for any DID — anyone can
+/// register a `did:plc` and anyone can publish a `did:web` document — and the
+/// caller is about to connect to whatever it names, so it must be an https URL
+/// (plain `http` only with [allowPrivateNetwork]) carrying no credentials,
+/// query, or fragment, on a host that is not `localhost` or a reserved IP
+/// literal. [what] names the endpoint in error messages.
+///
+/// The allowlist is deliberately not applied:
+/// [HttpIdentityResolver.allowedHosts] scopes which `did:web` issuers may be
+/// contacted, not which hosts a legitimate service may live on.
+Uri _validateServiceEndpoint(
+  final String endpoint, {
+  required final String what,
+  required final bool allowPrivateNetwork,
+}) {
+  final uri = _parseHttpOrigin(endpoint, what: what);
+  if (uri.userInfo.isNotEmpty || uri.hasQuery || uri.hasFragment) {
+    throw IdentityException(
+      'Invalid $what: "$endpoint" must not carry credentials, a query, or a '
+      'fragment',
+    );
+  }
+  if (!uri.isScheme('https') && !allowPrivateNetwork) {
+    throw IdentityException(
+      'Invalid $what: "$endpoint" must use https '
+      '(set allowPrivateNetwork: true to permit plain http)',
+    );
+  }
+  ensureNonReservedHost(
+    uri.host,
+    allowPrivateNetwork: allowPrivateNetwork,
+    what: '$what host',
+  );
 
   return uri;
 }

--- a/packages/atproto_identity/lib/src/service_auth.dart
+++ b/packages/atproto_identity/lib/src/service_auth.dart
@@ -10,6 +10,7 @@ import 'dart:typed_data';
 import 'package:did_plc/did_plc.dart';
 
 // Project imports:
+import 'did_syntax.dart';
 import 'identity/identity_resolver.dart';
 import 'identity_exception.dart';
 import 'signing_key.dart';
@@ -43,11 +44,6 @@ const _clockSkew = Duration(seconds: 30);
 /// accepts values up to year 2286) would otherwise let a leaked token stay
 /// valid for years. Callers may tighten this or opt out with `null`.
 const _defaultMaxTokenLifetime = Duration(minutes: 60);
-
-/// Strict DID grammar (per the DID Core `did:method:id` syntax): rejects
-/// fragments, queries, paths, whitespace, and a trailing `:`/`%` before the
-/// issuer is handed to the resolver.
-final _didPattern = RegExp(r'^did:[a-z]+:[a-zA-Z0-9._:%-]*[a-zA-Z0-9._-]$');
 
 /// Verifies an inbound AppView service-auth JWT from [authorizationHeader] and
 /// returns the issuer (viewer) DID.
@@ -150,7 +146,7 @@ Future<String> verifyServiceAuth(
   }
   // The issuer is attacker-controlled input that drives network resolution;
   // enforce a strict DID grammar before handing it to the resolver.
-  if (!_didPattern.hasMatch(iss)) {
+  if (!isValidDid(iss)) {
     throw IdentityException(
       'JWT "iss" is not a syntactically valid DID: "$iss"',
     );

--- a/packages/atproto_identity/pubspec.yaml
+++ b/packages/atproto_identity/pubspec.yaml
@@ -1,7 +1,7 @@
 name: atproto_identity
 resolution: workspace
 description: AT Protocol identity resolution (handle/DID) and inbound service-auth JWT verification for Dart/Flutter.
-version: 0.3.0
+version: 0.4.0
 homepage: https://atprotodart.com
 repository: https://github.com/myConsciousness/atproto.dart/tree/main/packages/atproto_identity
 issue_tracker: https://github.com/myConsciousness/atproto.dart/issues

--- a/packages/atproto_identity/test/src/identity/http_identity_resolver_test.dart
+++ b/packages/atproto_identity/test/src/identity/http_identity_resolver_test.dart
@@ -1147,6 +1147,45 @@ void main() {
       });
     }
 
+    test('scans past non-map, unrelated, and wrong-type entries', () {
+      final document = <String, dynamic>{
+        'id': did,
+        'service': const [
+          'not-a-map',
+          {
+            'id': '#atproto_pds',
+            'type': 'AtprotoPersonalDataServer',
+            'serviceEndpoint': _pds,
+          },
+          {
+            'id': '#bsky_fg',
+            'type': 'SomethingElse',
+            'serviceEndpoint': 'https://wrong.example.com',
+          },
+          {
+            'id': '#bsky_fg',
+            'type': 'BskyFeedGenerator',
+            'serviceEndpoint': 'https://foryou.club/fg',
+          },
+        ],
+      };
+
+      expect(
+        serviceEndpointOf(
+          document,
+          did,
+          id: '#bsky_fg',
+          type: 'BskyFeedGenerator',
+        ),
+        'https://foryou.club/fg',
+      );
+      // Without a type filter the first entry whose id matches wins.
+      expect(
+        serviceEndpointOf(document, did, id: '#bsky_fg'),
+        'https://wrong.example.com',
+      );
+    });
+
     test('throws when a matching service declares no endpoint', () {
       final document = documentWith(const {
         'id': '#bsky_fg',

--- a/packages/atproto_identity/test/src/identity/http_identity_resolver_test.dart
+++ b/packages/atproto_identity/test/src/identity/http_identity_resolver_test.dart
@@ -833,4 +833,330 @@ void main() {
       );
     });
   });
+
+  group('resolveDidDocument', () {
+    const feedGeneratorDid = 'did:web:foryou.club';
+    const feedGeneratorDocument = {
+      '@context': ['https://www.w3.org/ns/did/v1'],
+      'id': feedGeneratorDid,
+      'service': [
+        {
+          'id': '#bsky_fg',
+          'type': 'BskyFeedGenerator',
+          'serviceEndpoint': 'https://foryou.club',
+        },
+      ],
+    };
+
+    test('returns a did:plc document verbatim', () async {
+      final client = MockClient(
+        (final request) async => _json({
+          'id': _did,
+          'alsoKnownAs': ['at://$_handle'],
+          'customKey': {'nested': true},
+        }),
+      );
+      final resolver = HttpIdentityResolver(httpClient: client);
+      final document = await resolver.resolveDidDocument(_did);
+
+      expect(document['id'], _did);
+      expect(document['alsoKnownAs'], ['at://$_handle']);
+      // Entries outside the atproto identity model must survive verbatim.
+      expect(document['customKey'], {'nested': true});
+    });
+
+    test('returns a document resolve() cannot map to an identity', () async {
+      final client = MockClient(
+        (final request) async => _json(feedGeneratorDocument),
+      );
+      final resolver = HttpIdentityResolver(httpClient: client);
+
+      expect(
+        await resolver.resolveDidDocument(feedGeneratorDid),
+        feedGeneratorDocument,
+      );
+      await expectLater(
+        resolver.resolve(feedGeneratorDid),
+        throwsA(isA<IdentityException>()),
+        reason: 'a feed generator declares no #atproto_pds service',
+      );
+    });
+
+    test('rejects a did:web document whose id does not match', () async {
+      final client = MockClient(
+        (final request) async => _json({'id': 'did:web:evil.example.com'}),
+      );
+      final resolver = HttpIdentityResolver(httpClient: client);
+
+      await expectLater(
+        resolver.resolveDidDocument('did:web:feed.example.com'),
+        throwsA(isA<IdentityException>()),
+      );
+    });
+
+    test('rejects a private did:web host without a request', () async {
+      var requests = 0;
+      final client = MockClient((final request) async {
+        requests++;
+        return _json(feedGeneratorDocument);
+      });
+      final resolver = HttpIdentityResolver(httpClient: client);
+
+      await expectLater(
+        resolver.resolveDidDocument('did:web:127.0.0.1'),
+        throwsA(isA<IdentityException>()),
+      );
+      expect(requests, 0, reason: 'the host policy runs before the fetch');
+    });
+
+    test('honours allowedHosts', () async {
+      final client = MockClient(
+        (final request) async => _json({'id': 'did:web:feed.example.com'}),
+      );
+      final resolver = HttpIdentityResolver(
+        httpClient: client,
+        allowedHosts: const {'other.example.com'},
+      );
+
+      await expectLater(
+        resolver.resolveDidDocument('did:web:feed.example.com'),
+        throwsA(isA<IdentityException>()),
+      );
+    });
+
+    test('rejects an unsupported DID method', () async {
+      var requests = 0;
+      final client = MockClient((final request) async {
+        requests++;
+        return _json(_didDocumentWithPds());
+      });
+      final resolver = HttpIdentityResolver(httpClient: client);
+
+      await expectLater(
+        resolver.resolveDidDocument('did:key:z6MkexampleKey'),
+        throwsA(isA<IdentityException>()),
+      );
+      expect(requests, 0);
+    });
+
+    test('rejects a DID that is not syntactically valid', () async {
+      var requests = 0;
+      final client = MockClient((final request) async {
+        requests++;
+        return _json(_didDocumentWithPds());
+      });
+      final resolver = HttpIdentityResolver(httpClient: client);
+
+      await expectLater(
+        resolver.resolveDidDocument('did:plc:abc/../../admin'),
+        throwsA(isA<IdentityException>()),
+      );
+      expect(requests, 0, reason: 'a path must never reach the directory URL');
+    });
+
+    test('rejects a path smuggled in through handle resolution', () async {
+      final contacted = <String>[];
+      final client = MockClient((final request) async {
+        contacted.add(request.url.path);
+        if (request.url.path == '/xrpc/com.atproto.identity.resolveHandle') {
+          return _json({'did': 'did:plc:abc/../../admin'});
+        }
+        return _json(_didDocumentWithPds());
+      });
+      final resolver = HttpIdentityResolver(httpClient: client);
+
+      await expectLater(
+        resolver.resolve(_handle),
+        throwsA(isA<IdentityException>()),
+      );
+      // The smuggled DID must never reach the PLC directory.
+      expect(contacted, ['/xrpc/com.atproto.identity.resolveHandle']);
+    });
+
+    test('accepts a padded at:// prefixed DID', () async {
+      final client = MockClient((final request) async => _json({'id': _did}));
+      final resolver = HttpIdentityResolver(httpClient: client);
+
+      expect(await resolver.resolveDidDocument('  at://$_did  '), {'id': _did});
+    });
+
+    test('throws ArgumentError on a blank DID', () async {
+      await expectLater(
+        HttpIdentityResolver().resolveDidDocument('   '),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('enforces maxResponseBytes', () async {
+      final huge = '{"padding":"${'a' * 4096}"}';
+      final client = MockClient(
+        (final request) async => http.Response(huge, 200),
+      );
+      final resolver = HttpIdentityResolver(
+        httpClient: client,
+        maxResponseBytes: 1024,
+      );
+
+      await expectLater(
+        resolver.resolveDidDocument(_did),
+        throwsA(isA<IdentityException>()),
+      );
+    });
+
+    test('composes with signingKeyOf', () async {
+      final client = MockClient(
+        (final request) async => _json({
+          'id': _did,
+          'verificationMethod': [
+            {'id': '$_did#atproto', 'publicKeyMultibase': 'zQ3shSIGNINGKEY'},
+          ],
+        }),
+      );
+      final resolver = HttpIdentityResolver(httpClient: client);
+      final document = await resolver.resolveDidDocument(_did);
+
+      expect(signingKeyOf(document, _did), 'zQ3shSIGNINGKEY');
+    });
+  });
+
+  group('serviceEndpointOf', () {
+    const did = 'did:web:foryou.club';
+
+    Map<String, dynamic> documentWith(final Map<String, Object?> service) {
+      return {
+        'id': did,
+        'service': [service],
+      };
+    }
+
+    test('matches a relative fragment id', () {
+      final document = documentWith(const {
+        'id': '#bsky_fg',
+        'type': 'BskyFeedGenerator',
+        'serviceEndpoint': 'https://foryou.club',
+      });
+
+      expect(
+        serviceEndpointOf(
+          document,
+          did,
+          id: '#bsky_fg',
+          type: 'BskyFeedGenerator',
+        ),
+        'https://foryou.club',
+      );
+    });
+
+    test('matches a fully qualified id', () {
+      final document = documentWith(const {
+        'id': '$did#bsky_fg',
+        'type': 'BskyFeedGenerator',
+        'serviceEndpoint': 'https://foryou.club',
+      });
+
+      expect(
+        serviceEndpointOf(document, did, id: '#bsky_fg'),
+        'https://foryou.club',
+      );
+    });
+
+    test('returns null when no service matches', () {
+      final document = documentWith(const {
+        'id': '#atproto_pds',
+        'type': 'AtprotoPersonalDataServer',
+        'serviceEndpoint': _pds,
+      });
+
+      expect(serviceEndpointOf(document, did, id: '#bsky_fg'), isNull);
+    });
+
+    test('returns null when the document declares no services', () {
+      expect(serviceEndpointOf(const {'id': did}, did, id: '#bsky_fg'), isNull);
+    });
+
+    test('filters on type when one is given', () {
+      final document = documentWith(const {
+        'id': '#bsky_fg',
+        'type': 'SomethingElse',
+        'serviceEndpoint': 'https://foryou.club',
+      });
+
+      expect(
+        serviceEndpointOf(
+          document,
+          did,
+          id: '#bsky_fg',
+          type: 'BskyFeedGenerator',
+        ),
+        isNull,
+      );
+    });
+
+    test('keeps a path and trims a trailing slash', () {
+      final document = documentWith(const {
+        'id': '#bsky_fg',
+        'serviceEndpoint': 'https://foryou.club/fg/',
+      });
+
+      expect(
+        serviceEndpointOf(document, did, id: '#bsky_fg'),
+        'https://foryou.club/fg',
+      );
+    });
+
+    test('rejects a plain http endpoint', () {
+      final document = documentWith(const {
+        'id': '#bsky_fg',
+        'serviceEndpoint': 'http://foryou.club',
+      });
+
+      expect(
+        () => serviceEndpointOf(document, did, id: '#bsky_fg'),
+        throwsA(isA<IdentityException>()),
+      );
+      expect(
+        serviceEndpointOf(
+          document,
+          did,
+          id: '#bsky_fg',
+          allowPrivateNetwork: true,
+        ),
+        'http://foryou.club',
+      );
+    });
+
+    for (final endpoint in const [
+      'https://127.0.0.1',
+      'https://169.254.169.254',
+      'https://localhost:3000',
+      'https://[::1]',
+      'https://evil.example.com@127.0.0.1',
+      'https://foryou.club?a=b',
+      'https://foryou.club#fragment',
+    ]) {
+      test('rejects the endpoint $endpoint', () {
+        final document = documentWith({
+          'id': '#bsky_fg',
+          'serviceEndpoint': endpoint,
+        });
+
+        expect(
+          () => serviceEndpointOf(document, did, id: '#bsky_fg'),
+          throwsA(isA<IdentityException>()),
+        );
+      });
+    }
+
+    test('throws when a matching service declares no endpoint', () {
+      final document = documentWith(const {
+        'id': '#bsky_fg',
+        'type': 'BskyFeedGenerator',
+      });
+
+      expect(
+        () => serviceEndpointOf(document, did, id: '#bsky_fg'),
+        throwsA(isA<IdentityException>()),
+      );
+    });
+  });
 }

--- a/packages/atproto_oauth/CHANGELOG.md
+++ b/packages/atproto_oauth/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Note
 
+## v0.8.1
+
+- **chore**: bump `atproto_identity` to `^0.4.0`.
+
 ## v0.8.0
 
 - **feat**: `revoke` now actually revokes at the authorization server. It was local-only — the session was dropped from the `OAuthSessionStore` and nothing was sent — so after a "log out" the refresh token stayed live at the server for its full lifetime, and anyone holding a copy (a leaked backup, a shared device, a compromised store) could keep minting access tokens. When the server publishes an RFC 7009 `revocation_endpoint`, the refresh token is now POSTed to it with a DPoP proof before the local delete (the refresh token in preference to the access token, since revoking it takes the whole grant down). The call is best-effort: a server that publishes no endpoint is skipped, and a network or server failure never blocks the logout.

--- a/packages/atproto_oauth/pubspec.yaml
+++ b/packages/atproto_oauth/pubspec.yaml
@@ -1,7 +1,7 @@
 name: atproto_oauth
 resolution: workspace
 description: Provides tools to handle OAuth for AT Protocol and Bluesky Social.
-version: 0.8.0
+version: 0.8.1
 homepage: https://atprotodart.com
 repository: https://github.com/myConsciousness/atproto.dart/tree/main/packages/atproto_oauth
 issue_tracker: https://github.com/myConsciousness/atproto.dart/issues

--- a/packages/atproto_oauth/pubspec.yaml
+++ b/packages/atproto_oauth/pubspec.yaml
@@ -17,7 +17,7 @@ topics:
   - oauth
 
 dependencies:
-  atproto_identity: ^0.3.0
+  atproto_identity: ^0.4.0
   http: ^1.4.0
   crypto: ^3.0.6
   freezed_annotation: ^3.1.0

--- a/packages/bluesky/pubspec.yaml
+++ b/packages/bluesky/pubspec.yaml
@@ -37,6 +37,6 @@ dev_dependencies:
       ref: fix/monorepo-pub-workspaces
   atproto_test:
     path: ../atproto_test
-  atproto_oauth: ^0.8.0
+  atproto_oauth: ^0.8.1
   http: any
   fake_async: ^1.3.3

--- a/templates/feed_generator/pubspec.yaml
+++ b/templates/feed_generator/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 dependencies:
   bluesky: ^2.8.0
   atproto_core: ^2.4.1
-  atproto_identity: ^0.3.0
+  atproto_identity: ^0.4.0
   shelf: ^1.4.0
   shelf_router: ^1.1.0
 

--- a/website/docs/products/packages/atproto_identity.md
+++ b/website/docs/products/packages/atproto_identity.md
@@ -154,9 +154,9 @@ Every failure — a malformed Bearer header or JWT, an untrusted `alg` (`none`/`
 
 `resolve(...)` reads a DID document *as an atproto identity*, so it requires an `#atproto_pds` service and rejects any document without one. Not every DID document describes an account: a feed generator publishes a `did:web` document whose only service is `#bsky_fg`, and `resolve(...)` throws on it.
 
-**[resolveDidDocument](https://pub.dev/documentation/atproto_identity/latest/atproto_identity/HttpIdentityResolver/resolveDidDocument.html)** returns such a document verbatim, as decoded JSON, through the same hardened fetch — host policy, timeout, size cap, redirect rules, and, for `did:web`, the binding of the document's `id` to the DID you asked for. Only the atproto-specific interpretation is skipped.
+**[resolveDidDocument](https://pub.dev/documentation/atproto_identity/latest/atproto_identity/HttpIdentityResolver/resolveDidDocument.html)** returns such a document verbatim, as decoded JSON, through the same hardened fetch — the timeout, size cap and redirect cap on every fetch, plus, for `did:web`, the host policy and the binding of the document's `id` to the DID you asked for. Only the atproto-specific interpretation is skipped.
 
-The values inside a DID document are **not** validated: a `serviceEndpoint` other than the PDS one is attacker-controlled text that has passed no scheme or host policy. **[serviceEndpointOf](https://pub.dev/documentation/atproto_identity/latest/atproto_identity/serviceEndpointOf.html)** reads one out for you and holds it to the same bar the resolver applies to a PDS endpoint — https only, no credentials, query, or fragment, and no `localhost` or reserved IP literal.
+The values inside a DID document are **not** validated: every `serviceEndpoint` in it — the `#atproto_pds` entry included, since that one is checked only on the `resolve(...)` path — is attacker-controlled text that has passed no scheme or host policy. **[serviceEndpointOf](https://pub.dev/documentation/atproto_identity/latest/atproto_identity/serviceEndpointOf.html)** reads one out for you and holds it to the same bar the resolver applies to a PDS endpoint — https only, no credentials, query, or fragment, and no `localhost` or reserved IP literal.
 
 ```dart
 import 'package:atproto_identity/atproto_identity.dart';

--- a/website/docs/products/packages/atproto_identity.md
+++ b/website/docs/products/packages/atproto_identity.md
@@ -28,6 +28,7 @@ description: Handle/DID resolution and service-auth JWT verification for AT Prot
 - ✅ **Bidirectional Handle Verification** - Confirms the DID document claims the handle back via `alsoKnownAs`
 - ✅ **Service-Auth JWT Verification** - Validates AppView service-auth tokens (ES256K/ES256)
 - ✅ **SSRF / DoS Hardened** - `did:web` host allowlisting, private-network blocking, response-size caps, and timeouts
+- ✅ **Raw DID Documents** - Reads documents the atproto identity model does not describe, such as a feed generator's
 - ✅ **`did:plc` and `did:web` Support** - Resolves both DID methods
 - ✅ **Pluggable** - `IdentityResolver` is an interface you can implement
 - ✅ **Web/WASM Friendly** - Pure Dart, no `dart:io` requirement
@@ -148,6 +149,38 @@ Future<void> handleRequest(String authorizationHeader) async {
 ```
 
 Every failure — a malformed Bearer header or JWT, an untrusted `alg` (`none`/`HS*`/RSA are rejected), a wrong audience, an expired or not-yet-valid token, an `exp` beyond `maxTokenLifetime`, an `lxm` mismatch, an unresolvable issuer, a missing signing key, or a signature that does not verify — throws an **[IdentityException](https://pub.dev/documentation/atproto_identity/latest/atproto_identity/IdentityException-class.html)**.
+
+### Reading a Raw DID Document
+
+`resolve(...)` reads a DID document *as an atproto identity*, so it requires an `#atproto_pds` service and rejects any document without one. Not every DID document describes an account: a feed generator publishes a `did:web` document whose only service is `#bsky_fg`, and `resolve(...)` throws on it.
+
+**[resolveDidDocument](https://pub.dev/documentation/atproto_identity/latest/atproto_identity/HttpIdentityResolver/resolveDidDocument.html)** returns such a document verbatim, as decoded JSON, through the same hardened fetch — host policy, timeout, size cap, redirect rules, and, for `did:web`, the binding of the document's `id` to the DID you asked for. Only the atproto-specific interpretation is skipped.
+
+The values inside a DID document are **not** validated: a `serviceEndpoint` other than the PDS one is attacker-controlled text that has passed no scheme or host policy. **[serviceEndpointOf](https://pub.dev/documentation/atproto_identity/latest/atproto_identity/serviceEndpointOf.html)** reads one out for you and holds it to the same bar the resolver applies to a PDS endpoint — https only, no credentials, query, or fragment, and no `localhost` or reserved IP literal.
+
+```dart
+import 'package:atproto_identity/atproto_identity.dart';
+
+Future<void> main() async {
+  final resolver = HttpIdentityResolver();
+
+  const did = 'did:web:foryou.club';
+  final document = await resolver.resolveDidDocument(did);
+
+  final endpoint = serviceEndpointOf(
+    document,
+    did,
+    // Matches both `#bsky_fg` and `<did>#bsky_fg`.
+    id: '#bsky_fg',
+    // Optional; when given, the entry's type must equal it.
+    type: 'BskyFeedGenerator',
+  );
+
+  print(endpoint); // https origin (path preserved), or null
+}
+```
+
+`resolveDidDocument` is declared on `HttpIdentityResolver` rather than on the `IdentityResolver` interface, so implementing your own resolver (see [Custom Resolvers](#custom-resolvers)) stays a one-method job. Hold onto the concrete resolver where you need document access.
 
 ### Extracting a Signing Key
 


### PR DESCRIPTION
Closes #2569.

## Why

`resolve` reads a DID document *as an atproto identity*, so it requires an `#atproto_pds` service and throws on any document without one. Not every DID document describes an account: a feed generator publishes a `did:web` document whose only service is `#bsky_fg` — which is exactly the shape this repository's own feed generator template serves (`templates/feed_generator/lib/src/server/feed_generator_service.dart`).

The resolver already fetched, size-capped, redirect-checked and `id`-bound that document; `resolve` then discarded it and died in `_extractPdsEndpoint`. Nothing public could reach it, so a caller who needed a feed generator's endpoint had no local, hardened route to it at all.

## What

**`HttpIdentityResolver.resolveDidDocument(String did)`** returns the document verbatim as a `Map` keyed by `String` with `dynamic` values, through that same hardened fetch. Only the atproto-specific interpretation is skipped, so no `#atproto_pds` service is required.

It is declared on the concrete resolver rather than on the `IdentityResolver` interface. `IdentityResolver` is an `abstract interface class`, and `implements` inherits signatures only — never bodies — so a new member there is a compile error for every implementer, including the feed generator template's caching decorator, the sample published on the docs site, and any third party. `HttpIdentityResolver` is a `final class`, so adding to it cannot break a subtype: nobody can have one.

**`serviceEndpointOf(didDocument, did, {required id, type, allowPrivateNetwork})`** reads a service entry out of a raw document and validates its endpoint the way the resolver validates a PDS endpoint — https only, no credentials, query or fragment, and no `localhost` or reserved IP literal. Without it, handing back a raw document would hand every caller an unvalidated attacker-controlled URL, which is the gap `ensureNonReservedHost` was added in v0.3.0 to close. It matches both spellings the atproto DID spec accepts — the bare `#bsky_fg` fragment and the fully qualified form, the DID itself followed by `#bsky_fg` — and, unlike the PDS endpoint, keeps the endpoint's path, since DID Core allows one.

```dart
final document = await resolver.resolveDidDocument("did:web:foryou.club");
final endpoint = serviceEndpointOf(
  document,
  "did:web:foryou.club",
  id: "#bsky_fg",
  type: "BskyFeedGenerator",
);
```

**Security fix along the way.** The strict DID grammar `verifyServiceAuth` already applied to a JWT's `iss` moved into a shared library and now guards every document fetch — including one whose DID came back from handle resolution. That path checked only the `did:` prefix before the DID was interpolated into the PLC directory URL, so a hostile or compromised handle resolver could return `did:plc:x/../../admin` and change the URL the request reached. `resolve` is correspondingly stricter: a DID carrying a path, query, fragment or whitespace now fails before any request is issued.

## Not breaking

No existing signature, behaviour or export changes for any caller. `atproto_identity` goes 0.3.0 → 0.4.0; `atproto_oauth` gets 0.8.1 to carry the constraint (0.8.0 is already published pinning `^0.3.0`, so without a release an app on `atproto_oauth ^0.8.0` could never reach the new API), and `atproto_core` and `bluesky` follow the workspace's equal-constraint rule.

## Verification

Run locally against this merge base on Dart 3.13.2, the same version CI installs:

- `dart format --set-exit-if-changed` and `dart analyze` clean across the whole Dart workspace.
- `atproto_identity` 148 tests, `atproto_oauth` 120, `atproto_core` 190, `templates/feed_generator` 75 — all passing. 28 of those tests are new.
- `scripts/validate_dependencies.dart` and `scripts/validate_website_overrides.dart` pass.
- The new coverage is mutation-checked: removing the DID grammar gate, dropping the `type` filter, skipping input normalisation, no-oping the host policy, or stopping the service scan after the first entry each make a test fail.

CI on this branch is currently red for an unrelated upstream reason that predates and does not involve this diff — see the comment below for the diagnosis and the suggested one-line CI fix.

## Note for the reporter

If the goal is only to send `requestMore` / `requestLess` to a custom feed, this API is not required. The canonical route is service proxying: call `app.bsky.feed.sendInteractions` against your own PDS with an `atproto-proxy` header set to the feed generator's DID followed by `#bsky_fg`, and the PDS resolves the document and mints the inter-service auth for you. `sendInteractions` already takes per-call `$headers`, and the feed generator's DID is already on `GeneratorView.did`, so no DID-document fetch is needed. The gap this PR closes is real and independent — it just may not be what unblocks that particular use case fastest.