### PR TITLE
fix(bluesky): a like's feed-generator test reads the collection, not the whole URI

### DIFF
--- a/packages/bluesky/lib/src/tools/utils/notifications_grouper.dart
+++ b/packages/bluesky/lib/src/tools/utils/notifications_grouper.dart
@@ -170,7 +170,7 @@ final class _NotificationsGrouper implements NotificationsGrouper {
 
       for (final notification in chunk) {
         final reasonSubject = notification.reasonSubject?.toString();
-        final reason = _getGroupedReason(notification, reasonSubject);
+        final reason = _getGroupedReason(notification);
 
         if (!_isGroupable(notification.reason)) {
           groups.add(_buildGroup(notification, reason, ordinal: groups.length));
@@ -322,27 +322,29 @@ final class _NotificationsGrouper implements NotificationsGrouper {
   GroupedNotifications get emptyGroupedNotifications =>
       const GroupedNotifications(notifications: []);
 
-  GroupedNotificationReason _getGroupedReason(
-    final Notification notification,
-    final String? reasonSubject,
-  ) {
+  GroupedNotificationReason _getGroupedReason(final Notification notification) {
     final knownValue = notification.reason.knownValue;
 
     if (knownValue == KnownNotificationReason.like &&
-        _isCustomFeedLike(reasonSubject)) {
+        _isCustomFeedLike(notification.reasonSubject)) {
       return GroupedNotificationReason.customFeedLike;
     }
 
     return GroupedNotificationReason.valueOf(notification.reason.toJson());
   }
 
-  bool _isCustomFeedLike(final String? reasonSubject) {
-    if (reasonSubject == null) {
-      return false;
-    }
-
-    return reasonSubject.contains(ids.appBskyFeedGenerator);
-  }
+  /// Whether this like points at a feed generator record.
+  ///
+  /// Matches the AT URI's collection segment exactly instead of searching the
+  /// whole URI for the NSID. An rkey may legally contain dots, so a like on
+  /// `at://<did>/app.bsky.feed.post/app.bsky.feed.generator` is a post like;
+  /// the substring test this replaces called it a feed like.
+  ///
+  /// Uses [AtUri.collectionOrNull] rather than `collection` (or the generated
+  /// `isFeedGenerator`, which is built on it) because both throw on a URI with
+  /// no collection segment, and the substring test never threw.
+  bool _isCustomFeedLike(final AtUri? reasonSubject) =>
+      reasonSubject?.collectionOrNull?.toString() == ids.appBskyFeedGenerator;
 
   List<List<Notification>> _groupBy(
     final GroupBy? by,

--- a/packages/bluesky/test/src/services/utils/notifications_grouper_test.dart
+++ b/packages/bluesky/test/src/services/utils/notifications_grouper_test.dart
@@ -975,4 +975,74 @@ void main() {
       expect(() => notifications.groupByHour(61), throwsA(isA<RangeError>()));
     });
   });
+  group('customFeedLike discriminator', () {
+    test(
+      'a post like whose rkey spells the generator NSID is not a feed like',
+      () {
+        // The discriminator searched the whole AT-URI for
+        // `app.bsky.feed.generator`. An rkey may legally contain dots, so a like
+        // on a *post* with that rkey was reported as a feed like.
+        final grouped = _grouper.group(
+          NotificationListNotificationsOutput.fromJson({
+            'notifications': [
+              _notification(
+                did: 'did:plc:aaaa',
+                reason: 'like',
+                reasonSubject:
+                    'at://did:plc:xxxx/app.bsky.feed.post/app.bsky.feed.generator',
+                indexedAt: '2023-04-30T04:00:00.000Z',
+              ),
+            ],
+          }),
+        );
+
+        expect(grouped.notifications.length, 1);
+        expect(grouped.notifications[0].reason, GroupedNotificationReason.like);
+      },
+    );
+
+    test('a like on a generator record is still a feed like', () {
+      // Narrowing the match to the collection segment must not swallow the
+      // case the discriminator exists for.
+      final grouped = _grouper.group(
+        NotificationListNotificationsOutput.fromJson({
+          'notifications': [
+            _notification(
+              did: 'did:plc:aaaa',
+              reason: 'like',
+              reasonSubject: 'at://did:plc:xxxx/app.bsky.feed.generator/aaaa',
+              indexedAt: '2023-04-30T04:00:00.000Z',
+            ),
+          ],
+        }),
+      );
+
+      expect(grouped.notifications.length, 1);
+      expect(
+        grouped.notifications[0].reason,
+        GroupedNotificationReason.customFeedLike,
+      );
+    });
+
+    test('a reasonSubject with no collection segment does not throw', () {
+      // `AtUri.collection` throws when there is no collection segment, and the
+      // substring test being replaced never threw. Reading the collection has
+      // to stay non-throwing.
+      final grouped = _grouper.group(
+        NotificationListNotificationsOutput.fromJson({
+          'notifications': [
+            _notification(
+              did: 'did:plc:aaaa',
+              reason: 'like',
+              reasonSubject: 'at://did:plc:xxxx',
+              indexedAt: '2023-04-30T04:00:00.000Z',
+            ),
+          ],
+        }),
+      );
+
+      expect(grouped.notifications.length, 1);
+      expect(grouped.notifications[0].reason, GroupedNotificationReason.like);
+    });
+  });
 }


### PR DESCRIPTION
`_isCustomFeedLike` searched the entire `reasonSubject` AT URI for
`app.bsky.feed.generator`. An rkey may legally contain dots, so a like on
`at://<did>/app.bsky.feed.post/app.bsky.feed.generator` is a like on a post,
and the substring test grouped it as `customFeedLike`. It now compares the
URI's collection segment exactly.

`reasonSubject` is already an `AtUri` on the notification and was stringified
only for this check, so this drops the stringification rather than adding a
parse. The generated `AtUri.isFeedGenerator` expresses the same comparison but
is built on `collection`, which throws when the URI has no collection segment;
the substring test it replaces never threw, so this uses `collectionOrNull` to
keep that property. A test covers it.

Narrower than the official client, which tests
`reasonSubject?.includes('feed.generator')` in social-app's `toKnownType`, so
this is not a compatibility gap.

## Behaviour change

A like whose `reasonSubject` names a non-generator collection but spells
`app.bsky.feed.generator` elsewhere in the URI now groups as `like` instead of
`customFeedLike`. That was the defect, but it is a visible change for anyone
who relied on the old grouping.

## Tests

- a post like whose rkey spells the generator NSID is not a feed like
  (fails before this change, passes after)
- a like on a generator record is still a feed like
- a `reasonSubject` with no collection segment does not throw

Gates: workspace check 16, format 4901 files 0 changed, analyze clean,
`packages/bluesky` 1001 tests, `dart test scripts` 44 tests,
validate_dependencies 14, validate_website_overrides 11, doc snippets clean.
`melos gen` and the website snippet checks were skipped: the diff touches no
codegen input and nothing under `website/`.

## Not done here

- **No version bump and no CHANGELOG entry.** `bluesky` is at 2.8.0 and
  `bluesky-v2.8.0` is already tagged and published, so this cannot ship until
  someone bumps the version. Both are deliberately left to a human.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
