### PR TITLE
test(bluesky): pin GroupedNotificationReason to its lexicon

### DIFF
--- a/packages/bluesky/lib/src/tools/utils/grouped_notification_reason.dart
+++ b/packages/bluesky/lib/src/tools/utils/grouped_notification_reason.dart
@@ -7,13 +7,25 @@ import 'package:freezed_annotation/freezed_annotation.dart';
 
 /// A class that encapsulates a reason for grouped notification.
 ///
-/// Every value `app.bsky.notification.listNotifications#notification.reason`
-/// declares as known has an entry here, plus two this package synthesises and
-/// the lexicon therefore never lists: [customFeedLike] and [unknown]. A test
-/// checks that against the lexicon file itself, so a value added upstream fails
-/// naming that value rather than drifting unnoticed.
+/// This is the grouper's own vocabulary rather than the lexicon mirror — that
+/// is the generated `KnownNotificationReason`, and this enum is reached by
+/// converting from it. It still has to cover every value
+/// `app.bsky.notification.listNotifications#notification.reason` declares as
+/// known, because a reason with no entry here does not fail loudly: [valueOf]
+/// answers [unknown] and the notification groups under the wrong heading. A
+/// test checks the coverage against the lexicon file itself, so a value added
+/// upstream fails naming that value rather than drifting unnoticed.
+///
+/// Two values are synthesised here, and the lexicon therefore never lists
+/// them: [customFeedLike] and [unknown].
 enum GroupedNotificationReason {
   /// Indicates likes.
+  ///
+  /// Narrower than the lexicon's `like`: a like on a feed generator is
+  /// [customFeedLike] instead. The official client makes the same split
+  /// explicit by naming its two members `post-like` and `feedgen-like`;
+  /// renaming this one would break callers, so the narrowing is documented
+  /// here rather than spelled out in the name.
   like('like'),
 
   /// Indicates likes for custom feed.
@@ -22,6 +34,11 @@ enum GroupedNotificationReason {
   /// has no such reason. A `like` whose `reasonSubject` points at an
   /// `app.bsky.feed.generator` record is relabelled here so that likes on a
   /// custom feed group apart from likes on a post.
+  ///
+  /// The official client derives the same category from the same rule and
+  /// calls it `feedgen-like`, and there is no protocol signal to defer to
+  /// instead: the AppView sends a plain `like` and leaves the collection to be
+  /// read off `reasonSubject`.
   customFeedLike('customFeedLike'),
 
   /// Indicates reposts.

--- a/packages/bluesky/lib/src/tools/utils/grouped_notification_reason.dart
+++ b/packages/bluesky/lib/src/tools/utils/grouped_notification_reason.dart
@@ -6,11 +6,22 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 /// A class that encapsulates a reason for grouped notification.
+///
+/// Every value `app.bsky.notification.listNotifications#notification.reason`
+/// declares as known has an entry here, plus two this package synthesises and
+/// the lexicon therefore never lists: [customFeedLike] and [unknown]. A test
+/// checks that against the lexicon file itself, so a value added upstream fails
+/// naming that value rather than drifting unnoticed.
 enum GroupedNotificationReason {
   /// Indicates likes.
   like('like'),
 
   /// Indicates likes for custom feed.
+  ///
+  /// Synthesised by this package rather than sent by the AppView: the lexicon
+  /// has no such reason. A `like` whose `reasonSubject` points at an
+  /// `app.bsky.feed.generator` record is relabelled here so that likes on a
+  /// custom feed group apart from likes on a post.
   customFeedLike('customFeedLike'),
 
   /// Indicates reposts.

--- a/packages/bluesky/test/src/services/utils/grouped_notification_reason_lexicon_test.dart
+++ b/packages/bluesky/test/src/services/utils/grouped_notification_reason_lexicon_test.dart
@@ -1,0 +1,84 @@
+// Copyright (c) 2023-2025, Shinya Kato.
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:test/test.dart';
+
+import 'package:bluesky/src/tools/utils/grouped_notification_reason.dart';
+
+/// `app.bsky.notification.listNotifications#notification.reason.knownValues`,
+/// read from the lexicon this package is generated against.
+///
+/// Relative to the package directory, which is where `dart test` runs from —
+/// the same assumption every fixture path in this suite already makes.
+Set<String> _lexiconKnownValues() {
+  final file = File(
+    '../../lexicons/app/bsky/notification/listNotifications.json',
+  );
+  final defs = jsonDecode(file.readAsStringSync()) as Map<String, dynamic>;
+  final notification =
+      (defs['defs'] as Map<String, dynamic>)['notification']
+          as Map<String, dynamic>;
+  final reason =
+      (notification['properties'] as Map<String, dynamic>)['reason']
+          as Map<String, dynamic>;
+
+  return {...(reason['knownValues'] as List).cast<String>()};
+}
+
+/// The values this package synthesises, which the lexicon therefore never
+/// lists.
+///
+/// [GroupedNotificationReason.customFeedLike] is produced by the grouper from a
+/// `like` whose `reasonSubject` names an `app.bsky.feed.generator` record;
+/// [GroupedNotificationReason.unknown] is the fallback `valueOf` returns for a
+/// reason this client version does not know.
+const _synthesised = {'customFeedLike', 'unknown'};
+
+void main() {
+  group('GroupedNotificationReason against the lexicon', () {
+    test('every reason the lexicon calls known is in the enum', () {
+      final missing = _lexiconKnownValues().difference({
+        for (final reason in GroupedNotificationReason.values) reason.value,
+      });
+
+      expect(
+        missing,
+        isEmpty,
+        reason: 'in the lexicon but not in GroupedNotificationReason: $missing',
+      );
+    });
+
+    test(
+      'the enum keeps nothing beyond the lexicon except what it synthesises',
+      () {
+        // Not `isEmpty`: two values are deliberately not in the lexicon. Pinning
+        // them by name means a *new* divergence — an upstream removal, or a
+        // locally invented reason — fails this test instead of hiding behind
+        // them.
+        final extra = {
+          for (final reason in GroupedNotificationReason.values) reason.value,
+        }.difference(_lexiconKnownValues());
+
+        expect(extra, _synthesised);
+      },
+    );
+
+    test('valueOf resolves every lexicon reason to itself', () {
+      // `valueOf` falls back to `unknown` rather than throwing, so a missing
+      // entry would silently answer `unknown` instead of failing. Comparing
+      // against the value itself is what catches that.
+      for (final value in _lexiconKnownValues()) {
+        expect(
+          GroupedNotificationReason.valueOf(value).value,
+          value,
+          reason:
+              'GroupedNotificationReason.valueOf($value) did not round-trip',
+        );
+      }
+    });
+  });
+}


### PR DESCRIPTION
`app.bsky.notification.listNotifications#notification.reason` lists thirteen
`knownValues`. `GroupedNotificationReason` has all thirteen plus two more, and
nothing was checking — the same shape as `KnownLabelValue`, which shipped
missing `bot` (#2568) because it was kept in step by hand and hoped for.

## What this changes

**Nothing about behaviour.** No enum value is added, removed or renamed. This is
documentation and a test.

## Why coverage matters here

This enum is not the lexicon mirror. The mirror is the generated
`KnownNotificationReason`, wrapped in the open union `NotificationReason`, and
that is what parses the wire. `GroupedNotificationReason` is the grouper's own
vocabulary, reached by converting from that mirror
(`notifications_grouper.dart:336`) and attached to `GroupedNotification`, a type
the lexicon has no counterpart for.

So this is not about fidelity to a mirror. It matters because a gap does not
fail loudly: `valueOf` falls back to `unknown` rather than returning null, so a
reason added upstream would group every such notification under the wrong
heading and nothing would say so. That is the bug the test guards.

## The two extras are both deliberate

- `customFeedLike` is synthesised here, not sent by the AppView. A `like` whose
  `reasonSubject` names an `app.bsky.feed.generator` record is relabelled, so
  likes on a custom feed group apart from likes on a post.
- `unknown` is the fallback `valueOf` returns instead of throwing.

`customFeedLike` is not an invention of this package. The official client
derives the same category by the same discriminator — `toKnownType` in
`src/state/queries/notifications/util.ts` relabels a `like` whose
`reasonSubject` names a feed generator as `feedgen-like` — and it is
load-bearing there rather than cosmetic: it changes subject resolution, the link
target, the render guard, and the copy. Its `OtherNotificationType` union
carries both of the same extras and has no bare `like` at all.

There is also no protocol signal to defer to: the AppView sends a plain `like`
with the generator's AT-URI in `reasonSubject`, so every client re-derives this
or does without it.

## The test

It reads `lexicons/app/bsky/notification/listNotifications.json` directly rather
than restating its values, so a reason added upstream fails a test naming that
reason.

It pins the two extras **by name** rather than asserting the set is empty, so a
*new* divergence — an upstream removal, or another locally invented reason —
cannot hide behind them.

`valueOf` is checked by round-tripping the value rather than by a null check,
because of the `unknown` fallback described above: a missing entry would
otherwise answer `unknown` and pass.

## Verification

All three guards were exercised by changing `mention('mention')` to
`mention('mentionX')` and watching each fail naming the value:

- `in the lexicon but not in GroupedNotificationReason: {mention}`
- `Expected: Set:['customFeedLike', 'unknown']  Actual: Set:[..., 'mentionX', ...]`
- `valueOf` round-trip `Expected: 'mention'  Actual: 'unknown'`

Gates run locally: `dart_workspace_dirs.sh --check` (16 packages), `dart format
--set-exit-if-changed` and `dart analyze` clean across all workspace dirs, and
`dart test` in `packages/bluesky` green at 998 tests.

## Not done here

- **No version bump and no CHANGELOG entry.** This is tests and documentation
  only, with no behaviour a caller can observe, so it rides the next release
  rather than taking a patch of its own.
- **`gore` and `KnownLabelValue` are untouched** — already handled in #2568.
- **`like` is not renamed.** Once `customFeedLike` exists, `like` quietly means
  "a like that is not on a feed generator". The official client makes that split
  visible in the names (`post-like` beside `feedgen-like`); renaming a public
  enum member here would break callers, so the narrowing is documented instead.
  Worth a look if a breaking release is ever on the table.
- **The discriminator stays a substring test.**
  `notifications_grouper.dart:344` is
  `reasonSubject.contains(ids.appBskyFeedGenerator)`, not an `AtUri.collection`
  parse, so an AT-URI that embeds that NSID elsewhere would false-positive.
  Upstream's `includes('feed.generator')` is looser still, so this is not a
  compatibility gap — but it is untested at the edges and left as-is here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)