### PR TITLE
fix(atproto_identity): only the first alsoKnownAs handle is the claimed one

### DIFF
--- a/.github/actions/setup-dart-cached/action.yml
+++ b/.github/actions/setup-dart-cached/action.yml
@@ -17,6 +17,13 @@ runs:
       uses: dart-lang/setup-dart@v1
       with:
         sdk: ${{ inputs.sdk }}
+        # setup-dart v1.8.1 resolves its `dart analyze` problem-matcher JSON
+        # against the calling action's directory, which for this composite
+        # action is `.github/actions/setup-dart-cached/` rather than its own.
+        # The file is not there, `::add-matcher::` fails, and the whole step
+        # fails -- skipping `dart pub get` and every job that follows it.
+        # Disable the matcher until upstream resolves the path correctly.
+        problem-matcher: false
 
     - name: Cache pub-cache
       uses: actions/cache@v4

--- a/packages/atproto_core/pubspec.yaml
+++ b/packages/atproto_core/pubspec.yaml
@@ -27,7 +27,7 @@ dependencies:
   json_annotation: ^4.9.0
   cbor: ^6.3.7
   multiformats: ^1.4.0
-  atproto_oauth: ^0.8.0
+  atproto_oauth: ^0.8.1
   nanoid: ^1.0.0
   meta: ^1.17.0
 

--- a/packages/atproto_identity/CHANGELOG.md
+++ b/packages/atproto_identity/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release Note
 
+## v0.4.0
+
+- **fix**: `resolve` now performs bidirectional handle verification the way the atproto DID spec defines it. `alsoKnownAs` is an *ordered* list in which only the first syntactically valid handle is the claimed handle, and every later handle URI is ignored; the check instead asked whether the supplied handle appeared *anywhere* in the list. A DID document listing `["at://alice.example", "at://bob.example"]` therefore verified `bob.example` as well as `alice.example`, so a single account could present several handles as bidirectionally verified when the protocol says exactly one of them is canonical — and a caller using this to answer "is this handle really this account's" got a wrong yes. Entries that are not `at://` URIs, and `at://` entries that are not syntactically valid handles, are now skipped rather than ending the scan, since neither can be the claimed handle.
+- **chore**: depends on `at_primitives` for the handle grammar, rather than restating it, so the syntax rule this fix turns on cannot drift from the one the rest of the workspace enforces.
+
 ## v0.3.0
 
 - **feat**: added `ensureNonReservedHost`, which applies the same SSRF host policy `HttpIdentityResolver` uses for a PDS endpoint — reject `localhost` and IP literals in loopback, private, link-local, CGNAT, unique-local, multicast, unspecified, or reserved ranges (unless `allowPrivateNetwork`), with the same IP-literal-only limitation. Exposed so a caller that derives a further network target from resolver output can hold it to the same bar; `atproto_oauth` uses it to vet the authorization server taken from PDS metadata.

--- a/packages/atproto_identity/lib/src/identity/identity_resolver.dart
+++ b/packages/atproto_identity/lib/src/identity/identity_resolver.dart
@@ -8,6 +8,7 @@ import 'dart:convert';
 import 'dart:typed_data';
 
 // Package imports:
+import 'package:at_primitives/at_identifier.dart';
 import 'package:http/http.dart' as http;
 
 // Project imports:
