### PR TITLE
chore: release atproto_identity 0.6.0 and atproto_oauth 0.8.3

### DIFF
--- a/packages/atproto_core/pubspec.yaml
+++ b/packages/atproto_core/pubspec.yaml
@@ -27,7 +27,7 @@ dependencies:
   json_annotation: ^4.9.0
   cbor: ^6.3.7
   multiformats: ^1.4.0
-  atproto_oauth: ^0.8.2
+  atproto_oauth: ^0.8.3
   nanoid: ^1.0.0
   meta: ^1.17.0
 

--- a/packages/atproto_identity/CHANGELOG.md
+++ b/packages/atproto_identity/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release Note
 
+## v0.6.0
+
+- **feat!**: `resolve` now verifies the handle when resolution starts from a DID. It previously set `handle` to null and skipped bidirectional verification entirely, so a DID document's `alsoKnownAs` claim was read by nobody: a caller who passed a DID got no handle even when the document claimed one, and no way to learn whether that claim was real. The claimed handle is now resolved back and must return the DID that was asked about.
+- **feat!**: `ResolvedIdentity.handle` is no longer nullable. It carries the new `handleInvalid` constant (`handle.invalid`) when no handle verifies, which is the shape the protocol already defines — `com.atproto.identity.defs#identityInfo` requires the field and documents the same sentinel, and the generated `IdentityInfo` mirrors it. Only this hand-written type disagreed.
+- **feat**: verification never throws on the DID path. A handle that stopped resolving is an operational state — most often a verified domain whose DNS record was removed or misconfigured — and such an account is still valid, so `handle.invalid` is reported instead. Transport failures are caught alongside `IdentityException`, since the handle lookup wraps only timeouts; `Error`s are not caught, so a bug still surfaces. Resolution *from* a handle is unchanged and still throws when the document does not claim it back.
+- **feat**: a DID document claiming `handle.invalid` verbatim is treated as claiming nothing. The string is a syntactically valid handle, so honouring such a claim would make a verified handle indistinguishable from one that failed to verify.
+- **chore**: a document that claims no handle costs no extra request, so this adds a round trip only when there is a claim to check.
+
+**Breaking:** replace `identity.handle == null` with `identity.handle == handleInvalid`, and pass `handle:` when constructing a `ResolvedIdentity` yourself — it is now a required argument, because an identity always reports either a verified handle or the sentinel.
+
 ## v0.5.0
 
 - **feat**: added `HttpIdentityResolver.resolveDidDocument`, which fetches a DID document and returns it verbatim as a `Map<String, dynamic>`. `resolve` interprets a document as an atproto identity and therefore rejects anything without an `#atproto_pds` service, so a document that is not an account's — a feed generator's `did:web` document, which declares only a `#bsky_fg` service — was unreachable through this package even though the resolver already fetched, size-capped, redirect-checked, and `id`-bound it. The new method reuses that same fetch; only the atproto-specific interpretation is skipped.

--- a/packages/atproto_identity/pubspec.yaml
+++ b/packages/atproto_identity/pubspec.yaml
@@ -1,7 +1,7 @@
 name: atproto_identity
 resolution: workspace
 description: AT Protocol identity resolution (handle/DID) and inbound service-auth JWT verification for Dart/Flutter.
-version: 0.5.0
+version: 0.6.0
 homepage: https://atprotodart.com
 repository: https://github.com/myConsciousness/atproto.dart/tree/main/packages/atproto_identity
 issue_tracker: https://github.com/myConsciousness/atproto.dart/issues

--- a/packages/atproto_oauth/CHANGELOG.md
+++ b/packages/atproto_oauth/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release Note
 
