### PR TITLE
feat(atproto_identity)!: verify the claimed handle when resolving from a DID

### DIFF
--- a/packages/atproto_identity/README.md
+++ b/packages/atproto_identity/README.md
@@ -41,14 +41,18 @@ Future<void> main() async {
 
   print(identity.did); // did:plc:...
   print(identity.pds); // https://... (origin, no trailing slash)
-  print(identity.handle); // shinyakato.dev
+  print(identity.handle); // shinyakato.dev, or 'handle.invalid'
   print(identity.signingKey); // #atproto publicKeyMultibase, or null
 }
 ```
 
-When resolution starts from a handle, the resolver verifies the DID document
-claims that handle back through `alsoKnownAs` (bidirectional handle
-verification). On any failure it throws an `IdentityException`.
+The resolver performs bidirectional handle verification whichever way you
+enter. From a handle, the DID document must claim it back through
+`alsoKnownAs`, or an `IdentityException` is thrown. From a DID, the handle the
+document claims is resolved back and must return that same DID; anything else
+reports `handle.invalid` instead of throwing, because an account whose handle
+stopped resolving is still a valid account. `handle` is never null — it is
+either a verified handle or `handle.invalid`.
 
 `HttpIdentityResolver` is configurable and injectable:
 

--- a/packages/atproto_identity/lib/src/identity/identity_resolver.dart
+++ b/packages/atproto_identity/lib/src/identity/identity_resolver.dart
@@ -379,26 +379,30 @@ final class HttpIdentityResolver implements IdentityResolver {
     final normalized = _normalizeIdentity(identity, name: 'identity');
 
     final String did;
-    final String? handle;
+    final String? suppliedHandle;
     if (normalized.startsWith('did:')) {
       did = normalized;
-      handle = null;
+      suppliedHandle = null;
     } else {
-      handle = normalized.toLowerCase();
-      did = await _resolveHandle(handle);
+      suppliedHandle = normalized.toLowerCase();
+      did = await _resolveHandle(suppliedHandle);
     }
 
     final didDocument = await _resolveDidDocument(did);
 
-    if (handle != null) {
+    final String handle;
+    if (suppliedHandle != null) {
       final claimed = _claimedHandleOf(didDocument);
-      if (claimed != handle) {
+      if (claimed != suppliedHandle) {
         throw IdentityException(
           'Bidirectional handle verification failed: the DID document for '
           '"$did" claims ${claimed == null ? 'no handle' : '"$claimed"'}, '
-          'not "$handle"',
+          'not "$suppliedHandle"',
         );
       }
+      handle = suppliedHandle;
+    } else {
+      handle = await _verifiedHandleOf(didDocument, did);
     }
 
     return ResolvedIdentity(
@@ -407,6 +411,44 @@ final class HttpIdentityResolver implements IdentityResolver {
       handle: handle,
       signingKey: signingKeyOf(didDocument, did),
     );
+  }
+
+  /// The handle [didDocument] claims, but only when it resolves back to
+  /// [did]; otherwise [handleInvalid].
+  ///
+  /// **Never throws.** A handle that no longer resolves is an operational
+  /// state, not a broken account — the usual cause is the DNS record for a
+  /// verified domain being removed or misconfigured — and the atproto handle
+  /// specification gives that case a value of its own precisely so the
+  /// identity stays usable. Failing the whole resolution here would make every
+  /// account whose DNS broke unresolvable.
+  ///
+  /// [_resolveHandle] wraps only `TimeoutException`, so transport failures
+  /// (`SocketException`, `ClientException`, `HandshakeException`) arrive
+  /// unwrapped; catching `Exception` covers those as well as
+  /// [IdentityException]. `Error`s are deliberately not caught, so a bug here
+  /// still surfaces.
+  Future<String> _verifiedHandleOf(
+    final Map<String, dynamic> didDocument,
+    final String did,
+  ) async {
+    final claimed = _claimedHandleOf(didDocument);
+
+    // A document claiming the sentinel verbatim claims nothing: it is a
+    // syntactically valid handle, so honouring it would make a *verified*
+    // handle indistinguishable from one that failed to verify.
+    if (claimed == null || claimed == handleInvalid) return handleInvalid;
+
+    try {
+      final resolved = await _resolveHandle(claimed);
+
+      // `_resolveHandle` returns the DID exactly as the handle resolver
+      // spelled it, and a DID is case-sensitive, so this is an exact match
+      // against the DID the caller asked about.
+      return resolved.trim() == did ? claimed : handleInvalid;
+    } on Exception catch (_) {
+      return handleInvalid;
+    }
   }
 
   /// Fetches the DID document for [did] and returns it verbatim, as decoded

--- a/packages/atproto_identity/lib/src/types/resolved_identity.dart
+++ b/packages/atproto_identity/lib/src/types/resolved_identity.dart
@@ -2,12 +2,27 @@
 // All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+/// The handle of an identity whose handle could not be bidirectionally
+/// verified, as defined by the atproto handle specification.
+///
+/// A DID whose handle does not resolve back to it is still a valid account —
+/// the usual cause is an operational one, such as the DNS record for a
+/// verified domain being removed or misconfigured — so resolution reports this
+/// value rather than failing. The same string is what
+/// `com.atproto.identity.defs#identityInfo` carries in that case, which is why
+/// [ResolvedIdentity.handle] is never null.
+///
+/// It is a syntactically valid handle, so it cannot be told apart from a real
+/// one by shape alone. Resolution therefore refuses to treat a DID document
+/// that claims this exact string as claiming a handle at all.
+const handleInvalid = 'handle.invalid';
+
 /// The outcome of resolving a handle or DID to its atproto identity.
 final class ResolvedIdentity {
   const ResolvedIdentity({
     required this.did,
     required this.pds,
-    this.handle,
+    required this.handle,
     this.signingKey,
   });
 
@@ -17,8 +32,19 @@ final class ResolvedIdentity {
   /// The PDS origin (`https://host[:port]`, no trailing slash).
   final String pds;
 
-  /// The handle, when resolution started from one; otherwise `null`.
-  final String? handle;
+  /// The account's bidirectionally verified handle, or [handleInvalid] when it
+  /// has none that verifies.
+  ///
+  /// Resolving *from* a handle rejects a DID document that does not claim it,
+  /// so this is always the supplied handle in that case. Resolving from a DID
+  /// reads the handle the document claims and checks that it resolves back to
+  /// that DID; anything else — no claim, a claim that resolves elsewhere, a
+  /// handle resolver that cannot be reached — is reported as [handleInvalid],
+  /// because an account with a broken handle is still an account.
+  ///
+  /// Modelled on `com.atproto.identity.defs#identityInfo`, which requires the
+  /// field and defines the same sentinel.
+  final String handle;
 
   /// The `#atproto` verification method's `publicKeyMultibase`, when present
   /// in the DID document; otherwise `null`.

--- a/packages/atproto_identity/test/src/identity/http_identity_resolver_test.dart
+++ b/packages/atproto_identity/test/src/identity/http_identity_resolver_test.dart
@@ -1327,4 +1327,99 @@ void main() {
       );
     });
   });
