### PR TITLE
fix(ci): stop setup-dart's problem matcher from failing every job

### DIFF
--- a/.github/actions/setup-dart-cached/action.yml
+++ b/.github/actions/setup-dart-cached/action.yml
@@ -17,6 +17,13 @@ runs:
       uses: dart-lang/setup-dart@v1
       with:
         sdk: ${{ inputs.sdk }}
+        # setup-dart v1.8.1 resolves its `dart analyze` problem-matcher JSON
+        # against the calling action's directory, which for this composite
+        # action is `.github/actions/setup-dart-cached/` rather than its own.
+        # The file is not there, `::add-matcher::` fails, and the whole step
+        # fails -- skipping `dart pub get` and every job that follows it.
+        # Disable the matcher until upstream resolves the path correctly.
+        problem-matcher: false
 
     - name: Cache pub-cache
       uses: actions/cache@v4


### PR DESCRIPTION
CI is currently red on every PR in this repository, and it is not any PR's diff that is doing it.

## What happens

Every job that uses `./.github/actions/setup-dart-cached` dies inside its `Setup Dart` step:

```
##[error]Unable to process command '::add-matcher::/home/runner/work/atproto.dart/atproto.dart/./.github/actions/setup-dart-cached/dart-analyzer.json' successfully.
##[error]Could not find file '/home/runner/work/atproto.dart/atproto.dart/.github/actions/setup-dart-cached/dart-analyzer.json'.
```

`dart-lang/setup-dart` resolves its `dart analyze` problem-matcher JSON against the **calling** action's directory, which for a nested composite action is `.github/actions/setup-dart-cached/` rather than its own bundled directory. Only `action.yml` has ever lived there, so `::add-matcher::` fails and the step reports `outcome=failure`.

The missing annotations are not the damage. The step failing means `Cache pub-cache` and `Install dependencies` are both **skipped**, so no `dart pub get` runs and no test body ever executes. Jobs go red in roughly fifteen seconds and read like test failures when they are nothing of the kind.

## Why now

`@v1` is a moving tag. Runs currently resolve it to `6afc89d` — **v1.8.1, released 2026-08-28**. The last green run on this repository was 2026-08-25 (#2568), before that release, and no CI had run here since, so the breakage went unnoticed until the next PR opened.

## The change

`problem-matcher` is a documented input of `setup-dart`, described as "set to `false` to disable". Opting out is one line and restores green.

The cost is the inline `dart analyze` annotations on pull requests. Pinning `dart-lang/setup-dart` to v1.8.0 (or to a SHA) would keep them instead, at the price of a manual bump later; that is the better trade once upstream has a fix worth tracking again. Pinning to a SHA rather than a moving major tag would also stop this class of breakage generally — worth considering separately for the other third-party actions here.

## Verification

The proof is this PR's own CI: if these checks go green, the composite action works again, since nothing else in the repository changed.

Reproduced beforehand on #2571, where the identical failure appeared on two independent runs of the same commit (the second a deliberate re-run to rule out a transient), always with `duration_ms` under 9s for the `Setup Dart` step and `Cache pub-cache` / `Install dependencies` skipped.

The full Dart workspace was also run locally on Dart 3.13.2, the version CI installs, to confirm the suites themselves are healthy: `dart format --set-exit-if-changed` and `dart analyze` clean across all 16 workspace directories, and `atproto_identity` 148 / `atproto_oauth` 120 / `atproto_core` 190 / `templates/feed_generator` 75 tests all passing.

---
_Generated by [Claude Code](https://claude.ai/code/session_018qMvvBV72ZYaFNFLRdrSN4)_