+## v0.8.3
+
+- **chore!**: moved to `atproto_identity` `^0.6.0`, in which `ResolvedIdentity.handle` stops being nullable and carries `handleInvalid` when no handle verifies. `ResolvedIdentity` is re-exported from this package, so the type change is visible to callers of `atproto_oauth` too.
+- **fix**: `authorize` sends the DID as the `login_hint` when no handle verified. The old code fell back to the DID for a null handle; with the sentinel in place it would otherwise have offered the authorization server `handle.invalid`, which belongs to nobody.
+
 ## v0.8.2
 
 - **chore**: moved to `atproto_identity` `^0.5.0`, which adds `resolveDidDocument` and `serviceEndpointOf` and tightens the DID grammar applied to every document fetch. v0.8.1 is published pinning `^0.4.0`, so without this release an app on `atproto_oauth ^0.8.1` could not reach them.

--- a/packages/atproto_oauth/pubspec.yaml
+++ b/packages/atproto_oauth/pubspec.yaml
@@ -1,7 +1,7 @@
 name: atproto_oauth
 resolution: workspace
 description: Provides tools to handle OAuth for AT Protocol and Bluesky Social.
-version: 0.8.2
+version: 0.8.3
 homepage: https://atprotodart.com
 repository: https://github.com/myConsciousness/atproto.dart/tree/main/packages/atproto_oauth
 issue_tracker: https://github.com/myConsciousness/atproto.dart/issues
@@ -17,7 +17,7 @@ topics:
   - oauth
 
 dependencies:
-  atproto_identity: ^0.5.0
+  atproto_identity: ^0.6.0
   http: ^1.4.0
   crypto: ^3.0.6
   freezed_annotation: ^3.1.0

--- a/templates/feed_generator/pubspec.yaml
+++ b/templates/feed_generator/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 dependencies:
   bluesky: ^2.8.1
   atproto_core: ^2.4.1
-  atproto_identity: ^0.5.0
+  atproto_identity: ^0.6.0
   shelf: ^1.4.0
   shelf_router: ^1.1.0
 


### PR DESCRIPTION
Releases #2580, which gave a DID-initiated `resolve` bidirectional handle
verification and made `ResolvedIdentity.handle` non-nullable.

| package | version | why |
| --- | --- | --- |
| `atproto_identity` | 0.5.0 → **0.6.0** | breaking: `handle` changed type and became required |
| `atproto_oauth` | 0.8.2 → **0.8.3** | re-exports `ResolvedIdentity`; `login_hint` now falls back to the DID |

Minor rather than patch for `atproto_identity` because pub puts a breaking
change in the minor position while a package is on 0.x.

## Migration

```dart
- if (identity.handle == null) { ... }
+ if (identity.handle == handleInvalid) { ... }
```

`handle` is also a required constructor argument now, because an identity
always reports either a verified handle or the sentinel.

## Dependents

`scripts/validate_dependencies.dart` compares a workspace dependency's
constraint against that package's current version with the caret stripped, so
these fail without the bump:

- `packages/atproto_core/pubspec.yaml` → `atproto_oauth: ^0.8.3`
- `templates/feed_generator/pubspec.yaml` → `atproto_identity: ^0.6.0`

Each was confirmed by reverting that single line and re-running the script:

```
Invalid version for atproto_oauth in packages/atproto_core/pubspec.yaml.
Expected 0.8.3 but found 0.8.2
```

**`bluesky` is deliberately untouched.** Its `atproto_oauth` entry is a *dev*
dependency, which the validator does not read, and `^0.8.2` already admits
0.8.3. Changing it would have been a no-op edit to a file that carries the
release trigger.

## Gates

workspace check 16, format 4902 files 0 changed, analyze clean,
`atproto_identity` 165, `atproto_oauth` 122, `atproto_core` 190, `bluesky` 1001,
`templates/feed_generator` 75, `dart test scripts` 44, validate_dependencies 14,
validate_website_overrides 11, doc snippets 0 files changed.

`melos gen` was run because this PR touches `packages/*/pubspec.yaml` and
therefore triggers `verify_generated.yml`: **no diff** in the three codegen
directories.

## After merge

`release_tags.yml` creates `atproto_identity-v0.6.0` and `atproto_oauth-v0.8.3`
— neither tag exists yet — and `publish.yml` puts both on pub.dev. Merging this
ships them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