+  group('DID-initiated handle verification', () {
+    // Records the handles looked up so a test can assert that no lookup
+    // happened at all, which is the difference between "claims nothing" and
+    // "claims something that failed to verify".
+    final lookups = <String>[];
+
+    HttpIdentityResolver resolverFor({
+      final Object? alsoKnownAs,
+      final String? resolvesTo,
+      final int handleStatus = 200,
+    }) {
+      lookups.clear();
+      final client = MockClient((request) async {
+        if (request.url.path == '/xrpc/com.atproto.identity.resolveHandle') {
+          lookups.add(request.url.queryParameters['handle'] ?? '');
+          if (handleStatus != 200) return http.Response('nope', handleStatus);
+          return _json({'did': resolvesTo});
+        }
+        if (request.url.path == '/$_did') {
+          return _json({..._didDocumentWithPds(), 'alsoKnownAs': ?alsoKnownAs});
+        }
+        return http.Response('not found', 404);
+      });
+
+      return HttpIdentityResolver(httpClient: client);
+    }
+
+    test(
+      'returns the claimed handle when it resolves back to the DID',
+      () async {
+        final id = await resolverFor(
+          alsoKnownAs: ['at://$_handle'],
+          resolvesTo: _did,
+        ).resolve(_did);
+
+        expect(id.handle, _handle);
+        expect(lookups, [_handle]);
+      },
+    );
+
+    test(
+      'returns handleInvalid when the claim resolves to another DID',
+      () async {
+        final id = await resolverFor(
+          alsoKnownAs: ['at://$_handle'],
+          resolvesTo: 'did:plc:zzzzzzzzzzzzzzzzzzzzzzzz',
+        ).resolve(_did);
+
+        expect(id.handle, handleInvalid);
+        expect(lookups, [_handle]);
+      },
+    );
+
+    test(
+      'returns handleInvalid without a lookup when nothing is claimed',
+      () async {
+        final id = await resolverFor(resolvesTo: _did).resolve(_did);
+
+        expect(id.handle, handleInvalid);
+        // A document that claims no handle must not cost a round trip.
+        expect(lookups, isEmpty);
+      },
+    );
+
+    test(
+      'returns handleInvalid rather than throwing when the lookup fails',
+      () async {
+        // A handle that stopped resolving is an operational state — usually the
+        // DNS record for a verified domain being removed — and the account is
+        // still valid, so resolution must not fail.
+        final id = await resolverFor(
+          alsoKnownAs: ['at://$_handle'],
+          handleStatus: 500,
+        ).resolve(_did);
+
+        expect(id.handle, handleInvalid);
+        expect(lookups, [_handle]);
+      },
+    );
+
+    test(
+      'treats a document claiming handleInvalid as claiming nothing',
+      () async {
+        // The sentinel is a syntactically valid handle, so honouring a claim of
+        // it would make a verified handle indistinguishable from a failed one.
+        final id = await resolverFor(
+          alsoKnownAs: ['at://$handleInvalid'],
+          resolvesTo: _did,
+        ).resolve(_did);
+
+        expect(id.handle, handleInvalid);
+        expect(lookups, isEmpty);
+      },
+    );
+  });
 }

