### PR TITLE
fix(lex_gen): do not prefix a cross-package barrel import with union_

### DIFF
--- a/packages/lex_gen/CHANGELOG.md
+++ b/packages/lex_gen/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Note
 
+## v0.4.17
+
+- fix: do not prefix a cross-package barrel import with `union_`
+
 ## v0.4.16
 
 - chore: bump `lexicon` to `^1.2.14`

--- a/packages/lex_gen/lib/src/services/rule.dart
+++ b/packages/lex_gen/lib/src/services/rule.dart
@@ -230,14 +230,19 @@ String getLexObjectPackagePathFromRef(
   final samePackage = _isInTheSamePackage(lexiconId, ref);
 
   final fileName = switch (LexRef.parse(ref)) {
-    LocalRef(:final defName) => getLexObjectFileName(defName),
+    LocalRef(:final defName) =>
+      '$fileNamePrefix${getLexObjectFileName(defName)}',
     ForeignRef(:final lexicon, :final defName) =>
-      samePackage ? getLexObjectFileName(defName) : getPackageName(lexicon.raw),
+      samePackage
+          ? '$fileNamePrefix${getLexObjectFileName(defName)}'
+          : getPackageName(lexicon.raw),
     BareRef(:final lexicon) =>
-      samePackage ? getLexObjectFileName('main') : getPackageName(lexicon.raw),
+      samePackage
+          ? '$fileNamePrefix${getLexObjectFileName('main')}'
+          : getPackageName(lexicon.raw),
   };
 
-  return '$relativePath/$fileNamePrefix$fileName.dart';
+  return '$relativePath/$fileName.dart';
 }
 
 String getLexObjectPackagePathFromRefForService(

--- a/packages/lex_gen/pubspec.yaml
+++ b/packages/lex_gen/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lex_gen
 resolution: workspace
 description: Provides a generator that automatically generates source code from the Lexicon in the AT Protocol.
-version: 0.4.16
+version: 0.4.17
 homepage: https://atprotodart.com
 repository: https://github.com/myConsciousness/atproto.dart/tree/main/packages/lex_gen
 issue_tracker: https://github.com/myConsciousness/atproto.dart/issues

--- a/packages/lex_gen/test/src/services/rule_test.dart
+++ b/packages/lex_gen/test/src/services/rule_test.dart
@@ -10,6 +10,7 @@ import 'package:test/test.dart';
 import 'package:lex_gen/src/config.dart';
 import 'package:lex_gen/src/services/gen_context.dart';
 import 'package:lex_gen/src/services/rule.dart' as rule;
+import '../test_context.dart';
 
 /// A record-doc fixture whose `main` def is a record (no fragment).
 const _recordDoc = {
@@ -182,6 +183,86 @@ void main() {
       expect(rule.getLexKnownValuesElementName('dynamic'), 'dynamic');
       expect(rule.getLexKnownValuesElementName('spam'), 'spam');
       expect(rule.getLexKnownValuesElementName('nsfw'), 'nsfw');
+    });
+  });
+
+  group('getLexObjectPackagePathFromRef — union prefix vs barrel', () {
+    // A cross-authority ref cannot point at a per-def file: the referenced
+    // package only exports a barrel. Prefixing that barrel with `union_`
+    // yields an import of a file that never exists.
+    test('cross-authority union ref resolves to the barrel, unprefixed', () {
+      expect(
+        rule.getLexObjectPackagePathFromRef(
+          buildTestGenContext(),
+          'tools.ozone.moderation.getAccountPreferences',
+          'app.bsky.actor.defs#preferences',
+          isUnion: true,
+        ),
+        'package:bluesky/app_bsky_actor_defs.dart',
+      );
+    });
+
+    test(
+      'cross-authority bare union ref resolves to the barrel, unprefixed',
+      () {
+        expect(
+          rule.getLexObjectPackagePathFromRef(
+            buildTestGenContext(),
+            'tools.ozone.moderation.defs',
+            'app.bsky.actor.defs',
+            isUnion: true,
+          ),
+          'package:bluesky/app_bsky_actor_defs.dart',
+        );
+      },
+    );
+
+    test('cross-authority non-union ref is unchanged', () {
+      expect(
+        rule.getLexObjectPackagePathFromRef(
+          buildTestGenContext(),
+          'tools.ozone.moderation.getAccountPreferences',
+          'app.bsky.actor.defs#preferences',
+        ),
+        'package:bluesky/app_bsky_actor_defs.dart',
+      );
+    });
+
+    // Within one authority the generator emits per-def files, so the union
+    // file really is `union_<def>.dart` and the prefix must survive.
+    test('same-authority union ref keeps the union_ prefix', () {
+      expect(
+        rule.getLexObjectPackagePathFromRef(
+          buildTestGenContext(),
+          'app.bsky.actor.getPreferences',
+          'app.bsky.actor.defs#preferences',
+          isUnion: true,
+        ),
+        '../../../../app/bsky/actor/defs/union_preferences.dart',
+      );
+    });
+
+    test('same-authority non-union ref has no prefix', () {
+      expect(
+        rule.getLexObjectPackagePathFromRef(
+          buildTestGenContext(),
+          'app.bsky.actor.getPreferences',
+          'app.bsky.actor.defs#preferences',
+        ),
+        '../../../../app/bsky/actor/defs/preferences.dart',
+      );
+    });
+
+    test('local union ref keeps the union_ prefix', () {
+      expect(
+        rule.getLexObjectPackagePathFromRef(
+          buildTestGenContext(),
+          'app.bsky.actor.defs',
+          '#preferences',
+          isUnion: true,
+        ),
+        './union_preferences.dart',
+      );
     });
   });
 }