@@ -26,7 +27,9 @@ abstract interface class IdentityResolver {
 /// handle→DID via `com.atproto.identity.resolveHandle`, DID document via the
 /// PLC directory (`did:plc`) or well-known/path location (`did:web`), then the
 /// `#atproto_pds` service endpoint. When starting from a handle, verifies the
-/// DID document claims the handle back through `alsoKnownAs`.
+/// DID document claims that handle back: per the atproto DID spec the claimed
+/// handle is the *first* syntactically valid handle in `alsoKnownAs`, so a
+/// handle listed after it does not verify.
 final class HttpIdentityResolver implements IdentityResolver {
   HttpIdentityResolver({
     this.handleResolver = 'https://public.api.bsky.app',
@@ -404,16 +407,12 @@ final class HttpIdentityResolver implements IdentityResolver {
     final didDocument = await _resolveDidDocument(did);
 
     if (handle != null) {
-      final alsoKnownAs = didDocument['alsoKnownAs'];
-      final claimsHandle =
-          alsoKnownAs is List &&
-          alsoKnownAs.whereType<String>().any(
-            (final aka) => aka.toLowerCase() == 'at://$handle',
-          );
-      if (!claimsHandle) {
+      final claimed = _claimedHandleOf(didDocument);
+      if (claimed != handle) {
         throw IdentityException(
           'Bidirectional handle verification failed: the DID document for '
-          '"$did" does not list "at://$handle" in "alsoKnownAs"',
+          '"$did" claims ${claimed == null ? 'no handle' : '"$claimed"'}, '
+          'not "$handle"',
         );
       }
     }
@@ -684,6 +683,34 @@ bool _isProhibitedIpv6(final List<int> b) {
   return (b[0] == 0xfe && (b[1] & 0xc0) == 0x80) || // fe80::/10 link-local
       (b[0] & 0xfe) == 0xfc || // fc00::/7 unique-local
       b[0] == 0xff; // ff00::/8 multicast
+}
+
+/// The handle [didDocument] claims, lowercased, or `null` when it claims none.
+///
+/// Per the atproto DID spec, `alsoKnownAs` is an *ordered* list and only the
+/// first syntactically valid handle in it is the claimed handle; every later
+/// handle URI is ignored, even when the first fails to resolve
+/// bi-directionally. Entries that are not `at://` URIs (DID Core allows other
+/// URI types here) and `at://` entries that are not syntactically valid
+/// handles are skipped rather than ending the scan, since neither can be the
+/// claimed handle.
+///
+/// Reading the first entry instead of scanning for a match is what keeps a
+/// document from claiming several handles at once: an account whose
+/// `alsoKnownAs` is `["at://alice.example", "at://bob.example"]` claims
+/// `alice.example` and nothing else, so resolving `bob.example` against it
+/// must fail even though the string is present.
+String? _claimedHandleOf(final Map<String, dynamic> didDocument) {
+  final alsoKnownAs = didDocument['alsoKnownAs'];
+  if (alsoKnownAs is! List) return null;
+
+  for (final aka in alsoKnownAs.whereType<String>()) {
+    if (!aka.startsWith('at://')) continue;
+    final candidate = aka.substring('at://'.length).toLowerCase();
+    if (isValidHandle(candidate)) return candidate;
+  }
+
+  return null;
 }
 
 /// Holds [host] to the same SSRF policy [HttpIdentityResolver] applies to a PDS

--- a/packages/atproto_identity/pubspec.yaml
+++ b/packages/atproto_identity/pubspec.yaml
@@ -1,7 +1,7 @@
 name: atproto_identity
 resolution: workspace
 description: AT Protocol identity resolution (handle/DID) and inbound service-auth JWT verification for Dart/Flutter.
-version: 0.3.0
+version: 0.4.0
 homepage: https://atprotodart.com
 repository: https://github.com/myConsciousness/atproto.dart/tree/main/packages/atproto_identity
 issue_tracker: https://github.com/myConsciousness/atproto.dart/issues
@@ -20,6 +20,7 @@ topics:
 dependencies:
   http: ^1.4.0
   did_plc: ^1.2.0
+  at_primitives: ^1.2.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/packages/atproto_identity/test/src/identity/http_identity_resolver_test.dart
+++ b/packages/atproto_identity/test/src/identity/http_identity_resolver_test.dart
@@ -833,4 +833,133 @@ void main() {
       );
     });
   });
+
+  group('bidirectional handle verification (alsoKnownAs is ordered)', () {
+    // The claimed handle is the first syntactically valid handle in
+    // `alsoKnownAs`; every later handle URI is ignored. The document is
+    // otherwise a well-formed account document, so only the claim rule is
+    // under test.
+    HttpIdentityResolver resolverFor(final Object? alsoKnownAs) {
+      final client = MockClient((request) async {
+        if (request.url.path == '/xrpc/com.atproto.identity.resolveHandle') {
+          return _json({'did': _did});
+        }
+        if (request.url.path == '/$_did') {
+          return _json({
+            'alsoKnownAs': ?alsoKnownAs,
+            'service': [
+              {
+                'id': '#atproto_pds',
+                'type': 'AtprotoPersonalDataServer',
+                'serviceEndpoint': _pds,
+              },
+            ],
+          });
+        }
+        return http.Response('not found', 404);
+      });
+
+      return HttpIdentityResolver(httpClient: client);
+    }
+
+    test('accepts the first syntactically valid handle', () async {
+      final resolver = resolverFor(['at://$_handle', 'at://bob.example']);
+
+      expect((await resolver.resolve(_handle)).handle, _handle);
+    });
+
+    test('rejects a handle listed after the claimed one', () async {
+      // The regression: a document claiming `alice.example` also verified
+      // `bob.example`, because the check asked only whether the handle
+      // appeared anywhere in the list.
+      final resolver = resolverFor(['at://$_handle', 'at://bob.example']);
+
+      expect(
+        () => resolver.resolve('bob.example'),
+        throwsA(isA<IdentityException>()),
+      );
+    });
+
+    test('names the claimed handle when rejecting another one', () async {
+      final resolver = resolverFor(['at://$_handle', 'at://bob.example']);
+
+      expect(
+        () => resolver.resolve('bob.example'),
+        throwsA(
+          isA<IdentityException>().having(
+            (final e) => e.message,
+            'message',
+            allOf(contains(_handle), contains('bob.example')),
+          ),
+        ),
+      );
+    });
+
+    test('skips a non-at:// URI rather than ending the scan', () async {
+      // DID Core allows other URI types in `alsoKnownAs`; one appearing first
+      // must not stop the search for the claimed handle.
+      final resolver = resolverFor(['https://$_handle', 'at://$_handle']);
+
+      expect((await resolver.resolve(_handle)).handle, _handle);
+    });
+
+    test('ignores an entry that is not an at:// URI at all', () async {
+      // `alsoKnownAs` holds URIs, and only an `at://` one can name a handle.
+      // A bare domain is a valid *handle* string, so without the scheme check
+      // it would be taken as the claim -- and the real claim below ignored.
+      final resolver = resolverFor(['bob.example', 'at://$_handle']);
+
+      expect((await resolver.resolve(_handle)).handle, _handle);
+    });
+
+    test('rejects a bare-domain entry as if it were the claim', () async {
+      final resolver = resolverFor(['bob.example', 'at://$_handle']);
+
+      expect(
+        () => resolver.resolve('bob.example'),
+        throwsA(isA<IdentityException>()),
+      );
+    });
+
+    test('skips a syntactically invalid at:// entry', () async {
+      // `not_a_handle` carries an underscore and no dot, so it is not a
+      // possible domain name and cannot be the claimed handle.
+      final resolver = resolverFor(['at://not_a_handle', 'at://$_handle']);
+
+      expect((await resolver.resolve(_handle)).handle, _handle);
+    });
+
+    test('matches the claimed handle case-insensitively', () async {
+      final resolver = resolverFor(['at://ALICE.EXAMPLE']);
+
+      expect((await resolver.resolve(_handle)).handle, _handle);
+    });
+
+    test('rejects when no entry is a syntactically valid handle', () async {
+      final resolver = resolverFor(['https://$_handle', 'at://not_a_handle']);
+
+      expect(
+        () => resolver.resolve(_handle),
+        throwsA(isA<IdentityException>()),
+      );
+    });
+
+    test('rejects when alsoKnownAs is absent', () async {
+      final resolver = resolverFor(null);
+
+      expect(
+        () => resolver.resolve(_handle),
+        throwsA(isA<IdentityException>()),
+      );
+    });
+
+    test('rejects when alsoKnownAs is not a list', () async {
+      final resolver = resolverFor('at://$_handle');
+
+      expect(
+        () => resolver.resolve(_handle),
+        throwsA(isA<IdentityException>()),
+      );
+    });
+  });
 }

--- a/packages/atproto_oauth/CHANGELOG.md
+++ b/packages/atproto_oauth/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Note
 
+## v0.8.1
+
+- **chore**: moved to `atproto_identity` `^0.4.0`, which corrects bidirectional handle verification. v0.8.0 is published pinning `^0.3.0`, so without this release an app on `atproto_oauth ^0.8.0` would stay pinned to the version carrying the bug.
+
 ## v0.8.0
 
 - **feat**: `revoke` now actually revokes at the authorization server. It was local-only — the session was dropped from the `OAuthSessionStore` and nothing was sent — so after a "log out" the refresh token stayed live at the server for its full lifetime, and anyone holding a copy (a leaked backup, a shared device, a compromised store) could keep minting access tokens. When the server publishes an RFC 7009 `revocation_endpoint`, the refresh token is now POSTed to it with a DPoP proof before the local delete (the refresh token in preference to the access token, since revoking it takes the whole grant down). The call is best-effort: a server that publishes no endpoint is skipped, and a network or server failure never blocks the logout.

--- a/packages/atproto_oauth/pubspec.yaml
+++ b/packages/atproto_oauth/pubspec.yaml
@@ -1,7 +1,7 @@
 name: atproto_oauth
 resolution: workspace
 description: Provides tools to handle OAuth for AT Protocol and Bluesky Social.
-version: 0.8.0
+version: 0.8.1
 homepage: https://atprotodart.com
 repository: https://github.com/myConsciousness/atproto.dart/tree/main/packages/atproto_oauth
 issue_tracker: https://github.com/myConsciousness/atproto.dart/issues
@@ -17,7 +17,7 @@ topics:
   - oauth
 
 dependencies:
-  atproto_identity: ^0.3.0
+  atproto_identity: ^0.4.0
   http: ^1.4.0
   crypto: ^3.0.6
   freezed_annotation: ^3.1.0

--- a/packages/bluesky/pubspec.yaml
+++ b/packages/bluesky/pubspec.yaml
@@ -37,6 +37,6 @@ dev_dependencies:
       ref: fix/monorepo-pub-workspaces
   atproto_test:
     path: ../atproto_test
-  atproto_oauth: ^0.8.0
+  atproto_oauth: ^0.8.1
   http: any
   fake_async: ^1.3.3

--- a/templates/feed_generator/pubspec.yaml
+++ b/templates/feed_generator/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 dependencies:
   bluesky: ^2.8.0
   atproto_core: ^2.4.1
-  atproto_identity: ^0.3.0
+  atproto_identity: ^0.4.0
   shelf: ^1.4.0
   shelf_router: ^1.1.0
 


### PR DESCRIPTION
Closes #2570.

## The bug

`resolve` verified a handle bidirectionally by asking whether it appeared **anywhere** in the DID document's `alsoKnownAs`:

```dart
alsoKnownAs.whereType<String>().any((aka) => aka.toLowerCase() == 'at://$handle')
```

The atproto DID spec makes that list *ordered*: the first syntactically valid handle in it is the claimed handle, and every later handle URI is ignored — even when the first fails to resolve bi-directionally.

So a document listing

```json
"alsoKnownAs": ["at://alice.example", "at://bob.example"]
```

verified `bob.example` just as readily as `alice.example`. One account could present several handles as bidirectionally verified when the protocol says exactly one of them is canonical, and a caller using this to answer "is this handle really this account's" got a wrong yes for every alias the account cared to list.

## The fix

The check now reads the claimed handle and compares it, instead of scanning the list for a match.

Two kinds of entry are skipped rather than ending the scan, since neither can be the claim: entries that are not `at://` URIs (DID Core allows other URI types in `alsoKnownAs`), and `at://` entries whose handle part is not syntactically valid. The scheme check earns its place independently — a bare domain like `bob.example` is a valid handle *string*, so without it such an entry would be taken as the claim ahead of the real one.

The handle grammar comes from `at_primitives`, which already owns it for four other packages in this workspace, rather than being restated here where it could drift from the very rule this fix turns on.

## Scope

Deliberately only the bug. #2570 also asks for `handle` to be populated when resolution starts from a DID, and for the field to stop being nullable. That part is not here:

- A DID-start handle is an **unverified claim** — only the DID→handle direction exists, so putting it in the same `handle` field that today means "bidirectionally verified" would hand callers an attacker-controllable display name. Anyone can write `alsoKnownAs: ["at://google.com"]` into their own DID document.
- It cannot be non-nullable regardless: a document may carry no `alsoKnownAs`, or none whose entries are syntactically valid handles.
- Callers who want the raw claim can already read it from `resolveDidDocument` (#2571), whose contract states plainly that nothing inside the returned document is validated.

Worth settling separately rather than riding along with a security fix.

## Not breaking, but behaviour-changing

No signature or export changes. A caller that relied on an alias handle resolving now gets an `IdentityException`, so this ships as a minor rather than a patch: `atproto_identity` 0.3.0 → 0.4.0. `atproto_oauth` 0.8.0 is already published pinning `atproto_identity ^0.3.0`, so it gets 0.8.1 to carry the constraint, with `atproto_core` and `bluesky` following the workspace's equal-constraint rule.

## Verification

Run locally on Dart 3.13.2, the version CI installs:

- `dart format --set-exit-if-changed` and `dart analyze` clean across all 16 workspace directories.
- `atproto_identity` 131 tests (120 before, 11 new), `atproto_oauth` 120, `atproto_core` 190, `bluesky` 995, `templates/feed_generator` 75 — all passing.
- `scripts/validate_dependencies.dart` ✓ (14 packages) and `scripts/validate_website_overrides.dart` ✓ (11 packages).

The new tests are mutation-checked — each of these makes a test fail:

| Mutation | Test that catches it |
|---|---|
| revert to the old `any()` scan | rejects a handle listed after the claimed one |
| stop at the first `at://` entry instead of skipping invalid ones | skips a syntactically invalid at:// entry |
| drop the `at://` scheme check | ignores an entry that is not an at:// URI at all |

The third mutation initially survived — the first draft used `https://alice.example` as the non-`at://` entry, which the handle grammar rejects anyway, so the scheme check was never actually pinned. The bare-domain cases were added to close that.

## Note on overlap

The first commit here is the same one-line CI fix as #2572, ported so this PR's checks can run at all (`setup-dart` v1.8.1 breaks every job on `main`). It no-ops once #2572 lands.

This PR and #2571 both release `atproto_identity` as 0.4.0, so whichever merges second will conflict on the version and CHANGELOG. Both are independent changes; folding them into one 0.4.0 entry, or bumping the later one, resolves it.

---
_Generated by [Claude Code](https://claude.ai/code/session_018qMvvBV72ZYaFNFLRdrSN4)_