--- a/packages/atproto_identity/test/src/service_auth_test.dart
+++ b/packages/atproto_identity/test/src/service_auth_test.dart
@@ -22,6 +22,7 @@ final class _FakeResolver implements IdentityResolver {
       ResolvedIdentity(
         did: identity,
         pds: 'https://pds.example',
+        handle: handleInvalid,
         signingKey: signingKey,
       );
 }

--- a/packages/atproto_identity/test/src/types/resolved_identity_test.dart
+++ b/packages/atproto_identity/test/src/types/resolved_identity_test.dart
@@ -15,10 +15,20 @@ void main() {
     expect(id.signingKey, 'zQ3shpubkey');
   });
 
-  test('signingKey and handle default to null', () {
-    const id = ResolvedIdentity(did: 'did:plc:abc', pds: 'https://pds.example');
-    expect(id.handle, isNull);
+  test('signingKey defaults to null but handle is required', () {
+    const id = ResolvedIdentity(
+      did: 'did:plc:abc',
+      pds: 'https://pds.example',
+      handle: handleInvalid,
+    );
+    // `handle` has no default: an identity always reports either a verified
+    // handle or the sentinel, matching `identityInfo` in the lexicon.
+    expect(id.handle, handleInvalid);
     expect(id.signingKey, isNull);
+  });
+
+  test('handleInvalid is the value the atproto handle spec defines', () {
+    expect(handleInvalid, 'handle.invalid');
   });
 
   test('IdentityException carries a message', () {

--- a/packages/atproto_oauth/lib/src/oauth_client.dart
+++ b/packages/atproto_oauth/lib/src/oauth_client.dart
@@ -263,7 +263,13 @@ final class OAuthClient {
 
     // Use the resolved, normalized handle/DID as the login_hint (never the raw
     // input, which may carry `@`/`at://` prefixes or non-canonical casing).
-    final loginHint = resolved.handle ?? resolved.did;
+    //
+    // `handle` is never null, but it carries `handleInvalid` when nothing
+    // verified — that string is not this account's handle and must not be sent
+    // as one, so the DID stands in exactly as it did for the old null handle.
+    final loginHint = resolved.handle == handleInvalid
+        ? resolved.did
+        : resolved.handle;
     if (loginHint.isNotEmpty) {
       bodyParams['login_hint'] = loginHint;
     }

--- a/packages/atproto_oauth/test/src/oauth_client_test.dart
+++ b/packages/atproto_oauth/test/src/oauth_client_test.dart
@@ -59,6 +59,18 @@ class _FailingIdentityResolver implements IdentityResolver {
   }
 }
 
+/// An [IdentityResolver] that answers with a fixed identity, used to drive the
+/// `login_hint` decision without going through handle resolution.
+class _StubIdentityResolver implements IdentityResolver {
+  const _StubIdentityResolver(this.handle);
+
+  final String handle;
+
+  @override
+  Future<ResolvedIdentity> resolve(final String identity) async =>
+      ResolvedIdentity(did: _sub, pds: _pdsOrigin, handle: handle);
+}
+
 /// A recording mock HTTP client. Each request is routed to [handler]; all
 /// requests are captured in [requests] for assertions.
 class _Recorder {
@@ -327,6 +339,58 @@ void main() {
       // A prefixed / mixed-case identity must be normalized before use as the
       // login_hint (the `@` / `at://` prefixes must never be forwarded).
       await client.authorize('at://@$_handle');
+
+      final fields = Uri.splitQueryString(
+        recorder.requests.firstWhere(_isPar).body,
+      );
+      expect(fields['login_hint'], _handle);
+    });
+
+    test('login_hint falls back to the DID when no handle verified', () async {
+      // `ResolvedIdentity.handle` is never null; it carries `handleInvalid`
+      // when nothing verified — most often a verified domain whose DNS record
+      // was removed. That string is not this account's handle, so sending it
+      // as the `login_hint` would hand the authorization server a handle that
+      // belongs to nobody. The DID stands in instead.
+      final recorder = _Recorder();
+      final client = OAuthClient(
+        _metadata(),
+        identityResolver: const _StubIdentityResolver(handleInvalid),
+        signer: _StubSigner(),
+        httpClient: recorder.build((r) async {
+          final id = _identityRoute(r);
+          if (id != null) return id;
+          if (_isWellKnown(r)) return _json(_serverMetadataDoc());
+          if (_isPar(r)) return _json({'request_uri': 'urn:x'}, status: 201);
+          return http.Response('unexpected', 500);
+        }),
+      );
+
+      await client.authorize(_sub);
+
+      final fields = Uri.splitQueryString(
+        recorder.requests.firstWhere(_isPar).body,
+      );
+      expect(fields['login_hint'], _sub);
+      expect(fields['login_hint'], isNot(handleInvalid));
+    });
+
+    test('login_hint is the verified handle when one verified', () async {
+      final recorder = _Recorder();
+      final client = OAuthClient(
+        _metadata(),
+        identityResolver: const _StubIdentityResolver(_handle),
+        signer: _StubSigner(),
+        httpClient: recorder.build((r) async {
+          final id = _identityRoute(r);
+          if (id != null) return id;
+          if (_isWellKnown(r)) return _json(_serverMetadataDoc());
+          if (_isPar(r)) return _json({'request_uri': 'urn:x'}, status: 201);
+          return http.Response('unexpected', 500);
+        }),
+      );
+
+      await client.authorize(_sub);
 
       final fields = Uri.splitQueryString(
         recorder.requests.firstWhere(_isPar).body,

--- a/templates/feed_generator/test/identity/caching_identity_resolver_test.dart
+++ b/templates/feed_generator/test/identity/caching_identity_resolver_test.dart
@@ -14,7 +14,11 @@ final class _CountingResolver implements IdentityResolver {
   @override
   Future<ResolvedIdentity> resolve(final String identity) async {
     calls++;
-    return ResolvedIdentity(did: 'did:plc:$identity', pds: 'https://pds.test');
+    return ResolvedIdentity(
+      did: 'did:plc:$identity',
+      pds: 'https://pds.test',
+      handle: handleInvalid,
+    );
   }
 }
 
@@ -30,7 +34,11 @@ final class _BlockingResolver implements IdentityResolver {
   Future<ResolvedIdentity> resolve(final String identity) async {
     calls++;
     await _gate.future;
-    return ResolvedIdentity(did: identity, pds: 'https://pds.test');
+    return ResolvedIdentity(
+      did: identity,
+      pds: 'https://pds.test',
+      handle: handleInvalid,
+    );
   }
 }
 
@@ -220,6 +228,10 @@ final class _FailingOnceResolver implements IdentityResolver {
     if (_shouldFail()) {
       throw const IdentityException('resolver unavailable');
     }
-    return ResolvedIdentity(did: identity, pds: 'https://pds.test');
+    return ResolvedIdentity(
+      did: identity,
+      pds: 'https://pds.test',
+      handle: handleInvalid,
+    );
   }
 }

--- a/website/docs/products/packages/atproto_identity.md
+++ b/website/docs/products/packages/atproto_identity.md
@@ -74,12 +74,16 @@ Future<void> main() async {
 
   print(identity.did);        // did:plc:...
   print(identity.pds);        // https://host (PDS origin, no trailing slash)
-  print(identity.handle);     // shinyakato.dev (null when resolved from a DID)
+  print(identity.handle);     // shinyakato.dev, or 'handle.invalid'
   print(identity.signingKey); // #atproto publicKeyMultibase (null when absent)
 }
 ```
 
-When resolution starts from a handle, the resolver performs **bidirectional handle verification**: the DID document must list `at://<handle>` in its `alsoKnownAs`, otherwise an `IdentityException` is thrown.
+The resolver performs **bidirectional handle verification** in both directions of entry.
+
+Starting from a handle, the DID document must list `at://<handle>` in its `alsoKnownAs`, otherwise an `IdentityException` is thrown.
+
+Starting from a DID, the handle the document claims is resolved back and must return that same DID. Anything else — no claim, a claim that resolves elsewhere, or a handle resolver that cannot be reached — reports `handle.invalid` rather than throwing, because an account whose handle stopped resolving (a removed or misconfigured DNS record, most often) is still a valid account. `handle` is therefore never null; it is either a verified handle or `handle.invalid`, matching `com.atproto.identity.defs#identityInfo`.
 
 ## More Tips 🏄
 


### PR DESCRIPTION
Fixes #2575

`resolve` set `handle = null` for a DID and skipped bidirectional verification
entirely (`identity_resolver.dart:383-388`; the check was guarded by
`if (handle != null)`), so a DID document's `alsoKnownAs` claim was read by
nobody. A caller who passed a DID got no handle even when the document claimed
one, and no way to learn whether that claim was real.

## The shape already existed

`com.atproto.identity.defs#identityInfo` requires `handle` and documents the
sentinel: *"The validated handle of the account; or 'handle.invalid' if the
handle did not bi-directionally match the DID document."* The generated
`IdentityInfo` mirrors that faithfully (`required String handle`). Only the
hand-written `ResolvedIdentity` disagreed, with `String?` meaning "resolution
started from a handle".

`ResolvedIdentity.handle` is now `String`, carrying `handleInvalid` when
nothing verifies.

## Algorithm

Resolving from a DID:

1. read the claimed handle from the document
2. **no claim → `handle.invalid`, with no extra request**
3. a claim of the sentinel verbatim → `handle.invalid`, no request
4. otherwise resolve it, swallowing every `Exception`
5. equal to the input DID → the claimed handle, else `handle.invalid`

Resolving from a handle is unchanged: a document that does not claim it back
still throws. The asymmetry is deliberate and matches the reference
implementation.

**It never throws.** A handle that stopped resolving is an operational state —
most often a verified domain whose DNS record was removed or misconfigured —
and the account is still valid. `_resolveHandle` wraps only `TimeoutException`,
so `SocketException` / `ClientException` / `HandshakeException` arrive
unwrapped and are caught too. `Error`s are deliberately not caught, so a bug
here still surfaces.

Step 3 has no counterpart upstream. `ensureValidHandle` accepts
`handle.invalid` (it does not check for reserved TLDs, and neither does the
upstream validator), so honouring such a claim would make a verified handle
indistinguishable from one that failed to verify.

## Why breaking rather than nullable

Leaving `handle` nullable and filling it in only on success grows the meaning
of `null` from one case to three — no handle claimed, claim failed to verify,
entry was a DID. Callers cannot tell the second from the first, which is the
distinction the sentinel exists for: a caller seeing `null` could fall back to
the unverified value in the document.

The breakage is also loud. `dart analyze` exits non-zero on the old
`resolved.handle ?? resolved.did`, so `format-analyze` stops anyone who has not
updated. Measured on this change before it was fixed.

## Tests

Five for the resolver — claim verifies, claim resolves elsewhere, no claim (and
**no request issued**), lookup fails, document claims the sentinel — and two
for `login_hint`, which had no DID-input coverage at all.

Each guard was mutation-checked: removing the sentinel guard, the DID
comparison, the `try`/`catch`, or the `login_hint` fallback each fails exactly
the test that covers it.

Every pre-existing DID-initiated test passes unchanged, because none of their
documents declare `alsoKnownAs` and step 2 issues no request.

## Gates

workspace check 16, format 4902 files 0 changed, analyze clean,
`atproto_identity` 165, `atproto_oauth` 122, `atproto_core` 190, `bluesky` 1001,
`templates/feed_generator` 75, `dart test scripts` 44, validate_dependencies 14,
validate_website_overrides 11, doc snippets 0 files changed.

`melos gen` was not run: the diff touches no codegen input.

## Not done here

**No version bump and no CHANGELOG entry** — releases go in their own PR so a
version line never moves as a side effect of other work. Decided for the
follow-up: `atproto_identity` 0.5.0 → 0.6.0, `atproto_oauth` 0.8.2 → 0.8.3
(it re-exports `ResolvedIdentity`), with the dependent constraints in
`atproto_core` and `bluesky` moved to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