--- a/scripts/pubspec.yaml
+++ b/scripts/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 dependencies:
   github: ^9.12.0
   http: ^1.4.0
-  lex_gen: ^0.4.16
+  lex_gen: ^0.4.17
   lexicon: ^1.2.14
   pubspec: ^2.3.0
   test: ^1.26.2


### PR DESCRIPTION
## What

`getLexObjectPackagePathFromRef` applied the `union_` file-name prefix **after** the switch that resolves the file name, so it landed on every branch — including the two that resolve to another package's *barrel*.

A cross-authority ref cannot address a per-def file: the referenced package only exports a barrel (`app_bsky_actor_defs.dart`), which itself exports `union_preferences.dart`. Prefixing the barrel produced

```dart
import 'package:bluesky/union_app_bsky_actor_defs.dart';
```

which does not exist. The unresolved import left `@UPreferencesConverter()` unresolved, and `freezed` crashed with a null-check error during `build_runner`.

This moves the prefix into the branches that actually name a per-def file (local refs and same-authority refs) and leaves the barrel branches alone.

## Why now

`Sync and Generate` has failed on `Build (bluesky)` since 2026-09-03, both nightly runs on `f7be5bfd6`. The trigger is the new upstream lexicon `tools.ozone.moderation.getAccountPreferences`, which references `app.bsky.actor.defs#preferences` — the first cross-authority ref to a union def in the tree. No committed file has a `package:.../union_` import, which is why this never fired before.

## Verification

- `packages/lex_gen/test/src/services/rule_test.dart` gains a regression group covering all six branches (cross-authority union / bare union / non-union, same-authority union / non-union, local union). Reverting the fix fails exactly the two cross-authority union cases and leaves the other four green.
- `scripts/verify_gen_unchanged.sh check` — Tier A PASS: generated output is byte-identical for the currently committed lexicons.
- `scripts/verify_gen_unchanged.sh srccheck` — PASS.
- `dart analyze packages/lex_gen scripts` — no issues. `dart format --set-exit-if-changed` — clean.
- `dart run scripts/validate_dependencies.dart` — all 14 packages pass.

## Release

`lex_gen` 0.4.16 → 0.4.17, with `scripts/pubspec.yaml` following. The `lex_gen-v0.4.16` tag already exists, so merging this creates `lex_gen-v0.4.17` and publishes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
